### PR TITLE
TFN Standard Faction Update v1.14.0

### DIFF
--- a/reference/Task%20Force%20Noctem/composition.sqe
+++ b/reference/Task%20Force%20Noctem/composition.sqe
@@ -1,8 +1,8 @@
 version=53;
-center[]={7838.6177,5,3747.3743};
+center[]={2908.1531,5,4993.4072};
 class items
 {
-	items=20;
+	items=21;
 	class Item0
 	{
 		dataType="Group";
@@ -15,7 +15,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-5.8950195,0.0014390945,7.4130859};
+					position[]={-5.9748535,0.0014390945,7.6743164};
 				};
 				side="Independent";
 				flags=7;
@@ -58,7 +58,7 @@ class items
 						};
 						class uniform
 						{
-							typeName="cnto_flecktarn_u_mediterranean";
+							typeName="cnto_flecktarn_u_r_grassland";
 							isBackpack=0;
 							class ItemCargo
 							{
@@ -117,7 +117,7 @@ class items
 						};
 						class vest
 						{
-							typeName="cnto_flecktarn_v_mediterranean";
+							typeName="cnto_flecktarn_v_grassland";
 							isBackpack=0;
 							class MagazineCargo
 							{
@@ -165,7 +165,7 @@ class items
 						};
 						class backpack
 						{
-							typeName="cnto_flecktarn_b_ap_mediterranean";
+							typeName="cnto_flecktarn_b_ap_grassland";
 							isBackpack=1;
 							class MagazineCargo
 							{
@@ -209,15 +209,10 @@ class items
 							};
 							class ItemCargo
 							{
-								items=2;
+								items=1;
 								class Item0
 								{
 									name="ACE_IR_Strobe_Item";
-									count=1;
-								};
-								class Item1
-								{
-									name="cnto_flecktarn_h_beret";
 									count=1;
 								};
 							};
@@ -226,10 +221,10 @@ class items
 						compass="ItemCompass";
 						watch="ItemWatch";
 						gps="ItemGPS";
-						headgear="cnto_flecktarn_h_s_mediterranean";
+						headgear="cnto_flecktarn_h_boo_grassland";
 					};
 				};
-				id=1;
+				id=3;
 				type="I_officer_F";
 				class CustomAttributes
 				{
@@ -253,6 +248,25 @@ class items
 						};
 					};
 					class Attribute1
+					{
+						property="lambs_danger_disableAI";
+						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"BOOL"
+									};
+								};
+								value=1;
+							};
+						};
+					};
+					class Attribute2
 					{
 						property="a3ee_acre_chlist";
 						expression="_this setVariable [""a3ee_acre_chlist"",_value,true]";
@@ -316,7 +330,7 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					nAttributes=3;
 				};
 			};
 			class Item1
@@ -324,7 +338,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-4.8959961,0.0014390945,7.4140625};
+					position[]={-4.9758301,0.0014390945,7.675293};
 				};
 				side="Independent";
 				flags=5;
@@ -338,7 +352,7 @@ class items
 					{
 						class primaryWeapon
 						{
-							name="rhs_weap_hk416d145";
+							name="rhs_weap_hk416d10";
 							underBarrel="rhsusf_acc_grip2";
 							class primaryMuzzleMag
 							{
@@ -362,7 +376,7 @@ class items
 						};
 						class uniform
 						{
-							typeName="cnto_flecktarn_u_mediterranean";
+							typeName="cnto_flecktarn_u_grassland";
 							isBackpack=0;
 							class ItemCargo
 							{
@@ -421,7 +435,7 @@ class items
 						};
 						class vest
 						{
-							typeName="cnto_flecktarn_v_mediterranean";
+							typeName="cnto_flecktarn_v_l_grassland";
 							isBackpack=0;
 							class MagazineCargo
 							{
@@ -434,27 +448,27 @@ class items
 								};
 								class Item1
 								{
-									name="rhs_mag_30Rnd_556x45_M855A1_Stanag";
-									count=6;
-									ammoLeft=30;
-								};
-								class Item2
-								{
-									name="rhs_mag_30Rnd_556x45_M855A1_Stanag_Tracer_Red";
-									count=4;
-									ammoLeft=30;
-								};
-								class Item3
-								{
 									name="hlc_12Rnd_357SIG_B_P226";
 									count=1;
 									ammoLeft=12;
 								};
-								class Item4
+								class Item2
 								{
 									name="HandGrenade";
 									count=2;
 									ammoLeft=1;
+								};
+								class Item3
+								{
+									name="rhs_mag_30Rnd_556x45_M855A1_Stanag";
+									count=8;
+									ammoLeft=30;
+								};
+								class Item4
+								{
+									name="rhs_mag_30Rnd_556x45_M855A1_Stanag_Tracer_Red";
+									count=2;
+									ammoLeft=30;
 								};
 							};
 							class ItemCargo
@@ -467,14 +481,28 @@ class items
 								};
 							};
 						};
+						class backpack
+						{
+							typeName="UK3CB_B_O_Radio_Backpack";
+							isBackpack=1;
+							class ItemCargo
+							{
+								items=1;
+								class Item0
+								{
+									name="ACRE_PRC117F";
+									count=1;
+								};
+							};
+						};
 						map="ItemMap";
 						compass="ItemCompass";
 						watch="ItemWatch";
 						gps="ItemGPS";
-						headgear="cnto_flecktarn_h_s_mediterranean";
+						headgear="cnto_flecktarn_h_s_grassland";
 					};
 				};
-				id=2;
+				id=4;
 				type="I_Soldier_TL_F";
 				class CustomAttributes
 				{
@@ -498,6 +526,25 @@ class items
 						};
 					};
 					class Attribute1
+					{
+						property="lambs_danger_disableAI";
+						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"BOOL"
+									};
+								};
+								value=1;
+							};
+						};
+					};
+					class Attribute2
 					{
 						property="a3ee_acre_chlist";
 						expression="_this setVariable [""a3ee_acre_chlist"",_value,true]";
@@ -561,7 +608,7 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					nAttributes=3;
 				};
 			};
 			class Item2
@@ -569,7 +616,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-3.8959961,0.0014390945,7.4140625};
+					position[]={-3.9758301,0.0014390945,7.675293};
 				};
 				side="Independent";
 				flags=5;
@@ -582,7 +629,7 @@ class items
 					{
 						class primaryWeapon
 						{
-							name="rhs_weap_hk416d145";
+							name="rhs_weap_hk416d10";
 							underBarrel="rhsusf_acc_grip2";
 							class primaryMuzzleMag
 							{
@@ -602,7 +649,7 @@ class items
 						};
 						class uniform
 						{
-							typeName="cnto_flecktarn_u_mediterranean";
+							typeName="cnto_flecktarn_u_r_grassland";
 							isBackpack=0;
 							class MagazineCargo
 							{
@@ -651,34 +698,34 @@ class items
 						};
 						class vest
 						{
-							typeName="cnto_flecktarn_v_mediterranean";
+							typeName="cnto_flecktarn_v_grassland";
 							isBackpack=0;
 							class MagazineCargo
 							{
 								items=4;
 								class Item0
 								{
-									name="rhs_mag_30Rnd_556x45_M855A1_Stanag";
-									count=8;
-									ammoLeft=30;
-								};
-								class Item1
-								{
-									name="rhs_mag_30Rnd_556x45_M855A1_Stanag_Tracer_Red";
-									count=2;
-									ammoLeft=30;
-								};
-								class Item2
-								{
 									name="hlc_12Rnd_357SIG_B_P226";
 									count=1;
 									ammoLeft=12;
 								};
-								class Item3
+								class Item1
 								{
 									name="HandGrenade";
 									count=2;
 									ammoLeft=1;
+								};
+								class Item2
+								{
+									name="rhs_mag_30Rnd_556x45_M855A1_Stanag";
+									count=8;
+									ammoLeft=30;
+								};
+								class Item3
+								{
+									name="rhs_mag_30Rnd_556x45_M855A1_Stanag_Tracer_Red";
+									count=2;
+									ammoLeft=30;
 								};
 							};
 							class ItemCargo
@@ -693,7 +740,7 @@ class items
 						};
 						class backpack
 						{
-							typeName="cnto_flecktarn_b_kb_mediterranean";
+							typeName="cnto_flecktarn_b_kb_grassland";
 							isBackpack=1;
 							class MagazineCargo
 							{
@@ -775,10 +822,10 @@ class items
 						compass="ItemCompass";
 						watch="ItemWatch";
 						gps="ItemGPS";
-						headgear="cnto_flecktarn_h_s_mediterranean";
+						headgear="cnto_flecktarn_h_c_grassland";
 					};
 				};
-				id=3;
+				id=5;
 				type="I_medic_F";
 				class CustomAttributes
 				{
@@ -802,6 +849,25 @@ class items
 						};
 					};
 					class Attribute1
+					{
+						property="lambs_danger_disableAI";
+						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"BOOL"
+									};
+								};
+								value=1;
+							};
+						};
+					};
+					class Attribute2
 					{
 						property="a3ee_acre_chlist";
 						expression="_this setVariable [""a3ee_acre_chlist"",_value,true]";
@@ -837,7 +903,7 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					nAttributes=3;
 				};
 			};
 			class Item3
@@ -845,7 +911,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-2.8959961,0.0014390945,7.4140625};
+					position[]={-2.9758301,0.0014390945,7.675293};
 				};
 				side="Independent";
 				flags=5;
@@ -878,7 +944,7 @@ class items
 						};
 						class uniform
 						{
-							typeName="cnto_flecktarn_u_mediterranean";
+							typeName="cnto_flecktarn_u_grassland";
 							isBackpack=0;
 							class MagazineCargo
 							{
@@ -927,7 +993,7 @@ class items
 						};
 						class vest
 						{
-							typeName="cnto_flecktarn_v_mediterranean";
+							typeName="cnto_flecktarn_v_l_grassland";
 							isBackpack=0;
 							class MagazineCargo
 							{
@@ -970,10 +1036,10 @@ class items
 						map="ItemMap";
 						compass="ItemCompass";
 						watch="ItemWatch";
-						headgear="cnto_flecktarn_h_s_mediterranean";
+						headgear="cnto_flecktarn_h_c_grassland";
 					};
 				};
-				id=4;
+				id=6;
 				type="I_soldier_F";
 				class CustomAttributes
 				{
@@ -997,6 +1063,25 @@ class items
 						};
 					};
 					class Attribute1
+					{
+						property="lambs_danger_disableAI";
+						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"BOOL"
+									};
+								};
+								value=1;
+							};
+						};
+					};
+					class Attribute2
 					{
 						property="a3ee_acre_chlist";
 						expression="_this setVariable [""a3ee_acre_chlist"",_value,true]";
@@ -1032,14 +1117,14 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					nAttributes=3;
 				};
 			};
 		};
 		class Attributes
 		{
 		};
-		id=0;
+		id=2;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -1061,26 +1146,7 @@ class items
 					};
 				};
 			};
-			class Attribute1
-			{
-				property="groupID";
-				expression="[_this, _value] call CBA_fnc_setCallsign";
-				class Value
-				{
-					class data
-					{
-						class type
-						{
-							type[]=
-							{
-								"STRING"
-							};
-						};
-						value="PLATOON";
-					};
-				};
-			};
-			nAttributes=2;
+			nAttributes=1;
 		};
 	};
 	class Item1
@@ -1095,7 +1161,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-5.9536133,0.0014390945,5.1191406};
+					position[]={-6.0334473,0.0014390945,5.3803711};
 				};
 				side="Independent";
 				flags=7;
@@ -1104,6 +1170,7 @@ class items
 					rank="LIEUTENANT";
 					init="call{this disableAI ""MOVE"";" \n "this setSpeaker ""NoVoice"";" \n "enableRadio false;}";
 					description="Alpha Squad Leader@ALPHA";
+					isPlayer=1;
 					isPlayable=1;
 					class Inventory
 					{
@@ -1138,7 +1205,7 @@ class items
 						};
 						class uniform
 						{
-							typeName="cnto_flecktarn_u_mediterranean";
+							typeName="cnto_flecktarn_u_grassland";
 							isBackpack=0;
 							class MagazineCargo
 							{
@@ -1202,7 +1269,7 @@ class items
 						};
 						class vest
 						{
-							typeName="cnto_flecktarn_v_mediterranean";
+							typeName="cnto_flecktarn_v_grassland";
 							isBackpack=0;
 							class MagazineCargo
 							{
@@ -1250,7 +1317,7 @@ class items
 						};
 						class backpack
 						{
-							typeName="cnto_flecktarn_b_ap_mediterranean";
+							typeName="cnto_flecktarn_b_ap_grassland";
 							isBackpack=1;
 							class MagazineCargo
 							{
@@ -1312,10 +1379,10 @@ class items
 						compass="ItemCompass";
 						watch="ItemWatch";
 						gps="ItemGPS";
-						headgear="cnto_flecktarn_h_s_mediterranean";
+						headgear="cnto_flecktarn_h_s_grassland";
 					};
 				};
-				id=6;
+				id=8;
 				type="I_Soldier_SL_F";
 				class CustomAttributes
 				{
@@ -1339,6 +1406,25 @@ class items
 						};
 					};
 					class Attribute1
+					{
+						property="lambs_danger_disableAI";
+						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"BOOL"
+									};
+								};
+								value=1;
+							};
+						};
+					};
+					class Attribute2
 					{
 						property="a3ee_acre_chlist";
 						expression="_this setVariable [""a3ee_acre_chlist"",_value,true]";
@@ -1388,7 +1474,7 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					nAttributes=3;
 				};
 			};
 			class Item1
@@ -1396,7 +1482,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-4.9536133,0.0014390945,5.1201172};
+					position[]={-5.0334473,0.0014390945,5.3813477};
 				};
 				side="Independent";
 				flags=5;
@@ -1409,7 +1495,7 @@ class items
 					{
 						class primaryWeapon
 						{
-							name="rhs_weap_hk416d145";
+							name="rhs_weap_hk416d10";
 							underBarrel="rhsusf_acc_grip2";
 							class primaryMuzzleMag
 							{
@@ -1429,7 +1515,7 @@ class items
 						};
 						class uniform
 						{
-							typeName="cnto_flecktarn_u_mediterranean";
+							typeName="cnto_flecktarn_u_r_grassland";
 							isBackpack=0;
 							class MagazineCargo
 							{
@@ -1478,34 +1564,34 @@ class items
 						};
 						class vest
 						{
-							typeName="cnto_flecktarn_v_mediterranean";
+							typeName="cnto_flecktarn_v_grassland";
 							isBackpack=0;
 							class MagazineCargo
 							{
 								items=4;
 								class Item0
 								{
-									name="rhs_mag_30Rnd_556x45_M855A1_Stanag";
-									count=8;
-									ammoLeft=30;
-								};
-								class Item1
-								{
-									name="rhs_mag_30Rnd_556x45_M855A1_Stanag_Tracer_Red";
-									count=2;
-									ammoLeft=30;
-								};
-								class Item2
-								{
 									name="hlc_12Rnd_357SIG_B_P226";
 									count=1;
 									ammoLeft=12;
 								};
-								class Item3
+								class Item1
 								{
 									name="HandGrenade";
 									count=2;
 									ammoLeft=1;
+								};
+								class Item2
+								{
+									name="rhs_mag_30Rnd_556x45_M855A1_Stanag";
+									count=8;
+									ammoLeft=30;
+								};
+								class Item3
+								{
+									name="rhs_mag_30Rnd_556x45_M855A1_Stanag_Tracer_Red";
+									count=2;
+									ammoLeft=30;
 								};
 							};
 							class ItemCargo
@@ -1520,7 +1606,7 @@ class items
 						};
 						class backpack
 						{
-							typeName="cnto_flecktarn_b_kb_mediterranean";
+							typeName="cnto_flecktarn_b_kb_grassland";
 							isBackpack=1;
 							class MagazineCargo
 							{
@@ -1602,10 +1688,10 @@ class items
 						compass="ItemCompass";
 						watch="ItemWatch";
 						gps="ItemGPS";
-						headgear="cnto_flecktarn_h_s_mediterranean";
+						headgear="cnto_flecktarn_h_c_grassland";
 					};
 				};
-				id=7;
+				id=9;
 				type="I_medic_F";
 				class CustomAttributes
 				{
@@ -1629,6 +1715,25 @@ class items
 						};
 					};
 					class Attribute1
+					{
+						property="lambs_danger_disableAI";
+						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"BOOL"
+									};
+								};
+								value=1;
+							};
+						};
+					};
+					class Attribute2
 					{
 						property="a3ee_acre_chlist";
 						expression="_this setVariable [""a3ee_acre_chlist"",_value,true]";
@@ -1664,7 +1769,7 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					nAttributes=3;
 				};
 			};
 			class Item2
@@ -1672,7 +1777,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-5.9536133,0.0014390945,3.1201172};
+					position[]={-6.0334473,0.0014390945,3.3813477};
 				};
 				side="Independent";
 				flags=5;
@@ -1715,7 +1820,7 @@ class items
 						};
 						class uniform
 						{
-							typeName="cnto_flecktarn_u_mediterranean";
+							typeName="cnto_flecktarn_u_r_grassland";
 							isBackpack=0;
 							class MagazineCargo
 							{
@@ -1774,7 +1879,7 @@ class items
 						};
 						class vest
 						{
-							typeName="cnto_flecktarn_v_mediterranean";
+							typeName="cnto_flecktarn_v_grassland";
 							isBackpack=0;
 							class MagazineCargo
 							{
@@ -1816,7 +1921,7 @@ class items
 						};
 						class backpack
 						{
-							typeName="cnto_flecktarn_b_ap_mediterranean";
+							typeName="cnto_flecktarn_b_ap_grassland";
 							isBackpack=1;
 							class MagazineCargo
 							{
@@ -1872,10 +1977,10 @@ class items
 						compass="ItemCompass";
 						watch="ItemWatch";
 						gps="ItemGPS";
-						headgear="cnto_flecktarn_h_s_mediterranean";
+						headgear="cnto_flecktarn_h_s_grassland";
 					};
 				};
-				id=8;
+				id=10;
 				type="I_Soldier_TL_F";
 				class CustomAttributes
 				{
@@ -1919,6 +2024,25 @@ class items
 					};
 					class Attribute2
 					{
+						property="lambs_danger_disableAI";
+						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"BOOL"
+									};
+								};
+								value=1;
+							};
+						};
+					};
+					class Attribute3
+					{
 						property="a3ee_acre_chlist";
 						expression="_this setVariable [""a3ee_acre_chlist"",_value,true]";
 						class Value
@@ -1953,7 +2077,7 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					nAttributes=4;
 				};
 			};
 			class Item3
@@ -1961,7 +2085,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-4.9536133,0.0014390945,3.1201172};
+					position[]={-5.0334473,0.0014390945,3.3813477};
 				};
 				side="Independent";
 				flags=5;
@@ -1975,6 +2099,7 @@ class items
 						class primaryWeapon
 						{
 							name="rhs_weap_minimi_para_railed";
+							muzzle="rhsusf_acc_SF3P556";
 							underBarrel="rhsusf_acc_saw_bipod";
 							class primaryMuzzleMag
 							{
@@ -1994,7 +2119,7 @@ class items
 						};
 						class uniform
 						{
-							typeName="cnto_flecktarn_u_mediterranean";
+							typeName="cnto_flecktarn_u_grassland";
 							isBackpack=0;
 							class MagazineCargo
 							{
@@ -2043,7 +2168,7 @@ class items
 						};
 						class vest
 						{
-							typeName="cnto_flecktarn_v_mediterranean";
+							typeName="cnto_flecktarn_v_l_grassland";
 							isBackpack=0;
 							class MagazineCargo
 							{
@@ -2079,7 +2204,7 @@ class items
 						};
 						class backpack
 						{
-							typeName="cnto_flecktarn_b_ap_mediterranean";
+							typeName="cnto_flecktarn_b_ap_grassland";
 							isBackpack=1;
 							class MagazineCargo
 							{
@@ -2095,10 +2220,10 @@ class items
 						map="ItemMap";
 						compass="ItemCompass";
 						watch="ItemWatch";
-						headgear="cnto_flecktarn_h_s_mediterranean";
+						headgear="cnto_flecktarn_h_c_grassland";
 					};
 				};
-				id=9;
+				id=11;
 				type="I_Soldier_AR_F";
 				class CustomAttributes
 				{
@@ -2142,6 +2267,25 @@ class items
 					};
 					class Attribute2
 					{
+						property="lambs_danger_disableAI";
+						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"BOOL"
+									};
+								};
+								value=1;
+							};
+						};
+					};
+					class Attribute3
+					{
 						property="a3ee_acre_chlist";
 						expression="_this setVariable [""a3ee_acre_chlist"",_value,true]";
 						class Value
@@ -2176,7 +2320,7 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					nAttributes=4;
 				};
 			};
 			class Item4
@@ -2184,7 +2328,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-3.9536133,0.0014390945,3.1201172};
+					position[]={-4.0334473,0.0014390945,3.3813477};
 				};
 				side="Independent";
 				flags=5;
@@ -2222,7 +2366,7 @@ class items
 						};
 						class uniform
 						{
-							typeName="cnto_flecktarn_u_mediterranean";
+							typeName="cnto_flecktarn_u_r_grassland";
 							isBackpack=0;
 							class MagazineCargo
 							{
@@ -2281,7 +2425,7 @@ class items
 						};
 						class vest
 						{
-							typeName="cnto_flecktarn_v_mediterranean";
+							typeName="cnto_flecktarn_v_grassland";
 							isBackpack=0;
 							class MagazineCargo
 							{
@@ -2323,7 +2467,7 @@ class items
 						};
 						class backpack
 						{
-							typeName="cnto_flecktarn_b_kb_mediterranean";
+							typeName="cnto_flecktarn_b_kb_grassland";
 							isBackpack=1;
 							class MagazineCargo
 							{
@@ -2379,10 +2523,10 @@ class items
 						compass="ItemCompass";
 						watch="ItemWatch";
 						gps="ItemGPS";
-						headgear="cnto_flecktarn_h_s_mediterranean";
+						headgear="cnto_flecktarn_h_c_grassland";
 					};
 				};
-				id=10;
+				id=12;
 				type="I_Soldier_AAR_F";
 				class CustomAttributes
 				{
@@ -2426,6 +2570,25 @@ class items
 					};
 					class Attribute2
 					{
+						property="lambs_danger_disableAI";
+						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"BOOL"
+									};
+								};
+								value=1;
+							};
+						};
+					};
+					class Attribute3
+					{
 						property="a3ee_acre_chlist";
 						expression="_this setVariable [""a3ee_acre_chlist"",_value,true]";
 						class Value
@@ -2460,7 +2623,7 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					nAttributes=4;
 				};
 			};
 			class Item5
@@ -2468,7 +2631,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-2.9536133,0.0014390945,3.1201172};
+					position[]={-3.0334473,0.0014390945,3.3813477};
 				};
 				side="Independent";
 				flags=5;
@@ -2481,7 +2644,7 @@ class items
 					{
 						class primaryWeapon
 						{
-							name="rhs_weap_hk416d145";
+							name="rhs_weap_hk416d10";
 							underBarrel="rhsusf_acc_grip2";
 							class primaryMuzzleMag
 							{
@@ -2505,7 +2668,7 @@ class items
 						};
 						class uniform
 						{
-							typeName="cnto_flecktarn_u_mediterranean";
+							typeName="cnto_flecktarn_u_grassland";
 							isBackpack=0;
 							class MagazineCargo
 							{
@@ -2554,7 +2717,7 @@ class items
 						};
 						class vest
 						{
-							typeName="cnto_flecktarn_v_mediterranean";
+							typeName="cnto_flecktarn_v_l_grassland";
 							isBackpack=0;
 							class MagazineCargo
 							{
@@ -2597,10 +2760,10 @@ class items
 						map="ItemMap";
 						compass="ItemCompass";
 						watch="ItemWatch";
-						headgear="cnto_flecktarn_h_s_mediterranean";
+						headgear="cnto_flecktarn_h_c_grassland";
 					};
 				};
-				id=11;
+				id=13;
 				type="I_Soldier_LAT_F";
 				class CustomAttributes
 				{
@@ -2644,6 +2807,25 @@ class items
 					};
 					class Attribute2
 					{
+						property="lambs_danger_disableAI";
+						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"BOOL"
+									};
+								};
+								value=1;
+							};
+						};
+					};
+					class Attribute3
+					{
 						property="a3ee_acre_chlist";
 						expression="_this setVariable [""a3ee_acre_chlist"",_value,true]";
 						class Value
@@ -2678,7 +2860,7 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					nAttributes=4;
 				};
 			};
 			class Item6
@@ -2686,7 +2868,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-5.9536133,0.0014390945,1.1201172};
+					position[]={-6.0334473,0.0014390945,1.3813477};
 				};
 				side="Independent";
 				flags=5;
@@ -2729,7 +2911,7 @@ class items
 						};
 						class uniform
 						{
-							typeName="cnto_flecktarn_u_mediterranean";
+							typeName="cnto_flecktarn_u_r_grassland";
 							isBackpack=0;
 							class MagazineCargo
 							{
@@ -2788,7 +2970,7 @@ class items
 						};
 						class vest
 						{
-							typeName="cnto_flecktarn_v_mediterranean";
+							typeName="cnto_flecktarn_v_grassland";
 							isBackpack=0;
 							class MagazineCargo
 							{
@@ -2830,7 +3012,7 @@ class items
 						};
 						class backpack
 						{
-							typeName="cnto_flecktarn_b_ap_mediterranean";
+							typeName="cnto_flecktarn_b_ap_grassland";
 							isBackpack=1;
 							class MagazineCargo
 							{
@@ -2886,10 +3068,10 @@ class items
 						compass="ItemCompass";
 						watch="ItemWatch";
 						gps="ItemGPS";
-						headgear="cnto_flecktarn_h_s_mediterranean";
+						headgear="cnto_flecktarn_h_s_grassland";
 					};
 				};
-				id=12;
+				id=14;
 				type="I_Soldier_TL_F";
 				class CustomAttributes
 				{
@@ -2933,6 +3115,25 @@ class items
 					};
 					class Attribute2
 					{
+						property="lambs_danger_disableAI";
+						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"BOOL"
+									};
+								};
+								value=1;
+							};
+						};
+					};
+					class Attribute3
+					{
 						property="a3ee_acre_chlist";
 						expression="_this setVariable [""a3ee_acre_chlist"",_value,true]";
 						class Value
@@ -2967,7 +3168,7 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					nAttributes=4;
 				};
 			};
 			class Item7
@@ -2975,7 +3176,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-4.9536133,0.0014390945,1.1201172};
+					position[]={-5.0334473,0.0014390945,1.3813477};
 				};
 				side="Independent";
 				flags=5;
@@ -2989,6 +3190,7 @@ class items
 						class primaryWeapon
 						{
 							name="rhs_weap_minimi_para_railed";
+							muzzle="rhsusf_acc_SF3P556";
 							underBarrel="rhsusf_acc_saw_bipod";
 							class primaryMuzzleMag
 							{
@@ -3008,7 +3210,7 @@ class items
 						};
 						class uniform
 						{
-							typeName="cnto_flecktarn_u_mediterranean";
+							typeName="cnto_flecktarn_u_grassland";
 							isBackpack=0;
 							class MagazineCargo
 							{
@@ -3057,7 +3259,7 @@ class items
 						};
 						class vest
 						{
-							typeName="cnto_flecktarn_v_mediterranean";
+							typeName="cnto_flecktarn_v_l_grassland";
 							isBackpack=0;
 							class MagazineCargo
 							{
@@ -3093,7 +3295,7 @@ class items
 						};
 						class backpack
 						{
-							typeName="cnto_flecktarn_b_ap_mediterranean";
+							typeName="cnto_flecktarn_b_ap_grassland";
 							isBackpack=1;
 							class MagazineCargo
 							{
@@ -3109,10 +3311,10 @@ class items
 						map="ItemMap";
 						compass="ItemCompass";
 						watch="ItemWatch";
-						headgear="cnto_flecktarn_h_s_mediterranean";
+						headgear="cnto_flecktarn_h_c_grassland";
 					};
 				};
-				id=13;
+				id=15;
 				type="I_Soldier_AR_F";
 				class CustomAttributes
 				{
@@ -3156,6 +3358,25 @@ class items
 					};
 					class Attribute2
 					{
+						property="lambs_danger_disableAI";
+						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"BOOL"
+									};
+								};
+								value=1;
+							};
+						};
+					};
+					class Attribute3
+					{
 						property="a3ee_acre_chlist";
 						expression="_this setVariable [""a3ee_acre_chlist"",_value,true]";
 						class Value
@@ -3190,7 +3411,7 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					nAttributes=4;
 				};
 			};
 			class Item8
@@ -3198,7 +3419,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-3.9536133,0.0014390945,1.1201172};
+					position[]={-4.0334473,0.0014390945,1.3813477};
 				};
 				side="Independent";
 				flags=5;
@@ -3236,7 +3457,7 @@ class items
 						};
 						class uniform
 						{
-							typeName="cnto_flecktarn_u_mediterranean";
+							typeName="cnto_flecktarn_u_r_grassland";
 							isBackpack=0;
 							class MagazineCargo
 							{
@@ -3295,7 +3516,7 @@ class items
 						};
 						class vest
 						{
-							typeName="cnto_flecktarn_v_mediterranean";
+							typeName="cnto_flecktarn_v_grassland";
 							isBackpack=0;
 							class MagazineCargo
 							{
@@ -3337,7 +3558,7 @@ class items
 						};
 						class backpack
 						{
-							typeName="cnto_flecktarn_b_kb_mediterranean";
+							typeName="cnto_flecktarn_b_kb_grassland";
 							isBackpack=1;
 							class MagazineCargo
 							{
@@ -3393,10 +3614,10 @@ class items
 						compass="ItemCompass";
 						watch="ItemWatch";
 						gps="ItemGPS";
-						headgear="cnto_flecktarn_h_s_mediterranean";
+						headgear="cnto_flecktarn_h_c_grassland";
 					};
 				};
-				id=14;
+				id=16;
 				type="I_Soldier_AAR_F";
 				class CustomAttributes
 				{
@@ -3440,6 +3661,25 @@ class items
 					};
 					class Attribute2
 					{
+						property="lambs_danger_disableAI";
+						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"BOOL"
+									};
+								};
+								value=1;
+							};
+						};
+					};
+					class Attribute3
+					{
 						property="a3ee_acre_chlist";
 						expression="_this setVariable [""a3ee_acre_chlist"",_value,true]";
 						class Value
@@ -3474,7 +3714,7 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					nAttributes=4;
 				};
 			};
 			class Item9
@@ -3482,7 +3722,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-2.9536133,0.0014390945,1.1201172};
+					position[]={-3.0334473,0.0014390945,1.3813477};
 				};
 				side="Independent";
 				flags=5;
@@ -3495,7 +3735,7 @@ class items
 					{
 						class primaryWeapon
 						{
-							name="rhs_weap_hk416d145";
+							name="rhs_weap_hk416d10";
 							underBarrel="rhsusf_acc_grip2";
 							class primaryMuzzleMag
 							{
@@ -3519,7 +3759,7 @@ class items
 						};
 						class uniform
 						{
-							typeName="cnto_flecktarn_u_mediterranean";
+							typeName="cnto_flecktarn_u_grassland";
 							isBackpack=0;
 							class MagazineCargo
 							{
@@ -3568,7 +3808,7 @@ class items
 						};
 						class vest
 						{
-							typeName="cnto_flecktarn_v_mediterranean";
+							typeName="cnto_flecktarn_v_l_grassland";
 							isBackpack=0;
 							class MagazineCargo
 							{
@@ -3611,10 +3851,10 @@ class items
 						map="ItemMap";
 						compass="ItemCompass";
 						watch="ItemWatch";
-						headgear="cnto_flecktarn_h_s_mediterranean";
+						headgear="cnto_flecktarn_h_c_grassland";
 					};
 				};
-				id=15;
+				id=17;
 				type="I_Soldier_LAT_F";
 				class CustomAttributes
 				{
@@ -3658,6 +3898,25 @@ class items
 					};
 					class Attribute2
 					{
+						property="lambs_danger_disableAI";
+						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"BOOL"
+									};
+								};
+								value=1;
+							};
+						};
+					};
+					class Attribute3
+					{
 						property="a3ee_acre_chlist";
 						expression="_this setVariable [""a3ee_acre_chlist"",_value,true]";
 						class Value
@@ -3692,14 +3951,14 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					nAttributes=4;
 				};
 			};
 		};
 		class Attributes
 		{
 		};
-		id=5;
+		id=7;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -3721,26 +3980,7 @@ class items
 					};
 				};
 			};
-			class Attribute1
-			{
-				property="groupID";
-				expression="[_this, _value] call CBA_fnc_setCallsign";
-				class Value
-				{
-					class data
-					{
-						class type
-						{
-							type[]=
-							{
-								"STRING"
-							};
-						};
-						value="ALPHA";
-					};
-				};
-			};
-			nAttributes=2;
+			nAttributes=1;
 		};
 	};
 	class Item2
@@ -3755,7 +3995,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-0.39111328,0.0014390945,5.0083008};
+					position[]={-0.47094727,0.0014390945,5.269043};
 				};
 				side="Independent";
 				flags=7;
@@ -3798,7 +4038,7 @@ class items
 						};
 						class uniform
 						{
-							typeName="cnto_flecktarn_u_mediterranean";
+							typeName="cnto_flecktarn_u_grassland";
 							isBackpack=0;
 							class MagazineCargo
 							{
@@ -3862,7 +4102,7 @@ class items
 						};
 						class vest
 						{
-							typeName="cnto_flecktarn_v_mediterranean";
+							typeName="cnto_flecktarn_v_grassland";
 							isBackpack=0;
 							class MagazineCargo
 							{
@@ -3910,7 +4150,7 @@ class items
 						};
 						class backpack
 						{
-							typeName="cnto_flecktarn_b_ap_mediterranean";
+							typeName="cnto_flecktarn_b_ap_grassland";
 							isBackpack=1;
 							class MagazineCargo
 							{
@@ -3972,10 +4212,10 @@ class items
 						compass="ItemCompass";
 						watch="ItemWatch";
 						gps="ItemGPS";
-						headgear="cnto_flecktarn_h_s_mediterranean";
+						headgear="cnto_flecktarn_h_s_grassland";
 					};
 				};
-				id=17;
+				id=19;
 				type="I_Soldier_SL_F";
 				class CustomAttributes
 				{
@@ -3999,6 +4239,25 @@ class items
 						};
 					};
 					class Attribute1
+					{
+						property="lambs_danger_disableAI";
+						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"BOOL"
+									};
+								};
+								value=1;
+							};
+						};
+					};
+					class Attribute2
 					{
 						property="a3ee_acre_chlist";
 						expression="_this setVariable [""a3ee_acre_chlist"",_value,true]";
@@ -4048,7 +4307,7 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					nAttributes=3;
 				};
 			};
 			class Item1
@@ -4056,7 +4315,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={0.60791016,0.0014390945,5.0083008};
+					position[]={0.52807617,0.0014390945,5.269043};
 				};
 				side="Independent";
 				flags=5;
@@ -4069,7 +4328,7 @@ class items
 					{
 						class primaryWeapon
 						{
-							name="rhs_weap_hk416d145";
+							name="rhs_weap_hk416d10";
 							underBarrel="rhsusf_acc_grip2";
 							class primaryMuzzleMag
 							{
@@ -4089,7 +4348,7 @@ class items
 						};
 						class uniform
 						{
-							typeName="cnto_flecktarn_u_mediterranean";
+							typeName="cnto_flecktarn_u_r_grassland";
 							isBackpack=0;
 							class MagazineCargo
 							{
@@ -4138,34 +4397,34 @@ class items
 						};
 						class vest
 						{
-							typeName="cnto_flecktarn_v_mediterranean";
+							typeName="cnto_flecktarn_v_grassland";
 							isBackpack=0;
 							class MagazineCargo
 							{
 								items=4;
 								class Item0
 								{
-									name="rhs_mag_30Rnd_556x45_M855A1_Stanag";
-									count=8;
-									ammoLeft=30;
-								};
-								class Item1
-								{
-									name="rhs_mag_30Rnd_556x45_M855A1_Stanag_Tracer_Red";
-									count=2;
-									ammoLeft=30;
-								};
-								class Item2
-								{
 									name="hlc_12Rnd_357SIG_B_P226";
 									count=1;
 									ammoLeft=12;
 								};
-								class Item3
+								class Item1
 								{
 									name="HandGrenade";
 									count=2;
 									ammoLeft=1;
+								};
+								class Item2
+								{
+									name="rhs_mag_30Rnd_556x45_M855A1_Stanag";
+									count=8;
+									ammoLeft=30;
+								};
+								class Item3
+								{
+									name="rhs_mag_30Rnd_556x45_M855A1_Stanag_Tracer_Red";
+									count=2;
+									ammoLeft=30;
 								};
 							};
 							class ItemCargo
@@ -4180,7 +4439,7 @@ class items
 						};
 						class backpack
 						{
-							typeName="cnto_flecktarn_b_kb_mediterranean";
+							typeName="cnto_flecktarn_b_kb_grassland";
 							isBackpack=1;
 							class MagazineCargo
 							{
@@ -4262,10 +4521,10 @@ class items
 						compass="ItemCompass";
 						watch="ItemWatch";
 						gps="ItemGPS";
-						headgear="cnto_flecktarn_h_s_mediterranean";
+						headgear="cnto_flecktarn_h_c_grassland";
 					};
 				};
-				id=18;
+				id=20;
 				type="I_medic_F";
 				class CustomAttributes
 				{
@@ -4289,6 +4548,25 @@ class items
 						};
 					};
 					class Attribute1
+					{
+						property="lambs_danger_disableAI";
+						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"BOOL"
+									};
+								};
+								value=1;
+							};
+						};
+					};
+					class Attribute2
 					{
 						property="a3ee_acre_chlist";
 						expression="_this setVariable [""a3ee_acre_chlist"",_value,true]";
@@ -4324,7 +4602,7 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					nAttributes=3;
 				};
 			};
 			class Item2
@@ -4332,7 +4610,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-0.39208984,0.0014390945,3.0083008};
+					position[]={-0.47192383,0.0014390945,3.269043};
 				};
 				side="Independent";
 				flags=5;
@@ -4375,7 +4653,7 @@ class items
 						};
 						class uniform
 						{
-							typeName="cnto_flecktarn_u_mediterranean";
+							typeName="cnto_flecktarn_u_r_grassland";
 							isBackpack=0;
 							class MagazineCargo
 							{
@@ -4434,7 +4712,7 @@ class items
 						};
 						class vest
 						{
-							typeName="cnto_flecktarn_v_mediterranean";
+							typeName="cnto_flecktarn_v_grassland";
 							isBackpack=0;
 							class MagazineCargo
 							{
@@ -4476,7 +4754,7 @@ class items
 						};
 						class backpack
 						{
-							typeName="cnto_flecktarn_b_ap_mediterranean";
+							typeName="cnto_flecktarn_b_ap_grassland";
 							isBackpack=1;
 							class MagazineCargo
 							{
@@ -4532,10 +4810,10 @@ class items
 						compass="ItemCompass";
 						watch="ItemWatch";
 						gps="ItemGPS";
-						headgear="cnto_flecktarn_h_s_mediterranean";
+						headgear="cnto_flecktarn_h_s_grassland";
 					};
 				};
-				id=19;
+				id=21;
 				type="I_Soldier_TL_F";
 				class CustomAttributes
 				{
@@ -4579,6 +4857,25 @@ class items
 					};
 					class Attribute2
 					{
+						property="lambs_danger_disableAI";
+						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"BOOL"
+									};
+								};
+								value=1;
+							};
+						};
+					};
+					class Attribute3
+					{
 						property="a3ee_acre_chlist";
 						expression="_this setVariable [""a3ee_acre_chlist"",_value,true]";
 						class Value
@@ -4613,7 +4910,7 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					nAttributes=4;
 				};
 			};
 			class Item3
@@ -4621,7 +4918,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={0.60791016,0.0014390945,3.0083008};
+					position[]={0.52807617,0.0014390945,3.269043};
 				};
 				side="Independent";
 				flags=5;
@@ -4635,6 +4932,7 @@ class items
 						class primaryWeapon
 						{
 							name="rhs_weap_minimi_para_railed";
+							muzzle="rhsusf_acc_SF3P556";
 							underBarrel="rhsusf_acc_saw_bipod";
 							class primaryMuzzleMag
 							{
@@ -4654,7 +4952,7 @@ class items
 						};
 						class uniform
 						{
-							typeName="cnto_flecktarn_u_mediterranean";
+							typeName="cnto_flecktarn_u_grassland";
 							isBackpack=0;
 							class MagazineCargo
 							{
@@ -4703,7 +5001,7 @@ class items
 						};
 						class vest
 						{
-							typeName="cnto_flecktarn_v_mediterranean";
+							typeName="cnto_flecktarn_v_l_grassland";
 							isBackpack=0;
 							class MagazineCargo
 							{
@@ -4739,7 +5037,7 @@ class items
 						};
 						class backpack
 						{
-							typeName="cnto_flecktarn_b_ap_mediterranean";
+							typeName="cnto_flecktarn_b_ap_grassland";
 							isBackpack=1;
 							class MagazineCargo
 							{
@@ -4755,10 +5053,10 @@ class items
 						map="ItemMap";
 						compass="ItemCompass";
 						watch="ItemWatch";
-						headgear="cnto_flecktarn_h_s_mediterranean";
+						headgear="cnto_flecktarn_h_c_grassland";
 					};
 				};
-				id=20;
+				id=22;
 				type="I_Soldier_AR_F";
 				class CustomAttributes
 				{
@@ -4802,6 +5100,25 @@ class items
 					};
 					class Attribute2
 					{
+						property="lambs_danger_disableAI";
+						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"BOOL"
+									};
+								};
+								value=1;
+							};
+						};
+					};
+					class Attribute3
+					{
 						property="a3ee_acre_chlist";
 						expression="_this setVariable [""a3ee_acre_chlist"",_value,true]";
 						class Value
@@ -4836,7 +5153,7 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					nAttributes=4;
 				};
 			};
 			class Item4
@@ -4844,7 +5161,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={1.6079102,0.0014390945,3.0083008};
+					position[]={1.5280762,0.0014390945,3.269043};
 				};
 				side="Independent";
 				flags=5;
@@ -4882,7 +5199,7 @@ class items
 						};
 						class uniform
 						{
-							typeName="cnto_flecktarn_u_mediterranean";
+							typeName="cnto_flecktarn_u_r_grassland";
 							isBackpack=0;
 							class MagazineCargo
 							{
@@ -4941,7 +5258,7 @@ class items
 						};
 						class vest
 						{
-							typeName="cnto_flecktarn_v_mediterranean";
+							typeName="cnto_flecktarn_v_grassland";
 							isBackpack=0;
 							class MagazineCargo
 							{
@@ -4983,7 +5300,7 @@ class items
 						};
 						class backpack
 						{
-							typeName="cnto_flecktarn_b_kb_mediterranean";
+							typeName="cnto_flecktarn_b_kb_grassland";
 							isBackpack=1;
 							class MagazineCargo
 							{
@@ -5039,10 +5356,10 @@ class items
 						compass="ItemCompass";
 						watch="ItemWatch";
 						gps="ItemGPS";
-						headgear="cnto_flecktarn_h_s_mediterranean";
+						headgear="cnto_flecktarn_h_c_grassland";
 					};
 				};
-				id=21;
+				id=23;
 				type="I_Soldier_AAR_F";
 				class CustomAttributes
 				{
@@ -5086,6 +5403,25 @@ class items
 					};
 					class Attribute2
 					{
+						property="lambs_danger_disableAI";
+						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"BOOL"
+									};
+								};
+								value=1;
+							};
+						};
+					};
+					class Attribute3
+					{
 						property="a3ee_acre_chlist";
 						expression="_this setVariable [""a3ee_acre_chlist"",_value,true]";
 						class Value
@@ -5120,7 +5456,7 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					nAttributes=4;
 				};
 			};
 			class Item5
@@ -5128,7 +5464,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={2.6079102,0.0014390945,3.0083008};
+					position[]={2.5280762,0.0014390945,3.269043};
 				};
 				side="Independent";
 				flags=5;
@@ -5141,7 +5477,7 @@ class items
 					{
 						class primaryWeapon
 						{
-							name="rhs_weap_hk416d145";
+							name="rhs_weap_hk416d10";
 							underBarrel="rhsusf_acc_grip2";
 							class primaryMuzzleMag
 							{
@@ -5165,7 +5501,7 @@ class items
 						};
 						class uniform
 						{
-							typeName="cnto_flecktarn_u_mediterranean";
+							typeName="cnto_flecktarn_u_grassland";
 							isBackpack=0;
 							class MagazineCargo
 							{
@@ -5214,7 +5550,7 @@ class items
 						};
 						class vest
 						{
-							typeName="cnto_flecktarn_v_mediterranean";
+							typeName="cnto_flecktarn_v_l_grassland";
 							isBackpack=0;
 							class MagazineCargo
 							{
@@ -5257,10 +5593,10 @@ class items
 						map="ItemMap";
 						compass="ItemCompass";
 						watch="ItemWatch";
-						headgear="cnto_flecktarn_h_s_mediterranean";
+						headgear="cnto_flecktarn_h_c_grassland";
 					};
 				};
-				id=22;
+				id=24;
 				type="I_Soldier_LAT_F";
 				class CustomAttributes
 				{
@@ -5304,6 +5640,25 @@ class items
 					};
 					class Attribute2
 					{
+						property="lambs_danger_disableAI";
+						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"BOOL"
+									};
+								};
+								value=1;
+							};
+						};
+					};
+					class Attribute3
+					{
 						property="a3ee_acre_chlist";
 						expression="_this setVariable [""a3ee_acre_chlist"",_value,true]";
 						class Value
@@ -5338,7 +5693,7 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					nAttributes=4;
 				};
 			};
 			class Item6
@@ -5346,7 +5701,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-0.39208984,0.0014390945,1.0083008};
+					position[]={-0.47192383,0.0014390945,1.269043};
 				};
 				side="Independent";
 				flags=5;
@@ -5389,7 +5744,7 @@ class items
 						};
 						class uniform
 						{
-							typeName="cnto_flecktarn_u_mediterranean";
+							typeName="cnto_flecktarn_u_r_grassland";
 							isBackpack=0;
 							class MagazineCargo
 							{
@@ -5448,7 +5803,7 @@ class items
 						};
 						class vest
 						{
-							typeName="cnto_flecktarn_v_mediterranean";
+							typeName="cnto_flecktarn_v_grassland";
 							isBackpack=0;
 							class MagazineCargo
 							{
@@ -5490,7 +5845,7 @@ class items
 						};
 						class backpack
 						{
-							typeName="cnto_flecktarn_b_ap_mediterranean";
+							typeName="cnto_flecktarn_b_ap_grassland";
 							isBackpack=1;
 							class MagazineCargo
 							{
@@ -5546,10 +5901,10 @@ class items
 						compass="ItemCompass";
 						watch="ItemWatch";
 						gps="ItemGPS";
-						headgear="cnto_flecktarn_h_s_mediterranean";
+						headgear="cnto_flecktarn_h_s_grassland";
 					};
 				};
-				id=23;
+				id=25;
 				type="I_Soldier_TL_F";
 				class CustomAttributes
 				{
@@ -5593,6 +5948,25 @@ class items
 					};
 					class Attribute2
 					{
+						property="lambs_danger_disableAI";
+						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"BOOL"
+									};
+								};
+								value=1;
+							};
+						};
+					};
+					class Attribute3
+					{
 						property="a3ee_acre_chlist";
 						expression="_this setVariable [""a3ee_acre_chlist"",_value,true]";
 						class Value
@@ -5627,7 +6001,7 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					nAttributes=4;
 				};
 			};
 			class Item7
@@ -5635,7 +6009,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={0.60791016,0.0014390945,1.0083008};
+					position[]={0.52807617,0.0014390945,1.269043};
 				};
 				side="Independent";
 				flags=5;
@@ -5649,6 +6023,7 @@ class items
 						class primaryWeapon
 						{
 							name="rhs_weap_minimi_para_railed";
+							muzzle="rhsusf_acc_SF3P556";
 							underBarrel="rhsusf_acc_saw_bipod";
 							class primaryMuzzleMag
 							{
@@ -5668,7 +6043,7 @@ class items
 						};
 						class uniform
 						{
-							typeName="cnto_flecktarn_u_mediterranean";
+							typeName="cnto_flecktarn_u_grassland";
 							isBackpack=0;
 							class MagazineCargo
 							{
@@ -5717,7 +6092,7 @@ class items
 						};
 						class vest
 						{
-							typeName="cnto_flecktarn_v_mediterranean";
+							typeName="cnto_flecktarn_v_l_grassland";
 							isBackpack=0;
 							class MagazineCargo
 							{
@@ -5753,7 +6128,7 @@ class items
 						};
 						class backpack
 						{
-							typeName="cnto_flecktarn_b_ap_mediterranean";
+							typeName="cnto_flecktarn_b_ap_grassland";
 							isBackpack=1;
 							class MagazineCargo
 							{
@@ -5769,10 +6144,10 @@ class items
 						map="ItemMap";
 						compass="ItemCompass";
 						watch="ItemWatch";
-						headgear="cnto_flecktarn_h_s_mediterranean";
+						headgear="cnto_flecktarn_h_c_grassland";
 					};
 				};
-				id=24;
+				id=26;
 				type="I_Soldier_AR_F";
 				class CustomAttributes
 				{
@@ -5816,6 +6191,25 @@ class items
 					};
 					class Attribute2
 					{
+						property="lambs_danger_disableAI";
+						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"BOOL"
+									};
+								};
+								value=1;
+							};
+						};
+					};
+					class Attribute3
+					{
 						property="a3ee_acre_chlist";
 						expression="_this setVariable [""a3ee_acre_chlist"",_value,true]";
 						class Value
@@ -5850,7 +6244,7 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					nAttributes=4;
 				};
 			};
 			class Item8
@@ -5858,7 +6252,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={1.6079102,0.0014390945,1.0083008};
+					position[]={1.5280762,0.0014390945,1.269043};
 				};
 				side="Independent";
 				flags=5;
@@ -5896,7 +6290,7 @@ class items
 						};
 						class uniform
 						{
-							typeName="cnto_flecktarn_u_mediterranean";
+							typeName="cnto_flecktarn_u_r_grassland";
 							isBackpack=0;
 							class MagazineCargo
 							{
@@ -5955,7 +6349,7 @@ class items
 						};
 						class vest
 						{
-							typeName="cnto_flecktarn_v_mediterranean";
+							typeName="cnto_flecktarn_v_grassland";
 							isBackpack=0;
 							class MagazineCargo
 							{
@@ -5997,7 +6391,7 @@ class items
 						};
 						class backpack
 						{
-							typeName="cnto_flecktarn_b_kb_mediterranean";
+							typeName="cnto_flecktarn_b_kb_grassland";
 							isBackpack=1;
 							class MagazineCargo
 							{
@@ -6053,10 +6447,10 @@ class items
 						compass="ItemCompass";
 						watch="ItemWatch";
 						gps="ItemGPS";
-						headgear="cnto_flecktarn_h_s_mediterranean";
+						headgear="cnto_flecktarn_h_c_grassland";
 					};
 				};
-				id=25;
+				id=27;
 				type="I_Soldier_AAR_F";
 				class CustomAttributes
 				{
@@ -6100,6 +6494,25 @@ class items
 					};
 					class Attribute2
 					{
+						property="lambs_danger_disableAI";
+						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"BOOL"
+									};
+								};
+								value=1;
+							};
+						};
+					};
+					class Attribute3
+					{
 						property="a3ee_acre_chlist";
 						expression="_this setVariable [""a3ee_acre_chlist"",_value,true]";
 						class Value
@@ -6134,7 +6547,7 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					nAttributes=4;
 				};
 			};
 			class Item9
@@ -6142,7 +6555,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={2.6079102,0.0014390945,1.0083008};
+					position[]={2.5280762,0.0014390945,1.269043};
 				};
 				side="Independent";
 				flags=5;
@@ -6155,7 +6568,7 @@ class items
 					{
 						class primaryWeapon
 						{
-							name="rhs_weap_hk416d145";
+							name="rhs_weap_hk416d10";
 							underBarrel="rhsusf_acc_grip2";
 							class primaryMuzzleMag
 							{
@@ -6179,7 +6592,7 @@ class items
 						};
 						class uniform
 						{
-							typeName="cnto_flecktarn_u_mediterranean";
+							typeName="cnto_flecktarn_u_grassland";
 							isBackpack=0;
 							class MagazineCargo
 							{
@@ -6228,7 +6641,7 @@ class items
 						};
 						class vest
 						{
-							typeName="cnto_flecktarn_v_mediterranean";
+							typeName="cnto_flecktarn_v_l_grassland";
 							isBackpack=0;
 							class MagazineCargo
 							{
@@ -6271,10 +6684,10 @@ class items
 						map="ItemMap";
 						compass="ItemCompass";
 						watch="ItemWatch";
-						headgear="cnto_flecktarn_h_s_mediterranean";
+						headgear="cnto_flecktarn_h_c_grassland";
 					};
 				};
-				id=26;
+				id=28;
 				type="I_Soldier_LAT_F";
 				class CustomAttributes
 				{
@@ -6318,6 +6731,25 @@ class items
 					};
 					class Attribute2
 					{
+						property="lambs_danger_disableAI";
+						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"BOOL"
+									};
+								};
+								value=1;
+							};
+						};
+					};
+					class Attribute3
+					{
 						property="a3ee_acre_chlist";
 						expression="_this setVariable [""a3ee_acre_chlist"",_value,true]";
 						class Value
@@ -6352,14 +6784,14 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					nAttributes=4;
 				};
 			};
 		};
 		class Attributes
 		{
 		};
-		id=16;
+		id=18;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -6381,26 +6813,7 @@ class items
 					};
 				};
 			};
-			class Attribute1
-			{
-				property="groupID";
-				expression="[_this, _value] call CBA_fnc_setCallsign";
-				class Value
-				{
-					class data
-					{
-						class type
-						{
-							type[]=
-							{
-								"STRING"
-							};
-						};
-						value="BRAVO";
-					};
-				};
-			};
-			nAttributes=2;
+			nAttributes=1;
 		};
 	};
 	class Item3
@@ -6415,7 +6828,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={4.65625,0.0014390945,4.9003906};
+					position[]={4.576416,0.0014390945,5.1616211};
 				};
 				side="Independent";
 				flags=7;
@@ -6458,7 +6871,7 @@ class items
 						};
 						class uniform
 						{
-							typeName="cnto_flecktarn_u_mediterranean";
+							typeName="cnto_flecktarn_u_grassland";
 							isBackpack=0;
 							class MagazineCargo
 							{
@@ -6522,7 +6935,7 @@ class items
 						};
 						class vest
 						{
-							typeName="cnto_flecktarn_v_mediterranean";
+							typeName="cnto_flecktarn_v_grassland";
 							isBackpack=0;
 							class MagazineCargo
 							{
@@ -6570,7 +6983,7 @@ class items
 						};
 						class backpack
 						{
-							typeName="cnto_flecktarn_b_ap_mediterranean";
+							typeName="cnto_flecktarn_b_ap_grassland";
 							isBackpack=1;
 							class MagazineCargo
 							{
@@ -6632,10 +7045,10 @@ class items
 						compass="ItemCompass";
 						watch="ItemWatch";
 						gps="ItemGPS";
-						headgear="cnto_flecktarn_h_s_mediterranean";
+						headgear="cnto_flecktarn_h_s_grassland";
 					};
 				};
-				id=28;
+				id=30;
 				type="I_Soldier_SL_F";
 				class CustomAttributes
 				{
@@ -6659,6 +7072,25 @@ class items
 						};
 					};
 					class Attribute1
+					{
+						property="lambs_danger_disableAI";
+						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"BOOL"
+									};
+								};
+								value=1;
+							};
+						};
+					};
+					class Attribute2
 					{
 						property="a3ee_acre_chlist";
 						expression="_this setVariable [""a3ee_acre_chlist"",_value,true]";
@@ -6708,7 +7140,7 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					nAttributes=3;
 				};
 			};
 			class Item1
@@ -6716,7 +7148,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={5.65625,0.0014390945,4.8994141};
+					position[]={5.576416,0.0014390945,5.1606445};
 				};
 				side="Independent";
 				flags=5;
@@ -6729,7 +7161,7 @@ class items
 					{
 						class primaryWeapon
 						{
-							name="rhs_weap_hk416d145";
+							name="rhs_weap_hk416d10";
 							underBarrel="rhsusf_acc_grip2";
 							class primaryMuzzleMag
 							{
@@ -6749,7 +7181,7 @@ class items
 						};
 						class uniform
 						{
-							typeName="cnto_flecktarn_u_mediterranean";
+							typeName="cnto_flecktarn_u_r_grassland";
 							isBackpack=0;
 							class MagazineCargo
 							{
@@ -6798,34 +7230,34 @@ class items
 						};
 						class vest
 						{
-							typeName="cnto_flecktarn_v_mediterranean";
+							typeName="cnto_flecktarn_v_grassland";
 							isBackpack=0;
 							class MagazineCargo
 							{
 								items=4;
 								class Item0
 								{
-									name="rhs_mag_30Rnd_556x45_M855A1_Stanag";
-									count=8;
-									ammoLeft=30;
-								};
-								class Item1
-								{
-									name="rhs_mag_30Rnd_556x45_M855A1_Stanag_Tracer_Red";
-									count=2;
-									ammoLeft=30;
-								};
-								class Item2
-								{
 									name="hlc_12Rnd_357SIG_B_P226";
 									count=1;
 									ammoLeft=12;
 								};
-								class Item3
+								class Item1
 								{
 									name="HandGrenade";
 									count=2;
 									ammoLeft=1;
+								};
+								class Item2
+								{
+									name="rhs_mag_30Rnd_556x45_M855A1_Stanag";
+									count=8;
+									ammoLeft=30;
+								};
+								class Item3
+								{
+									name="rhs_mag_30Rnd_556x45_M855A1_Stanag_Tracer_Red";
+									count=2;
+									ammoLeft=30;
 								};
 							};
 							class ItemCargo
@@ -6840,7 +7272,7 @@ class items
 						};
 						class backpack
 						{
-							typeName="cnto_flecktarn_b_kb_mediterranean";
+							typeName="cnto_flecktarn_b_kb_grassland";
 							isBackpack=1;
 							class MagazineCargo
 							{
@@ -6922,10 +7354,10 @@ class items
 						compass="ItemCompass";
 						watch="ItemWatch";
 						gps="ItemGPS";
-						headgear="cnto_flecktarn_h_s_mediterranean";
+						headgear="cnto_flecktarn_h_c_grassland";
 					};
 				};
-				id=29;
+				id=31;
 				type="I_medic_F";
 				class CustomAttributes
 				{
@@ -6949,6 +7381,25 @@ class items
 						};
 					};
 					class Attribute1
+					{
+						property="lambs_danger_disableAI";
+						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"BOOL"
+									};
+								};
+								value=1;
+							};
+						};
+					};
+					class Attribute2
 					{
 						property="a3ee_acre_chlist";
 						expression="_this setVariable [""a3ee_acre_chlist"",_value,true]";
@@ -6984,7 +7435,7 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					nAttributes=3;
 				};
 			};
 			class Item2
@@ -6992,7 +7443,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={4.65625,0.0014390945,2.8994141};
+					position[]={4.576416,0.0014390945,3.1606445};
 				};
 				side="Independent";
 				flags=5;
@@ -7035,7 +7486,7 @@ class items
 						};
 						class uniform
 						{
-							typeName="cnto_flecktarn_u_mediterranean";
+							typeName="cnto_flecktarn_u_r_grassland";
 							isBackpack=0;
 							class MagazineCargo
 							{
@@ -7094,7 +7545,7 @@ class items
 						};
 						class vest
 						{
-							typeName="cnto_flecktarn_v_mediterranean";
+							typeName="cnto_flecktarn_v_grassland";
 							isBackpack=0;
 							class MagazineCargo
 							{
@@ -7136,7 +7587,7 @@ class items
 						};
 						class backpack
 						{
-							typeName="cnto_flecktarn_b_ap_mediterranean";
+							typeName="cnto_flecktarn_b_ap_grassland";
 							isBackpack=1;
 							class MagazineCargo
 							{
@@ -7192,10 +7643,10 @@ class items
 						compass="ItemCompass";
 						watch="ItemWatch";
 						gps="ItemGPS";
-						headgear="cnto_flecktarn_h_s_mediterranean";
+						headgear="cnto_flecktarn_h_s_grassland";
 					};
 				};
-				id=30;
+				id=32;
 				type="I_Soldier_TL_F";
 				class CustomAttributes
 				{
@@ -7239,6 +7690,25 @@ class items
 					};
 					class Attribute2
 					{
+						property="lambs_danger_disableAI";
+						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"BOOL"
+									};
+								};
+								value=1;
+							};
+						};
+					};
+					class Attribute3
+					{
 						property="a3ee_acre_chlist";
 						expression="_this setVariable [""a3ee_acre_chlist"",_value,true]";
 						class Value
@@ -7273,7 +7743,7 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					nAttributes=4;
 				};
 			};
 			class Item3
@@ -7281,7 +7751,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={5.65625,0.0014390945,2.8994141};
+					position[]={5.576416,0.0014390945,3.1606445};
 				};
 				side="Independent";
 				flags=5;
@@ -7295,6 +7765,7 @@ class items
 						class primaryWeapon
 						{
 							name="rhs_weap_minimi_para_railed";
+							muzzle="rhsusf_acc_SF3P556";
 							underBarrel="rhsusf_acc_saw_bipod";
 							class primaryMuzzleMag
 							{
@@ -7314,7 +7785,7 @@ class items
 						};
 						class uniform
 						{
-							typeName="cnto_flecktarn_u_mediterranean";
+							typeName="cnto_flecktarn_u_grassland";
 							isBackpack=0;
 							class MagazineCargo
 							{
@@ -7363,7 +7834,7 @@ class items
 						};
 						class vest
 						{
-							typeName="cnto_flecktarn_v_mediterranean";
+							typeName="cnto_flecktarn_v_l_grassland";
 							isBackpack=0;
 							class MagazineCargo
 							{
@@ -7399,7 +7870,7 @@ class items
 						};
 						class backpack
 						{
-							typeName="cnto_flecktarn_b_ap_mediterranean";
+							typeName="cnto_flecktarn_b_ap_grassland";
 							isBackpack=1;
 							class MagazineCargo
 							{
@@ -7415,10 +7886,10 @@ class items
 						map="ItemMap";
 						compass="ItemCompass";
 						watch="ItemWatch";
-						headgear="cnto_flecktarn_h_s_mediterranean";
+						headgear="cnto_flecktarn_h_c_grassland";
 					};
 				};
-				id=31;
+				id=33;
 				type="I_Soldier_AR_F";
 				class CustomAttributes
 				{
@@ -7462,6 +7933,25 @@ class items
 					};
 					class Attribute2
 					{
+						property="lambs_danger_disableAI";
+						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"BOOL"
+									};
+								};
+								value=1;
+							};
+						};
+					};
+					class Attribute3
+					{
 						property="a3ee_acre_chlist";
 						expression="_this setVariable [""a3ee_acre_chlist"",_value,true]";
 						class Value
@@ -7496,7 +7986,7 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					nAttributes=4;
 				};
 			};
 			class Item4
@@ -7504,7 +7994,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={6.65625,0.0014390945,2.8994141};
+					position[]={6.576416,0.0014390945,3.1606445};
 				};
 				side="Independent";
 				flags=5;
@@ -7542,7 +8032,7 @@ class items
 						};
 						class uniform
 						{
-							typeName="cnto_flecktarn_u_mediterranean";
+							typeName="cnto_flecktarn_u_r_grassland";
 							isBackpack=0;
 							class MagazineCargo
 							{
@@ -7601,7 +8091,7 @@ class items
 						};
 						class vest
 						{
-							typeName="cnto_flecktarn_v_mediterranean";
+							typeName="cnto_flecktarn_v_grassland";
 							isBackpack=0;
 							class MagazineCargo
 							{
@@ -7643,7 +8133,7 @@ class items
 						};
 						class backpack
 						{
-							typeName="cnto_flecktarn_b_kb_mediterranean";
+							typeName="cnto_flecktarn_b_kb_grassland";
 							isBackpack=1;
 							class MagazineCargo
 							{
@@ -7699,10 +8189,10 @@ class items
 						compass="ItemCompass";
 						watch="ItemWatch";
 						gps="ItemGPS";
-						headgear="cnto_flecktarn_h_s_mediterranean";
+						headgear="cnto_flecktarn_h_c_grassland";
 					};
 				};
-				id=32;
+				id=34;
 				type="I_Soldier_AAR_F";
 				class CustomAttributes
 				{
@@ -7746,6 +8236,25 @@ class items
 					};
 					class Attribute2
 					{
+						property="lambs_danger_disableAI";
+						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"BOOL"
+									};
+								};
+								value=1;
+							};
+						};
+					};
+					class Attribute3
+					{
 						property="a3ee_acre_chlist";
 						expression="_this setVariable [""a3ee_acre_chlist"",_value,true]";
 						class Value
@@ -7780,7 +8289,7 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					nAttributes=4;
 				};
 			};
 			class Item5
@@ -7788,7 +8297,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={7.65625,0.0014390945,2.8994141};
+					position[]={7.576416,0.0014390945,3.1606445};
 				};
 				side="Independent";
 				flags=5;
@@ -7801,7 +8310,7 @@ class items
 					{
 						class primaryWeapon
 						{
-							name="rhs_weap_hk416d145";
+							name="rhs_weap_hk416d10";
 							underBarrel="rhsusf_acc_grip2";
 							class primaryMuzzleMag
 							{
@@ -7825,7 +8334,7 @@ class items
 						};
 						class uniform
 						{
-							typeName="cnto_flecktarn_u_mediterranean";
+							typeName="cnto_flecktarn_u_grassland";
 							isBackpack=0;
 							class MagazineCargo
 							{
@@ -7874,7 +8383,7 @@ class items
 						};
 						class vest
 						{
-							typeName="cnto_flecktarn_v_mediterranean";
+							typeName="cnto_flecktarn_v_l_grassland";
 							isBackpack=0;
 							class MagazineCargo
 							{
@@ -7917,10 +8426,10 @@ class items
 						map="ItemMap";
 						compass="ItemCompass";
 						watch="ItemWatch";
-						headgear="cnto_flecktarn_h_s_mediterranean";
+						headgear="cnto_flecktarn_h_c_grassland";
 					};
 				};
-				id=33;
+				id=35;
 				type="I_Soldier_LAT_F";
 				class CustomAttributes
 				{
@@ -7964,6 +8473,25 @@ class items
 					};
 					class Attribute2
 					{
+						property="lambs_danger_disableAI";
+						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"BOOL"
+									};
+								};
+								value=1;
+							};
+						};
+					};
+					class Attribute3
+					{
 						property="a3ee_acre_chlist";
 						expression="_this setVariable [""a3ee_acre_chlist"",_value,true]";
 						class Value
@@ -7998,7 +8526,7 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					nAttributes=4;
 				};
 			};
 			class Item6
@@ -8006,7 +8534,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={4.65625,0.0014390945,0.89941406};
+					position[]={4.576416,0.0014390945,1.1606445};
 				};
 				side="Independent";
 				flags=5;
@@ -8049,7 +8577,7 @@ class items
 						};
 						class uniform
 						{
-							typeName="cnto_flecktarn_u_mediterranean";
+							typeName="cnto_flecktarn_u_r_grassland";
 							isBackpack=0;
 							class MagazineCargo
 							{
@@ -8108,7 +8636,7 @@ class items
 						};
 						class vest
 						{
-							typeName="cnto_flecktarn_v_mediterranean";
+							typeName="cnto_flecktarn_v_grassland";
 							isBackpack=0;
 							class MagazineCargo
 							{
@@ -8150,7 +8678,7 @@ class items
 						};
 						class backpack
 						{
-							typeName="cnto_flecktarn_b_ap_mediterranean";
+							typeName="cnto_flecktarn_b_ap_grassland";
 							isBackpack=1;
 							class MagazineCargo
 							{
@@ -8206,10 +8734,10 @@ class items
 						compass="ItemCompass";
 						watch="ItemWatch";
 						gps="ItemGPS";
-						headgear="cnto_flecktarn_h_s_mediterranean";
+						headgear="cnto_flecktarn_h_s_grassland";
 					};
 				};
-				id=34;
+				id=36;
 				type="I_Soldier_TL_F";
 				class CustomAttributes
 				{
@@ -8253,6 +8781,25 @@ class items
 					};
 					class Attribute2
 					{
+						property="lambs_danger_disableAI";
+						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"BOOL"
+									};
+								};
+								value=1;
+							};
+						};
+					};
+					class Attribute3
+					{
 						property="a3ee_acre_chlist";
 						expression="_this setVariable [""a3ee_acre_chlist"",_value,true]";
 						class Value
@@ -8287,7 +8834,7 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					nAttributes=4;
 				};
 			};
 			class Item7
@@ -8295,7 +8842,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={5.65625,0.0014390945,0.89941406};
+					position[]={5.576416,0.0014390945,1.1606445};
 				};
 				side="Independent";
 				flags=5;
@@ -8309,6 +8856,7 @@ class items
 						class primaryWeapon
 						{
 							name="rhs_weap_minimi_para_railed";
+							muzzle="rhsusf_acc_SF3P556";
 							underBarrel="rhsusf_acc_saw_bipod";
 							class primaryMuzzleMag
 							{
@@ -8328,7 +8876,7 @@ class items
 						};
 						class uniform
 						{
-							typeName="cnto_flecktarn_u_mediterranean";
+							typeName="cnto_flecktarn_u_grassland";
 							isBackpack=0;
 							class MagazineCargo
 							{
@@ -8377,7 +8925,7 @@ class items
 						};
 						class vest
 						{
-							typeName="cnto_flecktarn_v_mediterranean";
+							typeName="cnto_flecktarn_v_l_grassland";
 							isBackpack=0;
 							class MagazineCargo
 							{
@@ -8413,7 +8961,7 @@ class items
 						};
 						class backpack
 						{
-							typeName="cnto_flecktarn_b_ap_mediterranean";
+							typeName="cnto_flecktarn_b_ap_grassland";
 							isBackpack=1;
 							class MagazineCargo
 							{
@@ -8429,10 +8977,10 @@ class items
 						map="ItemMap";
 						compass="ItemCompass";
 						watch="ItemWatch";
-						headgear="cnto_flecktarn_h_s_mediterranean";
+						headgear="cnto_flecktarn_h_c_grassland";
 					};
 				};
-				id=35;
+				id=37;
 				type="I_Soldier_AR_F";
 				class CustomAttributes
 				{
@@ -8476,6 +9024,25 @@ class items
 					};
 					class Attribute2
 					{
+						property="lambs_danger_disableAI";
+						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"BOOL"
+									};
+								};
+								value=1;
+							};
+						};
+					};
+					class Attribute3
+					{
 						property="a3ee_acre_chlist";
 						expression="_this setVariable [""a3ee_acre_chlist"",_value,true]";
 						class Value
@@ -8510,7 +9077,7 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					nAttributes=4;
 				};
 			};
 			class Item8
@@ -8518,7 +9085,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={6.65625,0.0014390945,0.89941406};
+					position[]={6.576416,0.0014390945,1.1606445};
 				};
 				side="Independent";
 				flags=5;
@@ -8556,7 +9123,7 @@ class items
 						};
 						class uniform
 						{
-							typeName="cnto_flecktarn_u_mediterranean";
+							typeName="cnto_flecktarn_u_r_grassland";
 							isBackpack=0;
 							class MagazineCargo
 							{
@@ -8615,7 +9182,7 @@ class items
 						};
 						class vest
 						{
-							typeName="cnto_flecktarn_v_mediterranean";
+							typeName="cnto_flecktarn_v_grassland";
 							isBackpack=0;
 							class MagazineCargo
 							{
@@ -8657,7 +9224,7 @@ class items
 						};
 						class backpack
 						{
-							typeName="cnto_flecktarn_b_kb_mediterranean";
+							typeName="cnto_flecktarn_b_kb_grassland";
 							isBackpack=1;
 							class MagazineCargo
 							{
@@ -8713,10 +9280,10 @@ class items
 						compass="ItemCompass";
 						watch="ItemWatch";
 						gps="ItemGPS";
-						headgear="cnto_flecktarn_h_s_mediterranean";
+						headgear="cnto_flecktarn_h_c_grassland";
 					};
 				};
-				id=36;
+				id=38;
 				type="I_Soldier_AAR_F";
 				class CustomAttributes
 				{
@@ -8760,6 +9327,25 @@ class items
 					};
 					class Attribute2
 					{
+						property="lambs_danger_disableAI";
+						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"BOOL"
+									};
+								};
+								value=1;
+							};
+						};
+					};
+					class Attribute3
+					{
 						property="a3ee_acre_chlist";
 						expression="_this setVariable [""a3ee_acre_chlist"",_value,true]";
 						class Value
@@ -8794,7 +9380,7 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					nAttributes=4;
 				};
 			};
 			class Item9
@@ -8802,7 +9388,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={7.65625,0.0014390945,0.89941406};
+					position[]={7.576416,0.0014390945,1.1606445};
 				};
 				side="Independent";
 				flags=5;
@@ -8815,7 +9401,7 @@ class items
 					{
 						class primaryWeapon
 						{
-							name="rhs_weap_hk416d145";
+							name="rhs_weap_hk416d10";
 							underBarrel="rhsusf_acc_grip2";
 							class primaryMuzzleMag
 							{
@@ -8839,7 +9425,7 @@ class items
 						};
 						class uniform
 						{
-							typeName="cnto_flecktarn_u_mediterranean";
+							typeName="cnto_flecktarn_u_grassland";
 							isBackpack=0;
 							class MagazineCargo
 							{
@@ -8888,7 +9474,7 @@ class items
 						};
 						class vest
 						{
-							typeName="cnto_flecktarn_v_mediterranean";
+							typeName="cnto_flecktarn_v_l_grassland";
 							isBackpack=0;
 							class MagazineCargo
 							{
@@ -8931,10 +9517,10 @@ class items
 						map="ItemMap";
 						compass="ItemCompass";
 						watch="ItemWatch";
-						headgear="cnto_flecktarn_h_s_mediterranean";
+						headgear="cnto_flecktarn_h_c_grassland";
 					};
 				};
-				id=37;
+				id=39;
 				type="I_Soldier_LAT_F";
 				class CustomAttributes
 				{
@@ -8978,6 +9564,25 @@ class items
 					};
 					class Attribute2
 					{
+						property="lambs_danger_disableAI";
+						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"BOOL"
+									};
+								};
+								value=1;
+							};
+						};
+					};
+					class Attribute3
+					{
 						property="a3ee_acre_chlist";
 						expression="_this setVariable [""a3ee_acre_chlist"",_value,true]";
 						class Value
@@ -9012,14 +9617,14 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					nAttributes=4;
 				};
 			};
 		};
 		class Attributes
 		{
 		};
-		id=27;
+		id=29;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -9041,26 +9646,7 @@ class items
 					};
 				};
 			};
-			class Attribute1
-			{
-				property="groupID";
-				expression="[_this, _value] call CBA_fnc_setCallsign";
-				class Value
-				{
-					class data
-					{
-						class type
-						{
-							type[]=
-							{
-								"STRING"
-							};
-						};
-						value="CHARLIE";
-					};
-				};
-			};
-			nAttributes=2;
+			nAttributes=1;
 		};
 	};
 	class Item4
@@ -9075,7 +9661,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-6.3417969,0.0014390945,-1.762207};
+					position[]={-6.4216309,0.0014390945,-1.5014648};
 				};
 				side="Independent";
 				flags=7;
@@ -9118,7 +9704,7 @@ class items
 						};
 						class uniform
 						{
-							typeName="cnto_flecktarn_u_mediterranean";
+							typeName="cnto_flecktarn_u_r_grassland";
 							isBackpack=0;
 							class MagazineCargo
 							{
@@ -9182,7 +9768,7 @@ class items
 						};
 						class vest
 						{
-							typeName="cnto_flecktarn_v_mediterranean";
+							typeName="cnto_flecktarn_v_grassland";
 							isBackpack=0;
 							class MagazineCargo
 							{
@@ -9230,7 +9816,7 @@ class items
 						};
 						class backpack
 						{
-							typeName="cnto_flecktarn_b_ap_mediterranean";
+							typeName="cnto_flecktarn_b_ap_grassland";
 							isBackpack=1;
 							class MagazineCargo
 							{
@@ -9292,14 +9878,33 @@ class items
 						compass="ItemCompass";
 						watch="ItemWatch";
 						gps="ItemGPS";
-						headgear="cnto_flecktarn_h_s_mediterranean";
+						headgear="cnto_flecktarn_h_s_grassland";
 					};
 				};
-				id=39;
+				id=41;
 				type="I_Soldier_TL_F";
 				class CustomAttributes
 				{
 					class Attribute0
+					{
+						property="lambs_danger_disableAI";
+						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"BOOL"
+									};
+								};
+								value=1;
+							};
+						};
+					};
+					class Attribute1
 					{
 						property="a3ee_extgear_insignia";
 						expression="[_this, _value] call a3ee_extended_gear_fnc_insignia";
@@ -9318,7 +9923,7 @@ class items
 							};
 						};
 					};
-					nAttributes=1;
+					nAttributes=2;
 				};
 			};
 			class Item1
@@ -9326,7 +9931,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-5.3417969,0.0014390945,-1.7636719};
+					position[]={-5.4216309,0.0014390945,-1.5024414};
 				};
 				side="Independent";
 				flags=5;
@@ -9358,7 +9963,7 @@ class items
 						};
 						class uniform
 						{
-							typeName="cnto_flecktarn_u_mediterranean";
+							typeName="cnto_flecktarn_u_grassland";
 							isBackpack=0;
 							class MagazineCargo
 							{
@@ -9407,7 +10012,7 @@ class items
 						};
 						class vest
 						{
-							typeName="cnto_flecktarn_v_mediterranean";
+							typeName="cnto_flecktarn_v_l_grassland";
 							isBackpack=0;
 							class MagazineCargo
 							{
@@ -9437,7 +10042,7 @@ class items
 						};
 						class backpack
 						{
-							typeName="cnto_flecktarn_b_kb_mediterranean";
+							typeName="cnto_flecktarn_b_kb_grassland";
 							isBackpack=1;
 							class MagazineCargo
 							{
@@ -9453,14 +10058,33 @@ class items
 						map="ItemMap";
 						compass="ItemCompass";
 						watch="ItemWatch";
-						headgear="cnto_flecktarn_h_s_mediterranean";
+						headgear="cnto_flecktarn_h_c_grassland";
 					};
 				};
-				id=40;
+				id=42;
 				type="I_Soldier_AR_F";
 				class CustomAttributes
 				{
 					class Attribute0
+					{
+						property="lambs_danger_disableAI";
+						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"BOOL"
+									};
+								};
+								value=1;
+							};
+						};
+					};
+					class Attribute1
 					{
 						property="a3ee_extgear_insignia";
 						expression="[_this, _value] call a3ee_extended_gear_fnc_insignia";
@@ -9479,7 +10103,7 @@ class items
 							};
 						};
 					};
-					nAttributes=1;
+					nAttributes=2;
 				};
 			};
 			class Item2
@@ -9487,7 +10111,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-4.3417969,0.0014390945,-1.7636719};
+					position[]={-4.4216309,0.0014390945,-1.5024414};
 				};
 				side="Independent";
 				flags=5;
@@ -9520,7 +10144,7 @@ class items
 						};
 						class uniform
 						{
-							typeName="cnto_flecktarn_u_mediterranean";
+							typeName="cnto_flecktarn_u_grassland";
 							isBackpack=0;
 							class MagazineCargo
 							{
@@ -9569,7 +10193,7 @@ class items
 						};
 						class vest
 						{
-							typeName="cnto_flecktarn_v_mediterranean";
+							typeName="cnto_flecktarn_v_l_grassland";
 							isBackpack=0;
 							class MagazineCargo
 							{
@@ -9611,7 +10235,7 @@ class items
 						};
 						class backpack
 						{
-							typeName="cnto_flecktarn_b_kb_mediterranean";
+							typeName="cnto_flecktarn_b_kb_grassland";
 							isBackpack=1;
 							class MagazineCargo
 							{
@@ -9627,14 +10251,33 @@ class items
 						map="ItemMap";
 						compass="ItemCompass";
 						watch="ItemWatch";
-						headgear="cnto_flecktarn_h_s_mediterranean";
+						headgear="cnto_flecktarn_h_c_grassland";
 					};
 				};
-				id=41;
+				id=43;
 				type="I_Soldier_AAR_F";
 				class CustomAttributes
 				{
 					class Attribute0
+					{
+						property="lambs_danger_disableAI";
+						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"BOOL"
+									};
+								};
+								value=1;
+							};
+						};
+					};
+					class Attribute1
 					{
 						property="a3ee_extgear_insignia";
 						expression="[_this, _value] call a3ee_extended_gear_fnc_insignia";
@@ -9653,14 +10296,14 @@ class items
 							};
 						};
 					};
-					nAttributes=1;
+					nAttributes=2;
 				};
 			};
 		};
 		class Attributes
 		{
 		};
-		id=38;
+		id=40;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -9682,26 +10325,7 @@ class items
 					};
 				};
 			};
-			class Attribute1
-			{
-				property="groupID";
-				expression="[_this, _value] call CBA_fnc_setCallsign";
-				class Value
-				{
-					class data
-					{
-						class type
-						{
-							type[]=
-							{
-								"STRING"
-							};
-						};
-						value="MMG";
-					};
-				};
-			};
-			nAttributes=2;
+			nAttributes=1;
 		};
 	};
 	class Item5
@@ -9716,7 +10340,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-0.098632813,0.0014390945,-1.7971191};
+					position[]={-0.1784668,0.0014390945,-1.5366211};
 				};
 				side="Independent";
 				flags=7;
@@ -9759,7 +10383,7 @@ class items
 						};
 						class uniform
 						{
-							typeName="cnto_flecktarn_u_mediterranean";
+							typeName="cnto_flecktarn_u_r_grassland";
 							isBackpack=0;
 							class MagazineCargo
 							{
@@ -9823,7 +10447,7 @@ class items
 						};
 						class vest
 						{
-							typeName="cnto_flecktarn_v_mediterranean";
+							typeName="cnto_flecktarn_v_grassland";
 							isBackpack=0;
 							class MagazineCargo
 							{
@@ -9871,7 +10495,7 @@ class items
 						};
 						class backpack
 						{
-							typeName="cnto_flecktarn_b_ap_mediterranean";
+							typeName="cnto_flecktarn_b_ap_grassland";
 							isBackpack=1;
 							class MagazineCargo
 							{
@@ -9933,14 +10557,33 @@ class items
 						compass="ItemCompass";
 						watch="ItemWatch";
 						gps="ItemGPS";
-						headgear="cnto_flecktarn_h_s_mediterranean";
+						headgear="cnto_flecktarn_h_s_grassland";
 					};
 				};
-				id=43;
+				id=45;
 				type="I_Soldier_TL_F";
 				class CustomAttributes
 				{
 					class Attribute0
+					{
+						property="lambs_danger_disableAI";
+						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"BOOL"
+									};
+								};
+								value=1;
+							};
+						};
+					};
+					class Attribute1
 					{
 						property="a3ee_extgear_insignia";
 						expression="[_this, _value] call a3ee_extended_gear_fnc_insignia";
@@ -9959,7 +10602,7 @@ class items
 							};
 						};
 					};
-					nAttributes=1;
+					nAttributes=2;
 				};
 			};
 			class Item1
@@ -9967,7 +10610,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={0.89990234,0.0014390945,-1.7958984};
+					position[]={0.82006836,0.0014390945,-1.534668};
 				};
 				side="Independent";
 				flags=5;
@@ -9980,7 +10623,7 @@ class items
 					{
 						class primaryWeapon
 						{
-							name="rhs_weap_hk416d145";
+							name="rhs_weap_hk416d10";
 							underBarrel="rhsusf_acc_grip2";
 							class primaryMuzzleMag
 							{
@@ -10009,7 +10652,7 @@ class items
 						};
 						class uniform
 						{
-							typeName="cnto_flecktarn_u_mediterranean";
+							typeName="cnto_flecktarn_u_grassland";
 							isBackpack=0;
 							class MagazineCargo
 							{
@@ -10058,34 +10701,34 @@ class items
 						};
 						class vest
 						{
-							typeName="cnto_flecktarn_v_mediterranean";
+							typeName="cnto_flecktarn_v_l_grassland";
 							isBackpack=0;
 							class MagazineCargo
 							{
 								items=4;
 								class Item0
 								{
-									name="rhs_mag_30Rnd_556x45_M855A1_Stanag";
-									count=8;
-									ammoLeft=30;
-								};
-								class Item1
-								{
-									name="rhs_mag_30Rnd_556x45_M855A1_Stanag_Tracer_Red";
-									count=2;
-									ammoLeft=30;
-								};
-								class Item2
-								{
 									name="hlc_12Rnd_357SIG_B_P226";
 									count=1;
 									ammoLeft=12;
 								};
-								class Item3
+								class Item1
 								{
 									name="HandGrenade";
 									count=2;
 									ammoLeft=1;
+								};
+								class Item2
+								{
+									name="rhs_mag_30Rnd_556x45_M855A1_Stanag";
+									count=8;
+									ammoLeft=30;
+								};
+								class Item3
+								{
+									name="rhs_mag_30Rnd_556x45_M855A1_Stanag_Tracer_Red";
+									count=2;
+									ammoLeft=30;
 								};
 							};
 							class ItemCargo
@@ -10100,7 +10743,7 @@ class items
 						};
 						class backpack
 						{
-							typeName="cnto_flecktarn_b_ap_mediterranean";
+							typeName="cnto_flecktarn_b_ap_grassland";
 							isBackpack=1;
 							class MagazineCargo
 							{
@@ -10122,14 +10765,33 @@ class items
 						map="ItemMap";
 						compass="ItemCompass";
 						watch="ItemWatch";
-						headgear="cnto_flecktarn_h_s_mediterranean";
+						headgear="cnto_flecktarn_h_c_grassland";
 					};
 				};
-				id=44;
+				id=46;
 				type="I_Soldier_AT_F";
 				class CustomAttributes
 				{
 					class Attribute0
+					{
+						property="lambs_danger_disableAI";
+						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"BOOL"
+									};
+								};
+								value=1;
+							};
+						};
+					};
+					class Attribute1
 					{
 						property="a3ee_extgear_insignia";
 						expression="[_this, _value] call a3ee_extended_gear_fnc_insignia";
@@ -10148,7 +10810,7 @@ class items
 							};
 						};
 					};
-					nAttributes=1;
+					nAttributes=2;
 				};
 			};
 			class Item2
@@ -10156,7 +10818,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={1.8999023,0.0014390945,-1.7958984};
+					position[]={1.8200684,0.0014390945,-1.534668};
 				};
 				side="Independent";
 				flags=5;
@@ -10189,7 +10851,7 @@ class items
 						};
 						class uniform
 						{
-							typeName="cnto_flecktarn_u_mediterranean";
+							typeName="cnto_flecktarn_u_grassland";
 							isBackpack=0;
 							class MagazineCargo
 							{
@@ -10238,7 +10900,7 @@ class items
 						};
 						class vest
 						{
-							typeName="cnto_flecktarn_v_mediterranean";
+							typeName="cnto_flecktarn_v_l_grassland";
 							isBackpack=0;
 							class MagazineCargo
 							{
@@ -10280,7 +10942,7 @@ class items
 						};
 						class backpack
 						{
-							typeName="cnto_flecktarn_b_ap_mediterranean";
+							typeName="cnto_flecktarn_b_ap_grassland";
 							isBackpack=1;
 							class MagazineCargo
 							{
@@ -10302,14 +10964,33 @@ class items
 						map="ItemMap";
 						compass="ItemCompass";
 						watch="ItemWatch";
-						headgear="cnto_flecktarn_h_s_mediterranean";
+						headgear="cnto_flecktarn_h_c_grassland";
 					};
 				};
-				id=45;
+				id=47;
 				type="I_Soldier_AAT_F";
 				class CustomAttributes
 				{
 					class Attribute0
+					{
+						property="lambs_danger_disableAI";
+						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"BOOL"
+									};
+								};
+								value=1;
+							};
+						};
+					};
+					class Attribute1
 					{
 						property="a3ee_extgear_insignia";
 						expression="[_this, _value] call a3ee_extended_gear_fnc_insignia";
@@ -10328,14 +11009,14 @@ class items
 							};
 						};
 					};
-					nAttributes=1;
+					nAttributes=2;
 				};
 			};
 		};
 		class Attributes
 		{
 		};
-		id=42;
+		id=44;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -10357,26 +11038,7 @@ class items
 					};
 				};
 			};
-			class Attribute1
-			{
-				property="groupID";
-				expression="[_this, _value] call CBA_fnc_setCallsign";
-				class Value
-				{
-					class data
-					{
-						class type
-						{
-							type[]=
-							{
-								"STRING"
-							};
-						};
-						value="MAT";
-					};
-				};
-			};
-			nAttributes=2;
+			nAttributes=1;
 		};
 	};
 	class Item6
@@ -10391,7 +11053,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-6.6025391,0.0014390945,-4.4311523};
+					position[]={-6.682373,0.0014390945,-4.1704102};
 				};
 				side="Independent";
 				flags=7;
@@ -10435,7 +11097,7 @@ class items
 						};
 						class uniform
 						{
-							typeName="cnto_flecktarn_u_t_mediterranean";
+							typeName="cnto_flecktarn_u_t_grassland";
 							isBackpack=0;
 							class MagazineCargo
 							{
@@ -10499,7 +11161,7 @@ class items
 						};
 						class vest
 						{
-							typeName="cnto_flecktarn_v_mediterranean";
+							typeName="cnto_flecktarn_v_l_grassland";
 							isBackpack=0;
 							class MagazineCargo
 							{
@@ -10576,14 +11238,33 @@ class items
 						compass="ItemCompass";
 						watch="ItemWatch";
 						gps="ItemGPS";
-						headgear="cnto_flecktarn_h_boo_mediterranean";
+						headgear="cnto_flecktarn_h_boo_grassland";
 					};
 				};
-				id=47;
+				id=49;
 				type="I_Spotter_F";
 				class CustomAttributes
 				{
 					class Attribute0
+					{
+						property="lambs_danger_disableAI";
+						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"BOOL"
+									};
+								};
+								value=1;
+							};
+						};
+					};
+					class Attribute1
 					{
 						property="a3ee_extgear_insignia";
 						expression="[_this, _value] call a3ee_extended_gear_fnc_insignia";
@@ -10602,7 +11283,7 @@ class items
 							};
 						};
 					};
-					nAttributes=1;
+					nAttributes=2;
 				};
 			};
 			class Item1
@@ -10610,7 +11291,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-5.6030273,0.0014390945,-4.4326172};
+					position[]={-5.6828613,0.0014390945,-4.1713867};
 				};
 				side="Independent";
 				flags=5;
@@ -10652,7 +11333,7 @@ class items
 						};
 						class uniform
 						{
-							typeName="cnto_flecktarn_u_t_mediterranean";
+							typeName="cnto_flecktarn_u_t_grassland";
 							isBackpack=0;
 							class MagazineCargo
 							{
@@ -10726,7 +11407,7 @@ class items
 						};
 						class vest
 						{
-							typeName="cnto_flecktarn_v_mediterranean";
+							typeName="cnto_flecktarn_v_l_grassland";
 							isBackpack=0;
 							class MagazineCargo
 							{
@@ -10746,7 +11427,7 @@ class items
 							};
 							class ItemCargo
 							{
-								items=2;
+								items=3;
 								class Item0
 								{
 									name="ACE_IR_Strobe_Item";
@@ -10757,20 +11438,44 @@ class items
 									name="ACE_tourniquet";
 									count=1;
 								};
+								class Item2
+								{
+									name="rhsusf_acc_anpvs27";
+									count=1;
+								};
 							};
 						};
 						map="ItemMap";
 						compass="ItemCompass";
 						watch="ItemWatch";
 						gps="ItemGPS";
-						headgear="cnto_flecktarn_h_boo_mediterranean";
+						headgear="cnto_flecktarn_h_boo_grassland";
 					};
 				};
-				id=48;
+				id=50;
 				type="I_Spotter_F";
 				class CustomAttributes
 				{
 					class Attribute0
+					{
+						property="lambs_danger_disableAI";
+						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"BOOL"
+									};
+								};
+								value=1;
+							};
+						};
+					};
+					class Attribute1
 					{
 						property="a3ee_extgear_insignia";
 						expression="[_this, _value] call a3ee_extended_gear_fnc_insignia";
@@ -10789,14 +11494,14 @@ class items
 							};
 						};
 					};
-					nAttributes=1;
+					nAttributes=2;
 				};
 			};
 		};
 		class Attributes
 		{
 		};
-		id=46;
+		id=48;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -10818,26 +11523,7 @@ class items
 					};
 				};
 			};
-			class Attribute1
-			{
-				property="groupID";
-				expression="[_this, _value] call CBA_fnc_setCallsign";
-				class Value
-				{
-					class data
-					{
-						class type
-						{
-							type[]=
-							{
-								"STRING"
-							};
-						};
-						value="DMT";
-					};
-				};
-			};
-			nAttributes=2;
+			nAttributes=1;
 		};
 	};
 	class Item7
@@ -10852,7 +11538,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-0.47167969,0.0014390945,-4.4926758};
+					position[]={-0.55151367,0.0014390945,-4.2319336};
 				};
 				side="Independent";
 				flags=7;
@@ -10866,7 +11552,7 @@ class items
 					{
 						class primaryWeapon
 						{
-							name="rhs_weap_hk416d145";
+							name="rhs_weap_hk416d10";
 							flashlight="rhsusf_acc_anpeq16a";
 							underBarrel="rhsusf_acc_grip2";
 							class primaryMuzzleMag
@@ -10891,7 +11577,7 @@ class items
 						};
 						class uniform
 						{
-							typeName="cnto_flecktarn_u_mediterranean";
+							typeName="cnto_flecktarn_u_r_grassland";
 							isBackpack=0;
 							class MagazineCargo
 							{
@@ -10955,15 +11641,15 @@ class items
 						};
 						class vest
 						{
-							typeName="cnto_flecktarn_v_mediterranean";
+							typeName="cnto_flecktarn_v_s_grassland";
 							isBackpack=0;
 							class MagazineCargo
 							{
-								items=7;
+								items=5;
 								class Item0
 								{
 									name="SmokeShell";
-									count=2;
+									count=4;
 									ammoLeft=1;
 								};
 								class Item1
@@ -10980,27 +11666,15 @@ class items
 								};
 								class Item3
 								{
-									name="rhs_mag_30Rnd_556x45_M855A1_Stanag";
-									count=8;
-									ammoLeft=30;
+									name="HandGrenade";
+									count=2;
+									ammoLeft=1;
 								};
 								class Item4
 								{
-									name="rhs_mag_30Rnd_556x45_M855A1_Stanag_Tracer_Red";
-									count=2;
+									name="rhs_mag_30Rnd_556x45_M855A1_Stanag";
+									count=4;
 									ammoLeft=30;
-								};
-								class Item5
-								{
-									name="hlc_12Rnd_357SIG_B_P226";
-									count=1;
-									ammoLeft=12;
-								};
-								class Item6
-								{
-									name="HandGrenade";
-									count=1;
-									ammoLeft=1;
 								};
 							};
 							class ItemCargo
@@ -11022,14 +11696,33 @@ class items
 						compass="ItemCompass";
 						watch="ItemWatch";
 						gps="ItemGPS";
-						headgear="cnto_flecktarn_h_s_mediterranean";
+						headgear="cnto_flecktarn_h_s_grassland";
 					};
 				};
-				id=50;
+				id=52;
 				type="I_support_AMort_F";
 				class CustomAttributes
 				{
 					class Attribute0
+					{
+						property="lambs_danger_disableAI";
+						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"BOOL"
+									};
+								};
+								value=1;
+							};
+						};
+					};
+					class Attribute1
 					{
 						property="a3ee_extgear_insignia";
 						expression="[_this, _value] call a3ee_extended_gear_fnc_insignia";
@@ -11048,7 +11741,7 @@ class items
 							};
 						};
 					};
-					nAttributes=1;
+					nAttributes=2;
 				};
 			};
 			class Item1
@@ -11056,7 +11749,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={0.52929688,0.0014390945,-4.4926758};
+					position[]={0.44946289,0.0014390945,-4.2319336};
 				};
 				side="Independent";
 				flags=5;
@@ -11069,7 +11762,7 @@ class items
 					{
 						class primaryWeapon
 						{
-							name="rhs_weap_hk416d145";
+							name="rhs_weap_hk416d10";
 							underBarrel="rhsusf_acc_grip2";
 							class primaryMuzzleMag
 							{
@@ -11089,7 +11782,7 @@ class items
 						};
 						class uniform
 						{
-							typeName="cnto_flecktarn_u_mediterranean";
+							typeName="cnto_flecktarn_u_grassland";
 							isBackpack=0;
 							class MagazineCargo
 							{
@@ -11148,30 +11841,24 @@ class items
 						};
 						class vest
 						{
-							typeName="cnto_flecktarn_v_mediterranean";
+							typeName="cnto_flecktarn_v_s_grassland";
 							isBackpack=0;
 							class MagazineCargo
 							{
-								items=4;
+								items=3;
 								class Item0
 								{
 									name="rhs_mag_30Rnd_556x45_M855A1_Stanag";
-									count=8;
+									count=4;
 									ammoLeft=30;
 								};
 								class Item1
 								{
-									name="rhs_mag_30Rnd_556x45_M855A1_Stanag_Tracer_Red";
-									count=2;
-									ammoLeft=30;
+									name="SmokeShell";
+									count=4;
+									ammoLeft=1;
 								};
 								class Item2
-								{
-									name="hlc_12Rnd_357SIG_B_P226";
-									count=1;
-									ammoLeft=12;
-								};
-								class Item3
 								{
 									name="HandGrenade";
 									count=2;
@@ -11196,14 +11883,33 @@ class items
 						map="ItemMap";
 						compass="ItemCompass";
 						watch="ItemWatch";
-						headgear="cnto_flecktarn_h_s_mediterranean";
+						headgear="cnto_flecktarn_h_c_grassland";
 					};
 				};
-				id=51;
+				id=53;
 				type="I_support_Mort_F";
 				class CustomAttributes
 				{
 					class Attribute0
+					{
+						property="lambs_danger_disableAI";
+						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"BOOL"
+									};
+								};
+								value=1;
+							};
+						};
+					};
+					class Attribute1
 					{
 						property="a3ee_extgear_insignia";
 						expression="[_this, _value] call a3ee_extended_gear_fnc_insignia";
@@ -11222,14 +11928,14 @@ class items
 							};
 						};
 					};
-					nAttributes=1;
+					nAttributes=2;
 				};
 			};
 		};
 		class Attributes
 		{
 		};
-		id=49;
+		id=51;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -11251,26 +11957,7 @@ class items
 					};
 				};
 			};
-			class Attribute1
-			{
-				property="groupID";
-				expression="[_this, _value] call CBA_fnc_setCallsign";
-				class Value
-				{
-					class data
-					{
-						class type
-						{
-							type[]=
-							{
-								"STRING"
-							};
-						};
-						value="MORTAR";
-					};
-				};
-			};
-			nAttributes=2;
+			nAttributes=1;
 		};
 	};
 	class Item8
@@ -11285,7 +11972,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={4.7963867,0.0014390945,-1.7587891};
+					position[]={4.7165527,0.0014390945,-1.4975586};
 				};
 				side="Independent";
 				flags=7;
@@ -11324,7 +12011,7 @@ class items
 						};
 						class uniform
 						{
-							typeName="cnto_flecktarn_u_mediterranean";
+							typeName="cnto_flecktarn_u_r_grassland";
 							isBackpack=0;
 							class ItemCargo
 							{
@@ -11373,7 +12060,7 @@ class items
 						};
 						class vest
 						{
-							typeName="cnto_flecktarn_v_mediterranean";
+							typeName="cnto_flecktarn_v_h_grassland";
 							isBackpack=0;
 							class MagazineCargo
 							{
@@ -11429,7 +12116,7 @@ class items
 						};
 						class backpack
 						{
-							typeName="cnto_flecktarn_b_ca_mediterranean";
+							typeName="cnto_flecktarn_b_ca_grassland";
 							isBackpack=1;
 							class ItemCargo
 							{
@@ -11445,381 +12132,7 @@ class items
 						compass="ItemCompass";
 						watch="ItemWatch";
 						gps="ItemGPS";
-						headgear="cnto_flecktarn_h_s_mediterranean";
-					};
-				};
-				id=53;
-				type="I_engineer_F";
-				class CustomAttributes
-				{
-					class Attribute0
-					{
-						property="a3ee_extgear_insignia";
-						expression="[_this, _value] call a3ee_extended_gear_fnc_insignia";
-						class Value
-						{
-							class data
-							{
-								class type
-								{
-									type[]=
-									{
-										"STRING"
-									};
-								};
-								value="CNTOpatchAlt";
-							};
-						};
-					};
-					nAttributes=1;
-				};
-			};
-			class Item1
-			{
-				dataType="Object";
-				class PositionInfo
-				{
-					position[]={5.7963867,0.0014390945,-1.7587891};
-				};
-				side="Independent";
-				flags=5;
-				class Attributes
-				{
-					init="call{this disableAI ""MOVE"";" \n "this setSpeaker ""NoVoice"";" \n "enableRadio false;}";
-					description="Engineer Rifleman";
-					isPlayable=1;
-					class Inventory
-					{
-						class primaryWeapon
-						{
-							name="rhs_weap_hk416d145";
-							underBarrel="rhsusf_acc_grip2";
-							class primaryMuzzleMag
-							{
-								name="rhs_mag_30Rnd_556x45_M855A1_Stanag";
-								ammoLeft=30;
-							};
-						};
-						class handgun
-						{
-							name="hlc_pistol_P226R_357Elite";
-							optics="HLC_optic_VTAC";
-							class primaryMuzzleMag
-							{
-								name="hlc_12Rnd_357SIG_B_P226";
-								ammoLeft=12;
-							};
-						};
-						class binocular
-						{
-							name="ACE_VectorDay";
-						};
-						class uniform
-						{
-							typeName="cnto_flecktarn_u_mediterranean";
-							isBackpack=0;
-							class ItemCargo
-							{
-								items=7;
-								class Item0
-								{
-									name="ACE_fieldDressing";
-									count=4;
-								};
-								class Item1
-								{
-									name="ACE_quikclot";
-									count=6;
-								};
-								class Item2
-								{
-									name="ACE_morphine";
-									count=1;
-								};
-								class Item3
-								{
-									name="ACE_tourniquet";
-									count=1;
-								};
-								class Item4
-								{
-									name="rhsusf_acc_M952V";
-									count=1;
-								};
-								class Item5
-								{
-									name="ACE_MapTools";
-									count=1;
-								};
-								class Item6
-								{
-									name="ACRE_PRC343";
-									count=1;
-								};
-							};
-						};
-						class vest
-						{
-							typeName="cnto_flecktarn_v_mediterranean";
-							isBackpack=0;
-							class MagazineCargo
-							{
-								items=3;
-								class Item0
-								{
-									name="SmokeShell";
-									count=4;
-									ammoLeft=1;
-								};
-								class Item1
-								{
-									name="rhs_mag_30Rnd_556x45_M855A1_Stanag";
-									count=4;
-									ammoLeft=30;
-								};
-								class Item2
-								{
-									name="HandGrenade";
-									count=2;
-									ammoLeft=1;
-								};
-							};
-							class ItemCargo
-							{
-								items=5;
-								class Item0
-								{
-									name="ACE_M26_Clacker";
-									count=1;
-								};
-								class Item1
-								{
-									name="ACE_DefusalKit";
-									count=1;
-								};
-								class Item2
-								{
-									name="ACE_EntrenchingTool";
-									count=1;
-								};
-								class Item3
-								{
-									name="ACE_wirecutter";
-									count=1;
-								};
-								class Item4
-								{
-									name="ACE_tourniquet";
-									count=1;
-								};
-							};
-						};
-						class backpack
-						{
-							typeName="cnto_flecktarn_b_ca_mediterranean";
-							isBackpack=1;
-							class ItemCargo
-							{
-								items=1;
-								class Item0
-								{
-									name="ToolKit";
-									count=1;
-								};
-							};
-						};
-						map="ItemMap";
-						compass="ItemCompass";
-						watch="ItemWatch";
-						gps="ItemGPS";
-						headgear="cnto_flecktarn_h_s_mediterranean";
-					};
-				};
-				id=54;
-				type="I_engineer_F";
-				class CustomAttributes
-				{
-					class Attribute0
-					{
-						property="a3ee_extgear_insignia";
-						expression="[_this, _value] call a3ee_extended_gear_fnc_insignia";
-						class Value
-						{
-							class data
-							{
-								class type
-								{
-									type[]=
-									{
-										"STRING"
-									};
-								};
-								value="CNTOpatchAlt";
-							};
-						};
-					};
-					nAttributes=1;
-				};
-			};
-			class Item2
-			{
-				dataType="Object";
-				class PositionInfo
-				{
-					position[]={6.7963867,0.0014390945,-1.7587891};
-				};
-				side="Independent";
-				flags=5;
-				class Attributes
-				{
-					init="call{this disableAI ""MOVE"";" \n "this setSpeaker ""NoVoice"";" \n "enableRadio false;}";
-					description="Engineer Rifleman";
-					isPlayable=1;
-					class Inventory
-					{
-						class primaryWeapon
-						{
-							name="rhs_weap_hk416d145";
-							underBarrel="rhsusf_acc_grip2";
-							class primaryMuzzleMag
-							{
-								name="rhs_mag_30Rnd_556x45_M855A1_Stanag";
-								ammoLeft=30;
-							};
-						};
-						class handgun
-						{
-							name="hlc_pistol_P226R_357Elite";
-							optics="HLC_optic_VTAC";
-							class primaryMuzzleMag
-							{
-								name="hlc_12Rnd_357SIG_B_P226";
-								ammoLeft=12;
-							};
-						};
-						class binocular
-						{
-							name="ACE_VectorDay";
-						};
-						class uniform
-						{
-							typeName="cnto_flecktarn_u_mediterranean";
-							isBackpack=0;
-							class ItemCargo
-							{
-								items=7;
-								class Item0
-								{
-									name="ACE_fieldDressing";
-									count=4;
-								};
-								class Item1
-								{
-									name="ACE_quikclot";
-									count=6;
-								};
-								class Item2
-								{
-									name="ACE_morphine";
-									count=1;
-								};
-								class Item3
-								{
-									name="ACE_tourniquet";
-									count=1;
-								};
-								class Item4
-								{
-									name="rhsusf_acc_M952V";
-									count=1;
-								};
-								class Item5
-								{
-									name="ACE_MapTools";
-									count=1;
-								};
-								class Item6
-								{
-									name="ACRE_PRC343";
-									count=1;
-								};
-							};
-						};
-						class vest
-						{
-							typeName="cnto_flecktarn_v_mediterranean";
-							isBackpack=0;
-							class MagazineCargo
-							{
-								items=3;
-								class Item0
-								{
-									name="SmokeShell";
-									count=4;
-									ammoLeft=1;
-								};
-								class Item1
-								{
-									name="rhs_mag_30Rnd_556x45_M855A1_Stanag";
-									count=4;
-									ammoLeft=30;
-								};
-								class Item2
-								{
-									name="HandGrenade";
-									count=2;
-									ammoLeft=1;
-								};
-							};
-							class ItemCargo
-							{
-								items=5;
-								class Item0
-								{
-									name="ACE_M26_Clacker";
-									count=1;
-								};
-								class Item1
-								{
-									name="ACE_DefusalKit";
-									count=1;
-								};
-								class Item2
-								{
-									name="ACE_EntrenchingTool";
-									count=1;
-								};
-								class Item3
-								{
-									name="ACE_wirecutter";
-									count=1;
-								};
-								class Item4
-								{
-									name="ACE_tourniquet";
-									count=1;
-								};
-							};
-						};
-						class backpack
-						{
-							typeName="cnto_flecktarn_b_ca_mediterranean";
-							isBackpack=1;
-							class ItemCargo
-							{
-								items=1;
-								class Item0
-								{
-									name="ToolKit";
-									count=1;
-								};
-							};
-						};
-						map="ItemMap";
-						compass="ItemCompass";
-						watch="ItemWatch";
-						gps="ItemGPS";
-						headgear="cnto_flecktarn_h_s_mediterranean";
+						headgear="cnto_flecktarn_h_s_grassland";
 					};
 				};
 				id=55;
@@ -11828,6 +12141,25 @@ class items
 				{
 					class Attribute0
 					{
+						property="lambs_danger_disableAI";
+						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"BOOL"
+									};
+								};
+								value=1;
+							};
+						};
+					};
+					class Attribute1
+					{
 						property="a3ee_extgear_insignia";
 						expression="[_this, _value] call a3ee_extended_gear_fnc_insignia";
 						class Value
@@ -11845,15 +12177,15 @@ class items
 							};
 						};
 					};
-					nAttributes=1;
+					nAttributes=2;
 				};
 			};
-			class Item3
+			class Item1
 			{
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={7.7963867,0.0014390945,-1.7587891};
+					position[]={5.7165527,0.0014390945,-1.4975586};
 				};
 				side="Independent";
 				flags=5;
@@ -11890,7 +12222,7 @@ class items
 						};
 						class uniform
 						{
-							typeName="cnto_flecktarn_u_mediterranean";
+							typeName="cnto_flecktarn_u_grassland";
 							isBackpack=0;
 							class ItemCargo
 							{
@@ -11934,7 +12266,7 @@ class items
 						};
 						class vest
 						{
-							typeName="cnto_flecktarn_v_mediterranean";
+							typeName="cnto_flecktarn_v_h_grassland";
 							isBackpack=0;
 							class MagazineCargo
 							{
@@ -11990,7 +12322,7 @@ class items
 						};
 						class backpack
 						{
-							typeName="cnto_flecktarn_b_ca_mediterranean";
+							typeName="cnto_flecktarn_b_ca_grassland";
 							isBackpack=1;
 							class ItemCargo
 							{
@@ -12006,7 +12338,7 @@ class items
 						compass="ItemCompass";
 						watch="ItemWatch";
 						gps="ItemGPS";
-						headgear="cnto_flecktarn_h_s_mediterranean";
+						headgear="cnto_flecktarn_h_c_grassland";
 					};
 				};
 				id=56;
@@ -12014,6 +12346,25 @@ class items
 				class CustomAttributes
 				{
 					class Attribute0
+					{
+						property="lambs_danger_disableAI";
+						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"BOOL"
+									};
+								};
+								value=1;
+							};
+						};
+					};
+					class Attribute1
 					{
 						property="a3ee_extgear_insignia";
 						expression="[_this, _value] call a3ee_extended_gear_fnc_insignia";
@@ -12032,14 +12383,426 @@ class items
 							};
 						};
 					};
-					nAttributes=1;
+					nAttributes=2;
+				};
+			};
+			class Item2
+			{
+				dataType="Object";
+				class PositionInfo
+				{
+					position[]={6.7165527,0.0014390945,-1.4975586};
+				};
+				side="Independent";
+				flags=5;
+				class Attributes
+				{
+					init="call{this disableAI ""MOVE"";" \n "this setSpeaker ""NoVoice"";" \n "enableRadio false;}";
+					description="Engineer Rifleman";
+					isPlayable=1;
+					class Inventory
+					{
+						class primaryWeapon
+						{
+							name="rhs_weap_hk416d145";
+							underBarrel="rhsusf_acc_grip2";
+							class primaryMuzzleMag
+							{
+								name="rhs_mag_30Rnd_556x45_M855A1_Stanag";
+								ammoLeft=30;
+							};
+						};
+						class handgun
+						{
+							name="hlc_pistol_P226R_357Elite";
+							optics="HLC_optic_VTAC";
+							class primaryMuzzleMag
+							{
+								name="hlc_12Rnd_357SIG_B_P226";
+								ammoLeft=12;
+							};
+						};
+						class binocular
+						{
+							name="ACE_VectorDay";
+						};
+						class uniform
+						{
+							typeName="cnto_flecktarn_u_grassland";
+							isBackpack=0;
+							class ItemCargo
+							{
+								items=7;
+								class Item0
+								{
+									name="ACE_fieldDressing";
+									count=4;
+								};
+								class Item1
+								{
+									name="ACE_quikclot";
+									count=6;
+								};
+								class Item2
+								{
+									name="ACE_morphine";
+									count=1;
+								};
+								class Item3
+								{
+									name="ACE_tourniquet";
+									count=1;
+								};
+								class Item4
+								{
+									name="rhsusf_acc_M952V";
+									count=1;
+								};
+								class Item5
+								{
+									name="ACE_MapTools";
+									count=1;
+								};
+								class Item6
+								{
+									name="ACRE_PRC343";
+									count=1;
+								};
+							};
+						};
+						class vest
+						{
+							typeName="cnto_flecktarn_v_h_grassland";
+							isBackpack=0;
+							class MagazineCargo
+							{
+								items=3;
+								class Item0
+								{
+									name="SmokeShell";
+									count=4;
+									ammoLeft=1;
+								};
+								class Item1
+								{
+									name="rhs_mag_30Rnd_556x45_M855A1_Stanag";
+									count=4;
+									ammoLeft=30;
+								};
+								class Item2
+								{
+									name="HandGrenade";
+									count=2;
+									ammoLeft=1;
+								};
+							};
+							class ItemCargo
+							{
+								items=5;
+								class Item0
+								{
+									name="ACE_M26_Clacker";
+									count=1;
+								};
+								class Item1
+								{
+									name="ACE_DefusalKit";
+									count=1;
+								};
+								class Item2
+								{
+									name="ACE_EntrenchingTool";
+									count=1;
+								};
+								class Item3
+								{
+									name="ACE_wirecutter";
+									count=1;
+								};
+								class Item4
+								{
+									name="ACE_tourniquet";
+									count=1;
+								};
+							};
+						};
+						class backpack
+						{
+							typeName="cnto_flecktarn_b_ca_grassland";
+							isBackpack=1;
+							class ItemCargo
+							{
+								items=1;
+								class Item0
+								{
+									name="ToolKit";
+									count=1;
+								};
+							};
+						};
+						map="ItemMap";
+						compass="ItemCompass";
+						watch="ItemWatch";
+						gps="ItemGPS";
+						headgear="cnto_flecktarn_h_c_grassland";
+					};
+				};
+				id=57;
+				type="I_engineer_F";
+				class CustomAttributes
+				{
+					class Attribute0
+					{
+						property="lambs_danger_disableAI";
+						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"BOOL"
+									};
+								};
+								value=1;
+							};
+						};
+					};
+					class Attribute1
+					{
+						property="a3ee_extgear_insignia";
+						expression="[_this, _value] call a3ee_extended_gear_fnc_insignia";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="CNTOpatchAlt";
+							};
+						};
+					};
+					nAttributes=2;
+				};
+			};
+			class Item3
+			{
+				dataType="Object";
+				class PositionInfo
+				{
+					position[]={7.7165527,0.0014390945,-1.4975586};
+				};
+				side="Independent";
+				flags=5;
+				class Attributes
+				{
+					init="call{this disableAI ""MOVE"";" \n "this setSpeaker ""NoVoice"";" \n "enableRadio false;}";
+					description="Engineer Rifleman";
+					isPlayable=1;
+					class Inventory
+					{
+						class primaryWeapon
+						{
+							name="rhs_weap_hk416d145";
+							underBarrel="rhsusf_acc_grip2";
+							class primaryMuzzleMag
+							{
+								name="rhs_mag_30Rnd_556x45_M855A1_Stanag";
+								ammoLeft=30;
+							};
+						};
+						class handgun
+						{
+							name="hlc_pistol_P226R_357Elite";
+							optics="HLC_optic_VTAC";
+							class primaryMuzzleMag
+							{
+								name="hlc_12Rnd_357SIG_B_P226";
+								ammoLeft=12;
+							};
+						};
+						class binocular
+						{
+							name="ACE_VectorDay";
+						};
+						class uniform
+						{
+							typeName="cnto_flecktarn_u_grassland";
+							isBackpack=0;
+							class ItemCargo
+							{
+								items=7;
+								class Item0
+								{
+									name="ACE_fieldDressing";
+									count=4;
+								};
+								class Item1
+								{
+									name="ACE_quikclot";
+									count=6;
+								};
+								class Item2
+								{
+									name="ACE_morphine";
+									count=1;
+								};
+								class Item3
+								{
+									name="ACE_tourniquet";
+									count=1;
+								};
+								class Item4
+								{
+									name="rhsusf_acc_M952V";
+									count=1;
+								};
+								class Item5
+								{
+									name="ACE_MapTools";
+									count=1;
+								};
+								class Item6
+								{
+									name="ACRE_PRC343";
+									count=1;
+								};
+							};
+						};
+						class vest
+						{
+							typeName="cnto_flecktarn_v_h_grassland";
+							isBackpack=0;
+							class MagazineCargo
+							{
+								items=3;
+								class Item0
+								{
+									name="SmokeShell";
+									count=4;
+									ammoLeft=1;
+								};
+								class Item1
+								{
+									name="rhs_mag_30Rnd_556x45_M855A1_Stanag";
+									count=4;
+									ammoLeft=30;
+								};
+								class Item2
+								{
+									name="HandGrenade";
+									count=2;
+									ammoLeft=1;
+								};
+							};
+							class ItemCargo
+							{
+								items=5;
+								class Item0
+								{
+									name="ACE_M26_Clacker";
+									count=1;
+								};
+								class Item1
+								{
+									name="ACE_DefusalKit";
+									count=1;
+								};
+								class Item2
+								{
+									name="ACE_EntrenchingTool";
+									count=1;
+								};
+								class Item3
+								{
+									name="ACE_wirecutter";
+									count=1;
+								};
+								class Item4
+								{
+									name="ACE_tourniquet";
+									count=1;
+								};
+							};
+						};
+						class backpack
+						{
+							typeName="cnto_flecktarn_b_ca_grassland";
+							isBackpack=1;
+							class ItemCargo
+							{
+								items=1;
+								class Item0
+								{
+									name="ToolKit";
+									count=1;
+								};
+							};
+						};
+						map="ItemMap";
+						compass="ItemCompass";
+						watch="ItemWatch";
+						gps="ItemGPS";
+						headgear="cnto_flecktarn_h_c_grassland";
+					};
+				};
+				id=58;
+				type="I_engineer_F";
+				class CustomAttributes
+				{
+					class Attribute0
+					{
+						property="lambs_danger_disableAI";
+						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"BOOL"
+									};
+								};
+								value=1;
+							};
+						};
+					};
+					class Attribute1
+					{
+						property="a3ee_extgear_insignia";
+						expression="[_this, _value] call a3ee_extended_gear_fnc_insignia";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="CNTOpatchAlt";
+							};
+						};
+					};
+					nAttributes=2;
 				};
 			};
 		};
 		class Attributes
 		{
 		};
-		id=52;
+		id=54;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -12061,26 +12824,7 @@ class items
 					};
 				};
 			};
-			class Attribute1
-			{
-				property="groupID";
-				expression="[_this, _value] call CBA_fnc_setCallsign";
-				class Value
-				{
-					class data
-					{
-						class type
-						{
-							type[]=
-							{
-								"STRING"
-							};
-						};
-						value="ENG";
-					};
-				};
-			};
-			nAttributes=2;
+			nAttributes=1;
 		};
 	};
 	class Item9
@@ -12095,7 +12839,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-6.871582,0.0014390945,-7.1098633};
+					position[]={-6.951416,0.0014390945,-6.8491211};
 				};
 				side="Independent";
 				flags=7;
@@ -12235,7 +12979,7 @@ class items
 						headgear="H_HelmetCrew_I";
 					};
 				};
-				id=58;
+				id=60;
 				type="I_crew_F";
 				class CustomAttributes
 				{
@@ -12259,6 +13003,25 @@ class items
 						};
 					};
 					class Attribute1
+					{
+						property="lambs_danger_disableAI";
+						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"BOOL"
+									};
+								};
+								value=1;
+							};
+						};
+					};
+					class Attribute2
 					{
 						property="a3ee_acre_chlist";
 						expression="_this setVariable [""a3ee_acre_chlist"",_value,true]";
@@ -12322,7 +13085,7 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					nAttributes=3;
 				};
 			};
 			class Item1
@@ -12330,7 +13093,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-5.871582,0.0014390945,-7.1098633};
+					position[]={-5.951416,0.0014390945,-6.8491211};
 				};
 				side="Independent";
 				flags=5;
@@ -12464,7 +13227,7 @@ class items
 						headgear="H_HelmetCrew_I";
 					};
 				};
-				id=59;
+				id=61;
 				type="I_crew_F";
 				class CustomAttributes
 				{
@@ -12506,7 +13269,26 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="lambs_danger_disableAI";
+						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"BOOL"
+									};
+								};
+								value=1;
+							};
+						};
+					};
+					nAttributes=3;
 				};
 			};
 			class Item2
@@ -12514,7 +13296,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-4.871582,0.0014390945,-7.1098633};
+					position[]={-4.951416,0.0014390945,-6.8491211};
 				};
 				side="Independent";
 				flags=5;
@@ -12634,7 +13416,7 @@ class items
 						headgear="H_HelmetCrew_I";
 					};
 				};
-				id=60;
+				id=62;
 				type="I_crew_F";
 				class CustomAttributes
 				{
@@ -12676,14 +13458,33 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="lambs_danger_disableAI";
+						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"BOOL"
+									};
+								};
+								value=1;
+							};
+						};
+					};
+					nAttributes=3;
 				};
 			};
 		};
 		class Attributes
 		{
 		};
-		id=57;
+		id=59;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -12705,26 +13506,7 @@ class items
 					};
 				};
 			};
-			class Attribute1
-			{
-				property="groupID";
-				expression="[_this, _value] call CBA_fnc_setCallsign";
-				class Value
-				{
-					class data
-					{
-						class type
-						{
-							type[]=
-							{
-								"STRING"
-							};
-						};
-						value="DAGGER";
-					};
-				};
-			};
-			nAttributes=2;
+			nAttributes=1;
 		};
 	};
 	class Item10
@@ -12739,7 +13521,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-0.59179688,0.0014390945,-7.2988281};
+					position[]={-0.67163086,0.0014390945,-7.0375977};
 				};
 				side="Independent";
 				flags=7;
@@ -12879,7 +13661,7 @@ class items
 						headgear="H_PilotHelmetHeli_B";
 					};
 				};
-				id=62;
+				id=64;
 				type="I_pilot_F";
 				class CustomAttributes
 				{
@@ -12922,6 +13704,25 @@ class items
 						};
 					};
 					class Attribute2
+					{
+						property="lambs_danger_disableAI";
+						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"BOOL"
+									};
+								};
+								value=1;
+							};
+						};
+					};
+					class Attribute3
 					{
 						property="a3ee_acre_chlist";
 						expression="_this setVariable [""a3ee_acre_chlist"",_value,true]";
@@ -12985,7 +13786,7 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					nAttributes=4;
 				};
 			};
 			class Item1
@@ -12993,7 +13794,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={0.40820313,0.0014390945,-7.2978516};
+					position[]={0.32836914,0.0014390945,-7.0366211};
 				};
 				side="Independent";
 				flags=5;
@@ -13146,7 +13947,7 @@ class items
 						headgear="H_PilotHelmetHeli_B";
 					};
 				};
-				id=63;
+				id=65;
 				type="I_pilot_F";
 				class CustomAttributes
 				{
@@ -13189,6 +13990,25 @@ class items
 						};
 					};
 					class Attribute2
+					{
+						property="lambs_danger_disableAI";
+						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"BOOL"
+									};
+								};
+								value=1;
+							};
+						};
+					};
+					class Attribute3
 					{
 						property="a3ee_acre_chlist";
 						expression="_this setVariable [""a3ee_acre_chlist"",_value,true]";
@@ -13252,14 +14072,14 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					nAttributes=4;
 				};
 			};
 		};
 		class Attributes
 		{
 		};
-		id=61;
+		id=63;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -13281,26 +14101,7 @@ class items
 					};
 				};
 			};
-			class Attribute1
-			{
-				property="groupID";
-				expression="[_this, _value] call CBA_fnc_setCallsign";
-				class Value
-				{
-					class data
-					{
-						class type
-						{
-							type[]=
-							{
-								"STRING"
-							};
-						};
-						value="NIGHTBIRD";
-					};
-				};
-			};
-			nAttributes=2;
+			nAttributes=1;
 		};
 	};
 	class Item11
@@ -13315,7 +14116,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={3.1445313,0.0014390945,-7.4272461};
+					position[]={3.0646973,0.0014390945,-7.1665039};
 				};
 				side="Independent";
 				flags=7;
@@ -13459,7 +14260,7 @@ class items
 						headgear="H_PilotHelmetFighter_I";
 					};
 				};
-				id=65;
+				id=67;
 				type="I_pilot_F";
 				class CustomAttributes
 				{
@@ -13502,6 +14303,25 @@ class items
 						};
 					};
 					class Attribute2
+					{
+						property="lambs_danger_disableAI";
+						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"BOOL"
+									};
+								};
+								value=1;
+							};
+						};
+					};
+					class Attribute3
 					{
 						property="a3ee_acre_chlist";
 						expression="_this setVariable [""a3ee_acre_chlist"",_value,true]";
@@ -13565,14 +14385,14 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					nAttributes=4;
 				};
 			};
 		};
 		class Attributes
 		{
 		};
-		id=64;
+		id=66;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -13594,26 +14414,7 @@ class items
 					};
 				};
 			};
-			class Attribute1
-			{
-				property="groupID";
-				expression="[_this, _value] call CBA_fnc_setCallsign";
-				class Value
-				{
-					class data
-					{
-						class type
-						{
-							type[]=
-							{
-								"STRING"
-							};
-						};
-						value="FALCON";
-					};
-				};
-			};
-			nAttributes=2;
+			nAttributes=1;
 		};
 	};
 	class Item12
@@ -13621,7 +14422,7 @@ class items
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={7.2758789,0.28405476,-5.8486328};
+			position[]={7.1960449,0.28405476,-5.5874023};
 		};
 		side="Empty";
 		flags=4;
@@ -13629,7 +14430,7 @@ class items
 		{
 			init="[this, 200] call a3ee_fnc_boxGuard";
 		};
-		id=66;
+		id=68;
 		type="Box_IND_Ammo_F";
 		class CustomAttributes
 		{
@@ -13660,7 +14461,7 @@ class items
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={7.3295898,0.89242268,-8.2299805};
+			position[]={7.2497559,0.89242268,-7.9692383};
 		};
 		side="Empty";
 		flags=4;
@@ -13668,7 +14469,7 @@ class items
 		{
 			init="[this, 200] call a3ee_fnc_boxGuard";
 		};
-		id=67;
+		id=69;
 		type="I_supplyCrate_F";
 		class CustomAttributes
 		{
@@ -13697,28 +14498,28 @@ class items
 	class Item14
 	{
 		dataType="Marker";
-		position[]={3.7211914,1.3349106e+013,-3.6494141};
+		position[]={3.6413574,1.3349106e+013,-3.3881836};
 		name="respawn_guerrila";
 		type="respawn_unknown";
-		id=68;
+		id=70;
 		atlOffset=1.3349106e+013;
 	};
 	class Item15
 	{
 		dataType="Marker";
-		position[]={6.1293945,0,-6.75};
+		position[]={6.0495605,0,-6.4887695};
 		name="resupply_marker";
 		text="Resupply";
 		type="mil_triangle";
 		colorName="ColorGreen";
-		id=69;
+		id=71;
 	};
 	class Item16
 	{
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={5.1577148,0.14963102,-7.1591797};
+			position[]={5.0778809,0.14963102,-6.8979492};
 			angles[]={-0,4.7330365,0};
 		};
 		side="Empty";
@@ -13726,7 +14527,7 @@ class items
 		class Attributes
 		{
 		};
-		id=70;
+		id=72;
 		type="Box_IND_WpsLaunch_F";
 		class CustomAttributes
 		{
@@ -13757,11 +14558,11 @@ class items
 		dataType="Comment";
 		class PositionInfo
 		{
-			position[]={3.0703125,0,-5.2473145};
+			position[]={2.9909668,0,-4.9873047};
 		};
-		title="v1.13.6";
-		description="-v1.13.6" \n "  - ALL Added persistent Call-Signs for all GM's (where not included in v1.13.4)" \n "  - ALL Added the code `this disableAI ""MOVE""; this setSpeaker ""NoVoice""; enableRadio false;` to all playable units to prevent them from running off and spamming the vanilla-radio during local testing." \n "  - ALL Changed persistent call-signs (map markers) to a consistent formula: ≤ 2 syllables = written out call-sing. ≥ 3 syllables = abbreviated call-sign." \n "  - ALL Added full changelog to all factions for quick in-game reference" \n "  - TFN Added new yellow owl insignia patches to all uniforms" \n "" \n "- v1.13.5" \n "  - ALL Added respective GM's to Standard Faction Compositions for convenience / time saving " \n "  - ALL Added base clean-up module to Standard Faction Compositions to ensure Mission Makers don't forget it in the future - radius set to 200x200 meters" \n "" \n "- v1.13.4 " \n "  - ALL Added @ Squad/Team names to leaders so that Team name appears in role select" \n "  - TFN Changed M249 to the FN MINIMI" \n "" \n "- v1.13.3" \n "  - US Added Improved Bipod/SAW Grip to AR M249" \n "  - US Removed M14 Mags" \n "  - TFN Added Bipod to M249" \n "" \n "- v1.13.2" \n "  - ALL Added 1 Extra Tourniquet to every Unit" \n "  - TFN DMT Lead Rifle Changed to D10 Version" \n "  - TFN DMT given extra pistol mag to bring in line with other units" \n "  - TFN AAR Weapon changed to HK416 D14.5" \n "  - TFN Lead Elements Given AN/PEQ-16A's" \n "  - US Alpha Fireteam 2 AAR vest changed to ALT variant to match rest of faction" \n "  - US Lead Elements Given AN/PEQ-16A's" \n "  - US DMT given extra pistol mag to bring in line with other units" \n "  - US DMT Sniper Rifle Given SU-260/P (MDO) to bring zoom level to the same as Russian and TFN factions" \n "  - US DMT Bipod Changed to Harris Bipod" \n "  - US DMT Marksman Rifle changed to black version of same rifle" \n "  - US DMT Marksman Magazines changed to SR-25 version, as RHS hotfix made M14 mags incompatible with MK11" \n "  - RUS DMT given extra pistol mag to bring in line with other units" \n "  - RUS DGR Helmets changed to TSH-4 to make distinct from US Helmets" \n "  - RUS NB Helmets changed to ZSH-7A to make distinct from US and TFN helmets" \n "  - RUS Removed RIS Rail adaptors from AK rifles" \n "  - RUS Added PG-7V rocket to MAT ammo crate. This rocket is lighter and packs less payload than the PG-7VL. This gives it an  increased effective range but is less powerful due to decreased payload" \n "" \n "- v1.12.2" \n "  - Hotfixed US Vests across the Squads to match V.12 changes. Whoops." \n "  - Added Angled Grip to TFN HK416s where possible. " \n "" \n "- v1.12" \n "  - Fixed TFN MMG Ammo preloaded into Rifle to 100RND mag from 50rnd." \n "  - Fixed TFN DMT Marksman Ammo loaded into Rifle to correct SBLR mag." \n "  - Changed TFN DMT Lead Suppressor to QDSS NT4 Black from Rotex-5 Grey" \n "  - Changed TFN Dagger Uniforms from Gorka R Green to FFCP Green Fatigues [RS]" \n "  - Changed US PLT Commander + Squad Leader Vest from SPCS Rifleman/OEF- CP to SPCS Squad Lead/OEF-CP" \n "  - Changed US Medic Vest from SPCS Rifleman/OEF-CP to SPCS Medic/OEF-CP" \n "  - Changed US PLT Rifleman Vest from SPCS OEF-CP to SPCS Rifleman Alt/OEF-CP" \n "  - Changed US FTL Vest from SPCS Rifleman/OEF-CP to SPCS Team Leader Alt/OEF-CP" \n "  - Changed US AR Vest from SPCS Rifleman/OEF-CP to SPCS SAW/OEF-CP" \n "  - Changed US AAR Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP" \n "  - Changed US Rifleman AT Vest from SPCS OEF-CP to SPCS Rifleman Alt/OEF-CP" \n "  - Changed US MAT/MMG/DMT/ENG/MTR Lead Vest from SPCS Rifleman/OEF-CP to SPCS Team Leader Alt/OEF-CP" \n "  - Changed US MMG Gunner Vest from SPCS Rifleman/OEF-CP to SPCS Machinegunner/OEF-CP" \n "  - Changed US MMG/MAT Ammo Bearer Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP" \n "  - Changed US MAT Gunner Vest from SPCS OEF-CP to SPCS Rifleman Alt/OEF-CP" \n "  - Changed US DMT Marksman vest from SPCS OEF-CP to SPCS Sniper/OEF-CP" \n "  - Fixed US DMT Marksman Rifle Loaded Mag to correct varient." \n "  - Changed US Engineer Rifleman Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP." \n "  - Changed US MTR Gunner Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP." \n "  - Changed US DGR Uniforms from FFCP ACU Fatigues to FFCP ACU Fatigues [RS]" \n "  - Changed US DGR Driver Backpack from Assault Pack Green to Assault Pack Black" \n "  - Changed US Heli Pilot/Copilot Uniforms from Heli pilot Coveralls to FFCP Nomad Fatigues [RS]" \n "  - Fixed US Heli/Jet Pilot Vest White Smoke grenade count to 2." \n "  - Changed US Heli Pilot/Copilot Helmet from Heli Pilot NATO to HGU-56/P (Black/Visor)" \n "  - Changed US Jet Pilot Uniform from Pilot Coveralls NATO to  FFCP Nomad Fatigues" \n "  - Changed RUS Vic/Heli/Jet Crew Weapons to PP-2000" \n "  - Upped RUS PP-2000 Ammo counts to 6x Mag to bring in line with ammo counts for TFN and US." \n "  - Changed RUS Heli Pilot Uniforms from Pilot Coveralls CSAT to FFCP-Fatigues EMR [RS]" \n "  - Changed RUS Heli Pilot Vest from 6B23 (6Sh116) to FFCP Tactical Vest TigerVRS" \n "  - Changed RUS Jet Pilot Uniforms from Pilot Coveralls CSAT to FFCP-Fatigues EMR [RS]" \n "  - Changed RUS Jet Pilot Vest from 6B23 (6Sh116) to FFCP Tactical Vest TigerVRS" \n "" \n "- v1.11" \n "  - changed m40 mini grenades to m67 fragmentation" \n "  - replaced mp7 weapons with mp5k-pdw" \n "  - changed ak105 to ak74m (plum) " \n "  - changed PKM to PKP" \n "  - changed RUS PKM ammo boxes. MMG now loads with 7TZ (AP rounds)" \n "  - added vert grip to us weapons" \n "  - replaced m14 with HK PSG1A1" \n "  - replaced m260e4 with mg3" \n "  - updated all ammo boxes respectively. " \n "" \n "- v1.10" \n "  - changed Medic loadouts from 6 x 1000ml blood bags to 2 x 1000ml and 8 x 500ml." \n "" \n "- v1.09" \n "  - updated Fireteam colours A1 Red A2 Yellow, B1 Green B2 Blue, C1 Red C2 Yellow." \n "" \n "- v1.08" \n "  - changed ""Reaper"" to ""Nightbird"", ""RPR"" to ""NB""" \n "  - changed ""Paladin"" to ""Falcon"", ""PAL"" to ""FC""" \n "  - changed ""DAGGER"" to ""DGR""" \n "" \n "- v1.07" \n "  - US and RU faction bumped to v1.07 to avoid confusion regarding version numbers (US and RU was 1.05, TFN was 1.06)" \n "  - overhauled the RU faction: updated helmets, uniforms, weapons to a more modern look" \n "  - overhauled the US faction: updated helmets and vests to armour rating of IV" \n "  - corrected some mistakes in all factions (grenade ammount of MMG gunner, ENG not having tourniquetes, DGR not having GPS-s)" \n "  - overhauled the medics of all factions to reflect recent cahnges to ACE medical (less QuikClots, more Elastic Bandages, etc.)" \n "" \n "- v1.05" \n "  - Added a MAT ammo box on spawn." \n "" \n "- v1.04" \n "  - All MAT Teams carrying RPG's got the ver3 scopes with ranges for all types" \n "    of ammo." \n "  - All Callsigns were changed to be uniformed throught no matter the faction." \n "" \n "- v1.03" \n "  - set crew driver/gunner and pilot/copilot/jetpilot as Engineers through the" \n "    Object: ACE Options menu in unit attributes" \n "  - overhauled the TFN faction (weapons, helmets, etc.), changes not applicable" \n "    to derived factions" \n "" \n "- v1.02" \n "  - loadout overhaul for DMT, made them lighter + gave them tools for recon" \n "  - specified preset ACRE2 radio channels for most units" \n "" \n "- v1.01" \n "  - updated team colors func to `a3ee_team_colors_fnc_setColor`, just load+save" \n "    the composition in editor, this fixes it" \n "  - changed RPG-7 using MAT teams to carry Kitbags" \n "  - removed one PKM ammo box from AAR, MMG gunner, MMG bearer (fixes overload)" \n "  - moved 1-2 AR boxes from AAR to AR, gave AR an Assaultpack" \n "  - added 1-2 more AR boxes to AR's Assaultpack (if enough space)" \n "  - changed HEDP to HE rockets for Carl Gustav (M3MAAWS)" \n "  - changed US crew uniform and helmet to match grey color scheme of US pilots" \n "  - changed backpacks of driver/copilot to use less contrasting colors compared" \n "    to their respective uniform/vest colors" \n "  - changed Carryall backpacks of TFN Engineers to use custom Flecktarn Carryall" \n "  - changed all (GP-25 and normal) AK74m rifles to be the non-NPZ variants" \n "  - removed secondary long-range (PRC148) from Engineers" \n "" \n "- v1.00 (and before)" \n "  - added a Comment object with version number (`v1.00`)" \n "  - added `respawn_west`, `respawn_east`, `respawn_guerrila` markers" \n "  - added `[this, 200] call a3ee_fnc_boxGuard` to init lines of resupply boxes" \n "  - added `Resupply` green triangle markers on the position of resupply boxes";
-		id=71;
+		title="v1.14.0";
+		description="- v1.14.0 " \n "PL: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Boonie Hat"" for more visual diversity in the platoon and to bring PL headgear in line with RU and US Standard Factions. " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n "  - Removed CNTO ""Beret"" from Backpack gear due to old logo texture. " \n " " \n "Platoon Sergeant: " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n "  - Backpack added 3CB ""Radio Backpack MR3000"" and filled it with the ACRE2 ""AN/PRC-117F"" backpack radio. This gives more incentive to bring the PLT Sgt along since he is the only one who can act as a max range radio man for the platoon. " \n " " \n "Platoon Medic: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n " " \n "Platoon Rifleman: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n " " \n "Squad Medic: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n " " \n "FTL: " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n " " \n "AR: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n "  - Added muzzle attachment RHS ""SF3P-556 1/2-28"". " \n " " \n "AAR: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n " " \n "LAT: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n " " \n "MMG Teamleader: " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n " " \n "MMG Gunner: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n "  - Unfortunately no muzzle attachments available for the MG-3! " \n " " \n "MMG Asst. Gunner: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n " " \n "MAT Teamleader: " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n " " \n "MAT Gunner: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n " " \n "MAT Asst. Gunner: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n " " \n "ENG Leader: " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Heavy"" to differentiate ENG from the rest of the platoon. " \n " " \n "ENG Rifleman: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Heavy"" to differentiate ENG from the rest of the platoon. " \n " " \n "Mortar Leader: " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Special"" to visually differentiate the Mortar Team from the rest of the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n "  - Reduced STANAG mags from 10 to 5 to match the ENG ammo count. " \n " " \n "Mortar Gunner: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Special"" to visually differentiate the Mortar Team from the rest of the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n "  - Reduced STANAG mags from 10 to 5 to match the ENG ammo count. " \n " " \n "DMT Leader " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n " " \n "DMT Marksman " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n "  - Added NVG scope RHS ""AN/PVS-27"" to the vest gear. " \n " " \n "Zeus & Co-Zeus " \n "  - Uniform changed from vanilla ""VR Suit Indie"" to CNTO ""Flecktarn Recon"" to make Zeus look a bit more like an HQ commander than a Tron character. " \n "  - Facewear changed from vanilla ""VR Goggles"" to vanilla ""Aviator Glasses"". " \n "  - Insignia added ""Zeus"". " \n " " \n "All Units: " \n "  - Disabled LAMBS AI " \n " " \n "Alpha SL: " \n "  - Enabled ""is Player"". This makes it easier for Mission Makers to quickly test a mission in the editor by just hitting ""play"" instead of having to select a specific unit every time beforehand to avoid ending up in spectator mode by default. " \n " " \n "Crates: " \n "  - Added an ACE3 medical crate with our usual base script. " \n " " \n " " \n "- v1.13.6 " \n "  - ALL Added persistent Call-Signs for all GM's (where not included in v1.13.4) " \n "  - ALL Added the code `this disableAI ""MOVE""; this setSpeaker ""NoVoice""; enableRadio false;` to all playable units to prevent them from running off and spamming the vanilla-radio during local testing. " \n "  - ALL Changed persistent call-signs (map markers) to a consistent formula: ≤ 2 syllables = written out call-sing. ≥ 3 syllables = abbreviated call-sign. " \n "  - ALL Added full changelog to all factions for quick in-game reference " \n "  - TFN Added new yellow owl insignia patches to all uniforms " \n " " \n " " \n "- v1.13.5 " \n "  - ALL Added respective GM's to Standard Faction Compositions for convenience / time saving  " \n "  - ALL Added base clean-up module to Standard Faction Compositions to ensure Mission Makers don't forget it in the future - radius set to 200x200 meters " \n " " \n " " \n "- v1.13.4  " \n "  - ALL Added @ Squad/Team names to leaders so that Team name appears in role select " \n "  - TFN Changed M249 to the FN MINIMI " \n " " \n " " \n "- v1.13.3 " \n "  - US Added Improved Bipod/SAW Grip to AR M249 " \n "  - US Removed M14 Mags " \n "  - TFN Added Bipod to M249 " \n " " \n " " \n "- v1.13.2 " \n "  - ALL Added 1 Extra Tourniquet to every Unit " \n "  - TFN DMT Lead Rifle Changed to D10 Version " \n "  - TFN DMT given extra pistol mag to bring in line with other units " \n "  - TFN AAR Weapon changed to HK416 D14.5 " \n "  - TFN Lead Elements Given AN/PEQ-16A's " \n "  - US Alpha Fireteam 2 AAR vest changed to ALT variant to match rest of faction " \n "  - US Lead Elements Given AN/PEQ-16A's " \n "  - US DMT given extra pistol mag to bring in line with other units " \n "  - US DMT Sniper Rifle Given SU-260/P (MDO) to bring zoom level to the same as Russian and TFN factions " \n "  - US DMT Bipod Changed to Harris Bipod " \n "  - US DMT Marksman Rifle changed to black version of same rifle " \n "  - US DMT Marksman Magazines changed to SR-25 version, as RHS hotfix made M14 mags incompatible with MK11 " \n "  - RUS DMT given extra pistol mag to bring in line with other units " \n "  - RUS DGR Helmets changed to TSH-4 to make distinct from US Helmets " \n "  - RUS NB Helmets changed to ZSH-7A to make distinct from US and TFN helmets " \n "  - RUS Removed RIS Rail adaptors from AK rifles " \n "  - RUS Added PG-7V rocket to MAT ammo crate. This rocket is lighter and packs less payload than the PG-7VL. This gives it an  increased effective range but is less powerful due to decreased payload " \n " " \n " " \n "- v1.12.2 " \n "  - Hotfixed US Vests across the Squads to match V.12 changes. Whoops. " \n "  - Added Angled Grip to TFN HK416s where possible.  " \n " " \n " " \n "- v1.12 " \n "  - Fixed TFN MMG Ammo preloaded into Rifle to 100RND mag from 50rnd. " \n "  - Fixed TFN DMT Marksman Ammo loaded into Rifle to correct SBLR mag. " \n "  - Changed TFN DMT Lead Suppressor to QDSS NT4 Black from Rotex-5 Grey " \n "  - Changed TFN Dagger Uniforms from Gorka R Green to FFCP Green Fatigues [RS] " \n "  - Changed US PLT Commander + Squad Leader Vest from SPCS Rifleman/OEF- CP to SPCS Squad Lead/OEF-CP " \n "  - Changed US Medic Vest from SPCS Rifleman/OEF-CP to SPCS Medic/OEF-CP " \n "  - Changed US PLT Rifleman Vest from SPCS OEF-CP to SPCS Rifleman Alt/OEF-CP " \n "  - Changed US FTL Vest from SPCS Rifleman/OEF-CP to SPCS Team Leader Alt/OEF-CP " \n "  - Changed US AR Vest from SPCS Rifleman/OEF-CP to SPCS SAW/OEF-CP " \n "  - Changed US AAR Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP " \n "  - Changed US Rifleman AT Vest from SPCS OEF-CP to SPCS Rifleman Alt/OEF-CP " \n "  - Changed US MAT/MMG/DMT/ENG/MTR Lead Vest from SPCS Rifleman/OEF-CP to SPCS Team Leader Alt/OEF-CP " \n "  - Changed US MMG Gunner Vest from SPCS Rifleman/OEF-CP to SPCS Machinegunner/OEF-CP " \n "  - Changed US MMG/MAT Ammo Bearer Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP " \n "  - Changed US MAT Gunner Vest from SPCS OEF-CP to SPCS Rifleman Alt/OEF-CP " \n "  - Changed US DMT Marksman vest from SPCS OEF-CP to SPCS Sniper/OEF-CP " \n "  - Fixed US DMT Marksman Rifle Loaded Mag to correct varient. " \n "  - Changed US Engineer Rifleman Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP. " \n "  - Changed US MTR Gunner Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP. " \n "  - Changed US DGR Uniforms from FFCP ACU Fatigues to FFCP ACU Fatigues [RS] " \n "  - Changed US DGR Driver Backpack from Assault Pack Green to Assault Pack Black " \n "  - Changed US Heli Pilot/Copilot Uniforms from Heli pilot Coveralls to FFCP Nomad Fatigues [RS] " \n "  - Fixed US Heli/Jet Pilot Vest White Smoke grenade count to 2. " \n "  - Changed US Heli Pilot/Copilot Helmet from Heli Pilot NATO to HGU-56/P (Black/Visor) " \n "  - Changed US Jet Pilot Uniform from Pilot Coveralls NATO to  FFCP Nomad Fatigues " \n "  - Changed RUS Vic/Heli/Jet Crew Weapons to PP-2000 " \n "  - Upped RUS PP-2000 Ammo counts to 6x Mag to bring in line with ammo counts for TFN and US. " \n "  - Changed RUS Heli Pilot Uniforms from Pilot Coveralls CSAT to FFCP-Fatigues EMR [RS] " \n "  - Changed RUS Heli Pilot Vest from 6B23 (6Sh116) to FFCP Tactical Vest TigerVRS " \n "  - Changed RUS Jet Pilot Uniforms from Pilot Coveralls CSAT to FFCP-Fatigues EMR [RS] " \n "  - Changed RUS Jet Pilot Vest from 6B23 (6Sh116) to FFCP Tactical Vest TigerVRS " \n " " \n " " \n "- v1.11 " \n "  - changed m40 mini grenades to m67 fragmentation " \n "  - replaced mp7 weapons with mp5k-pdw " \n "  - changed ak105 to ak74m (plum)  " \n "  - changed PKM to PKP " \n "  - changed RUS PKM ammo boxes. MMG now loads with 7TZ (AP rounds) " \n "  - added vert grip to us weapons " \n "  - replaced m14 with HK PSG1A1 " \n "  - replaced m260e4 with mg3 " \n "  - updated all ammo boxes respectively.  " \n " " \n " " \n "- v1.10 " \n "  - changed Medic loadouts from 6 x 1000ml blood bags to 2 x 1000ml and 8 x 500ml. " \n " " \n " " \n "- v1.09 " \n "  - updated Fireteam colours A1 Red A2 Yellow, B1 Green B2 Blue, C1 Red C2 Yellow. " \n " " \n " " \n "- v1.08 " \n "  - changed ""Reaper"" to ""Nightbird"", ""RPR"" to ""NB"" " \n "  - changed ""Paladin"" to ""Falcon"", ""PAL"" to ""FC"" " \n "  - changed ""DAGGER"" to ""DGR"" " \n " " \n " " \n "- v1.07 " \n "  - US and RU faction bumped to v1.07 to avoid confusion regarding version numbers (US and RU was 1.05, TFN was 1.06) " \n "  - overhauled the RU faction: updated helmets, uniforms, weapons to a more modern look " \n "  - overhauled the US faction: updated helmets and vests to armour rating of IV " \n "  - corrected some mistakes in all factions (grenade ammount of MMG gunner, ENG not having tourniquetes, DGR not having GPS-s) " \n "  - overhauled the medics of all factions to reflect recent cahnges to ACE medical (less QuikClots, more Elastic Bandages, etc.) " \n " " \n " " \n "- v1.05 " \n "  - Added a MAT ammo box on spawn. " \n " " \n " " \n "- v1.04 " \n "  - All MAT Teams carrying RPG's got the ver3 scopes with ranges for all types " \n "    of ammo. " \n "  - All Callsigns were changed to be uniformed throught no matter the faction. " \n " " \n " " \n "- v1.03 " \n "  - set crew driver/gunner and pilot/copilot/jetpilot as Engineers through the " \n "    Object: ACE Options menu in unit attributes " \n "  - overhauled the TFN faction (weapons, helmets, etc.), changes not applicable " \n "    to derived factions " \n " " \n " " \n "- v1.02 " \n "  - loadout overhaul for DMT, made them lighter + gave them tools for recon " \n "  - specified preset ACRE2 radio channels for most units " \n " " \n " " \n "- v1.01 " \n "  - updated team colors func to `a3ee_team_colors_fnc_setColor`, just load+save " \n "    the composition in editor, this fixes it " \n "  - changed RPG-7 using MAT teams to carry Kitbags " \n "  - removed one PKM ammo box from AAR, MMG gunner, MMG bearer (fixes overload) " \n "  - moved 1-2 AR boxes from AAR to AR, gave AR an Assaultpack " \n "  - added 1-2 more AR boxes to AR's Assaultpack (if enough space) " \n "  - changed HEDP to HE rockets for Carl Gustav (M3MAAWS) " \n "  - changed US crew uniform and helmet to match grey color scheme of US pilots " \n "  - changed backpacks of driver/copilot to use less contrasting colors compared " \n "    to their respective uniform/vest colors " \n "  - changed Carryall backpacks of TFN Engineers to use custom Flecktarn Carryall " \n "  - changed all (GP-25 and normal) AK74m rifles to be the non-NPZ variants " \n "  - removed secondary long-range (PRC148) from Engineers " \n " " \n " " \n "- v1.00 (and before) " \n "  - added a Comment object with version number (`v1.00`) " \n "  - added `respawn_west`, `respawn_east`, `respawn_guerrila` markers " \n "  - added `[this, 200] call a3ee_fnc_boxGuard` to init lines of resupply boxes " \n "  - added `Resupply` green triangle markers on the position of resupply boxes";
+		id=73;
 	};
 	class Item18
 	{
@@ -13775,7 +14576,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={4.7963867,0.0014390945,-4.4926758};
+					position[]={4.7165527,0.0014390945,-4.2319336};
 				};
 				side="Independent";
 				flags=7;
@@ -13798,7 +14599,7 @@ class items
 						};
 						class uniform
 						{
-							typeName="U_I_Protagonist_VR";
+							typeName="cnto_flecktarn_u_r_grassland";
 							isBackpack=0;
 							class MagazineCargo
 							{
@@ -13806,7 +14607,7 @@ class items
 								class Item0
 								{
 									name="rhsusf_mag_17Rnd_9x19_JHP";
-									count=10;
+									count=2;
 									ammoLeft=17;
 								};
 							};
@@ -13844,10 +14645,10 @@ class items
 						compass="ItemCompass";
 						watch="ItemWatch";
 						gps="ItemGPS";
-						goggles="G_Goggles_VR";
+						goggles="G_Aviator";
 					};
 				};
-				id=73;
+				id=75;
 				type="I_Protagonist_VR_F";
 				class CustomAttributes
 				{
@@ -13866,11 +14667,30 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="Curator";
 							};
 						};
 					};
 					class Attribute1
+					{
+						property="lambs_danger_disableAI";
+						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"BOOL"
+									};
+								};
+								value=1;
+							};
+						};
+					};
+					class Attribute2
 					{
 						property="insta_zeus_unit_curator";
 						expression="[_this, _value] call Insta_Zeus_fnc_createUnitCurator";
@@ -13889,7 +14709,7 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					nAttributes=3;
 				};
 			};
 			class Item1
@@ -13897,7 +14717,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={5.7963867,0.0014390945,-4.4926758};
+					position[]={5.7165527,0.0014390945,-4.2319336};
 				};
 				side="Independent";
 				flags=5;
@@ -13920,7 +14740,7 @@ class items
 						};
 						class uniform
 						{
-							typeName="U_I_Protagonist_VR";
+							typeName="cnto_flecktarn_u_r_grassland";
 							isBackpack=0;
 							class MagazineCargo
 							{
@@ -13928,7 +14748,7 @@ class items
 								class Item0
 								{
 									name="rhsusf_mag_17Rnd_9x19_JHP";
-									count=10;
+									count=2;
 									ammoLeft=17;
 								};
 							};
@@ -13966,10 +14786,10 @@ class items
 						compass="ItemCompass";
 						watch="ItemWatch";
 						gps="ItemGPS";
-						goggles="G_Goggles_VR";
+						goggles="G_Aviator";
 					};
 				};
-				id=74;
+				id=76;
 				type="I_Protagonist_VR_F";
 				class CustomAttributes
 				{
@@ -13988,11 +14808,30 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="Curator";
 							};
 						};
 					};
 					class Attribute1
+					{
+						property="lambs_danger_disableAI";
+						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"BOOL"
+									};
+								};
+								value=1;
+							};
+						};
+					};
+					class Attribute2
 					{
 						property="insta_zeus_unit_curator";
 						expression="[_this, _value] call Insta_Zeus_fnc_createUnitCurator";
@@ -14011,14 +14850,14 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					nAttributes=3;
 				};
 			};
 		};
 		class Attributes
 		{
 		};
-		id=72;
+		id=74;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -14040,26 +14879,7 @@ class items
 					};
 				};
 			};
-			class Attribute1
-			{
-				property="groupID";
-				expression="[_this, _value] call CBA_fnc_setCallsign";
-				class Value
-				{
-					class data
-					{
-						class type
-						{
-							type[]=
-							{
-								"STRING"
-							};
-						};
-						value="GM";
-					};
-				};
-			};
-			nAttributes=2;
+			nAttributes=1;
 		};
 	};
 	class Item19
@@ -14067,12 +14887,12 @@ class items
 		dataType="Logic";
 		class PositionInfo
 		{
-			position[]={0.79736328,0,-0.59716797};
+			position[]={0.7175293,0,-0.33642578};
 		};
 		areaSize[]={200,0,200};
 		areaIsRectangle=1;
 		flags=1;
-		id=75;
+		id=77;
 		type="a3ee_custom_location";
 		class CustomAttributes
 		{
@@ -14134,6 +14954,45 @@ class items
 				};
 			};
 			nAttributes=3;
+		};
+	};
+	class Item20
+	{
+		dataType="Object";
+		class PositionInfo
+		{
+			position[]={7.6286621,0,-3.9125977};
+		};
+		side="Empty";
+		flags=4;
+		class Attributes
+		{
+			init="call{[this, 200] call a3ee_fnc_boxGuard}";
+		};
+		id=78;
+		type="ACE_medicalSupplyCrate";
+		class CustomAttributes
+		{
+			class Attribute0
+			{
+				property="ammoBox";
+				expression="[_this,_value] call bis_fnc_initAmmoBox;";
+				class Value
+				{
+					class data
+					{
+						class type
+						{
+							type[]=
+							{
+								"STRING"
+							};
+						};
+						value="[[[[],[]],[[],[]],[[""ACE_fieldDressing"",""ACE_morphine"",""ACE_epinephrine"",""ACE_bloodIV"",""ACE_bloodIV_500"",""ACE_bloodIV_250"",""ACE_packingBandage"",""ACE_elasticBandage"",""ACE_quikclot""],[40,15,15,5,15,10,20,20,40]],[[],[]]],false]";
+					};
+				};
+			};
+			nAttributes=1;
 		};
 	};
 };


### PR DESCRIPTION
PL:
- Helmet changed from CNTO "Flecktarn Enhanced Combat Helmet" to CNTO "Flecktarn Boonie Hat" for more visual diversity in the platoon and to bring PL headgear in line with RU and US Standard Factions.
- Uniform changed from CNTO "Flecktarn" to CNTO "Flecktarn Recon" for more visual diversity in the platoon.
- Removed CNTO "Beret" from Backpack gear due to old logo texture.

Platoon Sergeant:
- Vest changed from CNTO "Flecktarn Carrier" to CNTO "Flecktarn Carrier Lite" for more visual diversity in the platoon.
- Rifle changed from RHS "HK416 D14.5" to RHS "HK416 D10", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased.
- Backpack added 3CB "Radio Backpack MR3000" and filled it with the ACRE2 "AN/PRC-117F" backpack radio. This gives more incentive to bring the PLT Sgt along since he is the only one who can act as a max range radio man for the platoon.

Platoon Medic:
- Helmet changed from CNTO "Flecktarn Enhanced Combat Helmet" to CNTO "Flecktarn Combat Helmet" for more visual diversity in the platoon.
- Uniform changed from CNTO "Flecktarn" to CNTO "Flecktarn Recon" for more visual diversity in the platoon.
- Rifle changed from RHS "HK416 D14.5" to RHS "HK416 D10", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased.

Platoon Rifleman:
- Helmet changed from CNTO "Flecktarn Enhanced Combat Helmet" to CNTO "Flecktarn Combat Helmet" for more visual diversity in the platoon.
- Vest changed from CNTO "Flecktarn Carrier" to CNTO "Flecktarn Carrier Lite" for more visual diversity in the platoon.

Squad Medic:
- Helmet changed from CNTO "Flecktarn Enhanced Combat Helmet" to CNTO "Flecktarn Combat Helmet" for more visual diversity in the platoon.
- Uniform changed from CNTO "Flecktarn" to CNTO "Flecktarn Recon" for more visual diversity in the platoon.
- Rifle changed from RHS "HK416 D14.5" to RHS "HK416 D10", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased.

FTL:
- Uniform changed from CNTO "Flecktarn" to CNTO "Flecktarn Recon" for more visual diversity in the platoon.

AR:
- Helmet changed from CNTO "Flecktarn Enhanced Combat Helmet" to CNTO "Flecktarn Combat Helmet" for more visual diversity in the platoon.
- Vest changed from CNTO "Flecktarn Carrier" to CNTO "Flecktarn Carrier Lite" for more visual diversity in the platoon.
- Added muzzle attachment RHS "SF3P-556 1/2-28".

AAR:
- Helmet changed from CNTO "Flecktarn Enhanced Combat Helmet" to CNTO "Flecktarn Combat Helmet" for more visual diversity in the platoon.
- Uniform changed from CNTO "Flecktarn" to CNTO "Flecktarn Recon" for more visual diversity in the platoon.

LAT:
- Helmet changed from CNTO "Flecktarn Enhanced Combat Helmet" to CNTO "Flecktarn Combat Helmet" for more visual diversity in the platoon.
- Vest changed from CNTO "Flecktarn Carrier" to CNTO "Flecktarn Carrier Lite" for more visual diversity in the platoon.
- Rifle changed from RHS "HK416 D14.5" to RHS "HK416 D10", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased.

MMG Teamleader:
- Uniform changed from CNTO "Flecktarn" to CNTO "Flecktarn Recon" for more visual diversity in the platoon.

MMG Gunner:
- Helmet changed from CNTO "Flecktarn Enhanced Combat Helmet" to CNTO "Flecktarn Combat Helmet" for more visual diversity in the platoon.
- Vest changed from CNTO "Flecktarn Carrier" to CNTO "Flecktarn Carrier Lite" for more visual diversity in the platoon.
- Unfortunately no muzzle attachments available for the MG-3!

MMG Asst. Gunner:
- Helmet changed from CNTO "Flecktarn Enhanced Combat Helmet" to CNTO "Flecktarn Combat Helmet" for more visual diversity in the platoon.
- Vest changed from CNTO "Flecktarn Carrier" to CNTO "Flecktarn Carrier Lite" for more visual diversity in the platoon.

MAT Teamleader:
- Uniform changed from CNTO "Flecktarn" to CNTO "Flecktarn Recon" for more visual diversity in the platoon.

MAT Gunner:
- Helmet changed from CNTO "Flecktarn Enhanced Combat Helmet" to CNTO "Flecktarn Combat Helmet" for more visual diversity in the platoon.
- Vest changed from CNTO "Flecktarn Carrier" to CNTO "Flecktarn Carrier Lite" for more visual diversity in the platoon.
- Rifle changed from RHS "HK416 D14.5" to RHS "HK416 D10", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased.

MAT Asst. Gunner:
- Helmet changed from CNTO "Flecktarn Enhanced Combat Helmet" to CNTO "Flecktarn Combat Helmet" for more visual diversity in the platoon.
- Vest changed from CNTO "Flecktarn Carrier" to CNTO "Flecktarn Carrier Lite" for more visual diversity in the platoon.

ENG Leader:
- Uniform changed from CNTO "Flecktarn" to CNTO "Flecktarn Recon" for more visual diversity in the platoon.
- Vest changed from CNTO "Flecktarn Carrier" to CNTO "Flecktarn Carrier Heavy" to differentiate ENG from the rest of the platoon.

ENG Rifleman:
- Helmet changed from CNTO "Flecktarn Enhanced Combat Helmet" to CNTO "Flecktarn Combat Helmet" for more visual diversity in the platoon.
- Vest changed from CNTO "Flecktarn Carrier" to CNTO "Flecktarn Carrier Heavy" to differentiate ENG from the rest of the platoon.

Mortar Leader:
- Vest changed from CNTO "Flecktarn Carrier" to CNTO "Flecktarn Carrier Special" to visually differentiate the Mortar Team from the rest of the platoon.
- Rifle changed from RHS "HK416 D14.5" to RHS "HK416 D10", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased.
- Reduced STANAG mags from 10 to 5 to match the ENG ammo count.

Mortar Gunner:
- Helmet changed from CNTO "Flecktarn Enhanced Combat Helmet" to CNTO "Flecktarn Combat Helmet" for more visual diversity in the platoon.
- Vest changed from CNTO "Flecktarn Carrier" to CNTO "Flecktarn Carrier Special" to visually differentiate the Mortar Team from the rest of the platoon.
- Rifle changed from RHS "HK416 D14.5" to RHS "HK416 D10", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased.
- Reduced STANAG mags from 10 to 5 to match the ENG ammo count.

DMT Leader
- Vest changed from CNTO "Flecktarn Carrier" to CNTO "Flecktarn Carrier Lite" for more visual diversity in the platoon.

DMT Marksman
- Vest changed from CNTO "Flecktarn Carrier" to CNTO "Flecktarn Carrier Lite" for more visual diversity in the platoon.
- Added NVG scope RHS "AN/PVS-27" to the vest gear.

Zeus & Co-Zeus
- Uniform changed from vanilla "VR Suit Indie" to CNTO "Flecktarn Recon" to make Zeus look a bit more like an HQ commander than a Tron character.
- Facewear changed from vanilla "VR Goggles" to vanilla "Aviator Glasses".
- Insignia added "Zeus".

All Units:
- Disabled LAMBS AI

Alpha SL:
- Enabled "is Player". This makes it easier for Mission Makers to quickly test a mission in the editor by just hitting "play" instead of having to select a specific unit every time beforehand to avoid ending up in spectator mode by default.

Crates:
- Added an ACE3 medical crate with our usual base script.