### PR TITLE
optimize medic loadout for practical usefulness

### DIFF
--- a/reference/Russian%20Army/composition.sqe
+++ b/reference/Russian%20Army/composition.sqe
@@ -641,12 +641,12 @@ class items
 								class Item0
 								{
 									name="ACE_fieldDressing";
-									count=20;
+									count=10;
 								};
 								class Item1
 								{
 									name="ACE_quikclot";
-									count=30;
+									count=10;
 								};
 								class Item2
 								{
@@ -656,17 +656,17 @@ class items
 								class Item3
 								{
 									name="ACE_elasticBandage";
-									count=20;
+									count=30;
 								};
 								class Item4
 								{
 									name="ACE_morphine";
-									count=20;
+									count=15;
 								};
 								class Item5
 								{
 									name="ACE_epinephrine";
-									count=10;
+									count=15;
 								};
 								class Item6
 								{
@@ -675,13 +675,13 @@ class items
 								};
 								class Item7
 								{
-									name="ACE_bloodIV_500";
+									name="ACE_bloodIV";
 									count=8;
 								};
 								class Item8
 								{
 									name="ACE_tourniquet";
-									count=4;
+									count=6;
 								};
 								class Item9
 								{
@@ -1354,12 +1354,12 @@ class items
 								class Item0
 								{
 									name="ACE_fieldDressing";
-									count=20;
+									count=10;
 								};
 								class Item1
 								{
 									name="ACE_quikclot";
-									count=30;
+									count=10;
 								};
 								class Item2
 								{
@@ -1369,17 +1369,17 @@ class items
 								class Item3
 								{
 									name="ACE_elasticBandage";
-									count=20;
+									count=30;
 								};
 								class Item4
 								{
 									name="ACE_morphine";
-									count=20;
+									count=15;
 								};
 								class Item5
 								{
 									name="ACE_epinephrine";
-									count=10;
+									count=15;
 								};
 								class Item6
 								{
@@ -1388,13 +1388,13 @@ class items
 								};
 								class Item7
 								{
-									name="ACE_bloodIV_500";
+									name="ACE_bloodIV";
 									count=8;
 								};
 								class Item8
 								{
 									name="ACE_tourniquet";
-									count=4;
+									count=6;
 								};
 								class Item9
 								{
@@ -3688,12 +3688,12 @@ class items
 								class Item0
 								{
 									name="ACE_fieldDressing";
-									count=20;
+									count=10;
 								};
 								class Item1
 								{
 									name="ACE_quikclot";
-									count=30;
+									count=10;
 								};
 								class Item2
 								{
@@ -3703,17 +3703,17 @@ class items
 								class Item3
 								{
 									name="ACE_elasticBandage";
-									count=20;
+									count=30;
 								};
 								class Item4
 								{
 									name="ACE_morphine";
-									count=20;
+									count=15;
 								};
 								class Item5
 								{
 									name="ACE_epinephrine";
-									count=10;
+									count=15;
 								};
 								class Item6
 								{
@@ -3722,13 +3722,13 @@ class items
 								};
 								class Item7
 								{
-									name="ACE_bloodIV_500";
+									name="ACE_bloodIV";
 									count=8;
 								};
 								class Item8
 								{
 									name="ACE_tourniquet";
-									count=4;
+									count=6;
 								};
 								class Item9
 								{
@@ -6022,12 +6022,12 @@ class items
 								class Item0
 								{
 									name="ACE_fieldDressing";
-									count=20;
+									count=10;
 								};
 								class Item1
 								{
 									name="ACE_quikclot";
-									count=30;
+									count=10;
 								};
 								class Item2
 								{
@@ -6037,17 +6037,17 @@ class items
 								class Item3
 								{
 									name="ACE_elasticBandage";
-									count=20;
+									count=30;
 								};
 								class Item4
 								{
 									name="ACE_morphine";
-									count=20;
+									count=15;
 								};
 								class Item5
 								{
 									name="ACE_epinephrine";
-									count=10;
+									count=15;
 								};
 								class Item6
 								{
@@ -6056,13 +6056,13 @@ class items
 								};
 								class Item7
 								{
-									name="ACE_bloodIV_500";
+									name="ACE_bloodIV";
 									count=8;
 								};
 								class Item8
 								{
 									name="ACE_tourniquet";
-									count=4;
+									count=6;
 								};
 								class Item9
 								{

--- a/reference/Task%20Force%20Noctem/composition.sqe
+++ b/reference/Task%20Force%20Noctem/composition.sqe
@@ -647,12 +647,12 @@ class items
 								class Item0
 								{
 									name="ACE_fieldDressing";
-									count=20;
+									count=10;
 								};
 								class Item1
 								{
 									name="ACE_quikclot";
-									count=30;
+									count=10;
 								};
 								class Item2
 								{
@@ -662,17 +662,17 @@ class items
 								class Item3
 								{
 									name="ACE_elasticBandage";
-									count=20;
+									count=30;
 								};
 								class Item4
 								{
 									name="ACE_morphine";
-									count=20;
+									count=15;
 								};
 								class Item5
 								{
 									name="ACE_epinephrine";
-									count=10;
+									count=15;
 								};
 								class Item6
 								{
@@ -681,13 +681,13 @@ class items
 								};
 								class Item7
 								{
-									name="ACE_bloodIV_500";
+									name="ACE_bloodIV";
 									count=8;
 								};
 								class Item8
 								{
 									name="ACE_tourniquet";
-									count=4;
+									count=6;
 								};
 								class Item9
 								{
@@ -1362,12 +1362,12 @@ class items
 								class Item0
 								{
 									name="ACE_fieldDressing";
-									count=20;
+									count=10;
 								};
 								class Item1
 								{
 									name="ACE_quikclot";
-									count=30;
+									count=10;
 								};
 								class Item2
 								{
@@ -1377,17 +1377,17 @@ class items
 								class Item3
 								{
 									name="ACE_elasticBandage";
-									count=20;
+									count=30;
 								};
 								class Item4
 								{
 									name="ACE_morphine";
-									count=20;
+									count=15;
 								};
 								class Item5
 								{
 									name="ACE_epinephrine";
-									count=10;
+									count=15;
 								};
 								class Item6
 								{
@@ -1396,13 +1396,13 @@ class items
 								};
 								class Item7
 								{
-									name="ACE_bloodIV_500";
+									name="ACE_bloodIV";
 									count=8;
 								};
 								class Item8
 								{
 									name="ACE_tourniquet";
-									count=4;
+									count=6;
 								};
 								class Item9
 								{
@@ -6050,12 +6050,12 @@ class items
 								class Item0
 								{
 									name="ACE_fieldDressing";
-									count=20;
+									count=10;
 								};
 								class Item1
 								{
 									name="ACE_quikclot";
-									count=30;
+									count=10;
 								};
 								class Item2
 								{
@@ -6065,17 +6065,17 @@ class items
 								class Item3
 								{
 									name="ACE_elasticBandage";
-									count=20;
+									count=30;
 								};
 								class Item4
 								{
 									name="ACE_morphine";
-									count=20;
+									count=15;
 								};
 								class Item5
 								{
 									name="ACE_epinephrine";
-									count=10;
+									count=15;
 								};
 								class Item6
 								{
@@ -6084,13 +6084,13 @@ class items
 								};
 								class Item7
 								{
-									name="ACE_bloodIV_500";
+									name="ACE_bloodIV";
 									count=8;
 								};
 								class Item8
 								{
 									name="ACE_tourniquet";
-									count=4;
+									count=6;
 								};
 								class Item9
 								{

--- a/reference/US%20Army/composition.sqe
+++ b/reference/US%20Army/composition.sqe
@@ -640,12 +640,12 @@ class items
 								class Item0
 								{
 									name="ACE_fieldDressing";
-									count=20;
+									count=10;
 								};
 								class Item1
 								{
 									name="ACE_quikclot";
-									count=30;
+									count=10;
 								};
 								class Item2
 								{
@@ -655,17 +655,17 @@ class items
 								class Item3
 								{
 									name="ACE_elasticBandage";
-									count=20;
+									count=30;
 								};
 								class Item4
 								{
 									name="ACE_morphine";
-									count=20;
+									count=15;
 								};
 								class Item5
 								{
 									name="ACE_epinephrine";
-									count=10;
+									count=15;
 								};
 								class Item6
 								{
@@ -674,13 +674,13 @@ class items
 								};
 								class Item7
 								{
-									name="ACE_bloodIV_500";
+									name="ACE_bloodIV";
 									count=8;
 								};
 								class Item8
 								{
 									name="ACE_tourniquet";
-									count=4;
+									count=6;
 								};
 								class Item9
 								{
@@ -1353,12 +1353,12 @@ class items
 								class Item0
 								{
 									name="ACE_fieldDressing";
-									count=20;
+									count=10;
 								};
 								class Item1
 								{
 									name="ACE_quikclot";
-									count=30;
+									count=10;
 								};
 								class Item2
 								{
@@ -1368,17 +1368,17 @@ class items
 								class Item3
 								{
 									name="ACE_elasticBandage";
-									count=20;
+									count=30;
 								};
 								class Item4
 								{
 									name="ACE_morphine";
-									count=20;
+									count=15;
 								};
 								class Item5
 								{
 									name="ACE_epinephrine";
-									count=10;
+									count=15;
 								};
 								class Item6
 								{
@@ -1387,13 +1387,13 @@ class items
 								};
 								class Item7
 								{
-									name="ACE_bloodIV_500";
+									name="ACE_bloodIV";
 									count=8;
 								};
 								class Item8
 								{
 									name="ACE_tourniquet";
-									count=4;
+									count=6;
 								};
 								class Item9
 								{
@@ -3685,12 +3685,12 @@ class items
 								class Item0
 								{
 									name="ACE_fieldDressing";
-									count=20;
+									count=10;
 								};
 								class Item1
 								{
 									name="ACE_quikclot";
-									count=30;
+									count=10;
 								};
 								class Item2
 								{
@@ -3700,17 +3700,17 @@ class items
 								class Item3
 								{
 									name="ACE_elasticBandage";
-									count=20;
+									count=30;
 								};
 								class Item4
 								{
 									name="ACE_morphine";
-									count=20;
+									count=15;
 								};
 								class Item5
 								{
 									name="ACE_epinephrine";
-									count=10;
+									count=15;
 								};
 								class Item6
 								{
@@ -3719,13 +3719,13 @@ class items
 								};
 								class Item7
 								{
-									name="ACE_bloodIV_500";
+									name="ACE_bloodIV";
 									count=8;
 								};
 								class Item8
 								{
 									name="ACE_tourniquet";
-									count=4;
+									count=6;
 								};
 								class Item9
 								{
@@ -6020,12 +6020,12 @@ class items
 								class Item0
 								{
 									name="ACE_fieldDressing";
-									count=20;
+									count=10;
 								};
 								class Item1
 								{
 									name="ACE_quikclot";
-									count=30;
+									count=10;
 								};
 								class Item2
 								{
@@ -6035,17 +6035,17 @@ class items
 								class Item3
 								{
 									name="ACE_elasticBandage";
-									count=20;
+									count=30;
 								};
 								class Item4
 								{
 									name="ACE_morphine";
-									count=20;
+									count=15;
 								};
 								class Item5
 								{
 									name="ACE_epinephrine";
-									count=10;
+									count=15;
 								};
 								class Item6
 								{
@@ -6054,13 +6054,13 @@ class items
 								};
 								class Item7
 								{
-									name="ACE_bloodIV_500";
+									name="ACE_bloodIV";
 									count=8;
 								};
 								class Item8
 								{
 									name="ACE_tourniquet";
-									count=4;
+									count=6;
 								};
 								class Item9
 								{


### PR DESCRIPTION
These changes hopefully make medics more effective with "prevent insta death" enabled, without making them too effective.

* Basic bandages and Quikclots were originally meant as a resupply for others, but almost never did I need to resupply others, people either
  * die before they get to use their original supply (they wait for medic to bandage them)
  * resupply from corpses (friendly or enemy, many enemies carry tons of bandages, morphine and quikclots)
  * resupply from resupply box

* Elastic bandages are the most used kind as they are the most effective and their short reopening time is less important when you can just stitch right after bandaging. They are essential now that people can sustain heavy injuries and survive.

* Morphines are surprisingly not used too much, they have significant disadvantages when overused and players inject themselves when they really need to. Resupply from medic isn't needed as people just loot for themselves (whatever's your opinion, that's the reality), share existing supply or use the resupply box.

* Epinephrines are now more useful as they can compensate for the lack of blood to some extent, though medics need to be trained to recognize high heart rate and administer adenosine to wake the person up.

* Tourniquets are easily lost as they get given to the person that removes them. If that's the patient, the medic loses the tourniquet.

* With the recent medical changes, it's not worth topping up the blood to the maximum level, so a "coarse" precision of 1000ml instead of 500ml doesn't matter as much. The only time I give blood now is when the person has very serious blood loss and in that case, I work in units of liters and have to infuse ie. 4x500ml instead of 2x1000ml, wasting a lot of time.
