### PR TITLE
Russian Army Update v1.14.2

### DIFF
--- a/reference/Russian%20Army/composition.sqe
+++ b/reference/Russian%20Army/composition.sqe
@@ -1,8 +1,8 @@
 version=53;
-center[]={5960.6396,5,5296.5737};
+center[]={4145.208,5,742.66644};
 class items
 {
-	items=21;
+	items=22;
 	class Item0
 	{
 		dataType="Group";
@@ -15,7 +15,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-6.0209961,0.0014390945,8.112793};
+					position[]={-6.0830078,0.0014390945,8.3413086};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -60,6 +60,16 @@ class items
 						{
 							typeName="rhs_uniform_flora_patchless";
 							isBackpack=0;
+							class MagazineCargo
+							{
+								items=1;
+								class Item0
+								{
+									name="rhs_mag_9x19_17";
+									count=1;
+									ammoLeft=17;
+								};
+							};
 							class ItemCargo
 							{
 								items=9;
@@ -75,17 +85,17 @@ class items
 								};
 								class Item2
 								{
-									name="ACE_morphine";
-									count=1;
+									name="ACE_tourniquet";
+									count=2;
 								};
 								class Item3
 								{
-									name="rhs_acc_2dpZenit";
+									name="ACE_morphine";
 									count=1;
 								};
 								class Item4
 								{
-									name="ACRE_PRC343";
+									name="ACE_epinephrine";
 									count=1;
 								};
 								class Item5
@@ -100,12 +110,12 @@ class items
 								};
 								class Item7
 								{
-									name="ACRE_PRC152";
+									name="rhs_acc_2dpZenit";
 									count=1;
 								};
 								class Item8
 								{
-									name="ACRE_PRC148";
+									name="ACRE_PRC343";
 									count=1;
 								};
 							};
@@ -116,39 +126,24 @@ class items
 							isBackpack=0;
 							class MagazineCargo
 							{
-								items=4;
+								items=3;
 								class Item0
-								{
-									name="SmokeShell";
-									count=4;
-									ammoLeft=1;
-								};
-								class Item1
-								{
-									name="rhs_mag_9x19_17";
-									count=1;
-									ammoLeft=17;
-								};
-								class Item2
 								{
 									name="rhs_30Rnd_545x39_7N22_plum_AK";
 									count=6;
 									ammoLeft=30;
 								};
-								class Item3
+								class Item1
 								{
 									name="rhs_30Rnd_545x39_AK_plum_green";
 									count=4;
 									ammoLeft=30;
 								};
-							};
-							class ItemCargo
-							{
-								items=1;
-								class Item0
+								class Item2
 								{
-									name="ACE_tourniquet";
+									name="HandGrenade";
 									count=2;
+									ammoLeft=1;
 								};
 							};
 						};
@@ -158,7 +153,7 @@ class items
 							isBackpack=1;
 							class MagazineCargo
 							{
-								items=7;
+								items=6;
 								class Item0
 								{
 									name="rhs_GRD40_White";
@@ -180,7 +175,7 @@ class items
 								class Item3
 								{
 									name="SmokeShell";
-									count=3;
+									count=7;
 									ammoLeft=1;
 								};
 								class Item4
@@ -195,19 +190,23 @@ class items
 									count=2;
 									ammoLeft=1;
 								};
-								class Item6
-								{
-									name="HandGrenade";
-									count=2;
-									ammoLeft=1;
-								};
 							};
 							class ItemCargo
 							{
-								items=1;
+								items=3;
 								class Item0
 								{
 									name="ACE_IR_Strobe_Item";
+									count=1;
+								};
+								class Item1
+								{
+									name="ACRE_PRC152";
+									count=1;
+								};
+								class Item2
+								{
+									name="ACRE_PRC148";
 									count=1;
 								};
 							};
@@ -216,10 +215,10 @@ class items
 						compass="ItemCompass";
 						watch="ItemWatch";
 						gps="ItemGPS";
-						headgear="rhs_fieldcap_vsr";
+						headgear="rhs_6b27m_green_ess";
 					};
 				};
-				id=155;
+				id=1;
 				type="O_officer_F";
 				class CustomAttributes
 				{
@@ -261,7 +260,109 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=3;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="4";
+										};
+									};
+									class Item1
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+									class Item2
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="5";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute3
+					{
+						property="speaker";
+						expression="_this setspeaker _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="Male01PER";
+							};
+						};
+					};
+					class Attribute4
+					{
+						property="pitch";
+						expression="_this setpitch _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"SCALAR"
+									};
+								};
+								value=0.99000001;
+							};
+						};
+					};
+					nAttributes=5;
 				};
 			};
 			class Item1
@@ -269,7 +370,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-5.0209961,0.0014390945,8.0913086};
+					position[]={-5.0830078,0.0014390945,8.3192139};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -311,7 +412,7 @@ class items
 							isBackpack=0;
 							class ItemCargo
 							{
-								items=9;
+								items=10;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -324,35 +425,40 @@ class items
 								};
 								class Item2
 								{
-									name="ACE_morphine";
-									count=1;
+									name="ACE_tourniquet";
+									count=2;
 								};
 								class Item3
 								{
-									name="rhs_acc_2dpZenit";
+									name="ACE_morphine";
 									count=1;
 								};
 								class Item4
 								{
-									name="ACRE_PRC343";
+									name="ACE_epinephrine";
 									count=1;
 								};
 								class Item5
 								{
-									name="ACE_CableTie";
-									count=2;
+									name="ACE_MapTools";
+									count=1;
 								};
 								class Item6
 								{
-									name="ACE_MapTools";
+									name="rhs_acc_2dpZenit";
 									count=1;
 								};
 								class Item7
 								{
-									name="ACRE_PRC152";
+									name="ACRE_PRC343";
 									count=1;
 								};
 								class Item8
+								{
+									name="ACRE_PRC152";
+									count=1;
+								};
+								class Item9
 								{
 									name="ACRE_PRC148";
 									count=1;
@@ -368,33 +474,33 @@ class items
 								items=5;
 								class Item0
 								{
-									name="SmokeShell";
-									count=4;
-									ammoLeft=1;
+									name="rhs_30Rnd_545x39_7N22_plum_AK";
+									count=6;
+									ammoLeft=30;
 								};
 								class Item1
+								{
+									name="rhs_30Rnd_545x39_AK_plum_green";
+									count=4;
+									ammoLeft=30;
+								};
+								class Item2
 								{
 									name="rhs_mag_9x19_17";
 									count=1;
 									ammoLeft=17;
 								};
-								class Item2
+								class Item3
 								{
 									name="HandGrenade";
 									count=2;
 									ammoLeft=1;
 								};
-								class Item3
-								{
-									name="rhs_30Rnd_545x39_7N22_plum_AK";
-									count=6;
-									ammoLeft=30;
-								};
 								class Item4
 								{
-									name="rhs_30Rnd_545x39_AK_plum_green";
+									name="SmokeShell";
 									count=4;
-									ammoLeft=30;
+									ammoLeft=1;
 								};
 							};
 							class ItemCargo
@@ -402,7 +508,7 @@ class items
 								items=1;
 								class Item0
 								{
-									name="ACE_tourniquet";
+									name="ACE_CableTie";
 									count=2;
 								};
 							};
@@ -425,10 +531,10 @@ class items
 						compass="ItemCompass";
 						watch="ItemWatch";
 						gps="ItemGPS";
-						headgear="rhs_6b26_ess_green";
+						headgear="rhs_6b27m_green_bala";
 					};
 				};
-				id=156;
+				id=2;
 				type="O_Soldier_TL_F";
 				class CustomAttributes
 				{
@@ -470,7 +576,109 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=3;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="4";
+										};
+									};
+									class Item1
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+									class Item2
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="3";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute3
+					{
+						property="speaker";
+						expression="_this setspeaker _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="Male02PER";
+							};
+						};
+					};
+					class Attribute4
+					{
+						property="pitch";
+						expression="_this setpitch _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"SCALAR"
+									};
+								};
+								value=1.01;
+							};
+						};
+					};
+					nAttributes=5;
 				};
 			};
 			class Item2
@@ -478,7 +686,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-4.0209961,0.0014390945,8.112793};
+					position[]={-4.0834961,0.0014390945,8.3409424};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -492,7 +700,7 @@ class items
 					{
 						class primaryWeapon
 						{
-							name="rhs_weap_aks74u";
+							name="rhs_weap_aks74un";
 							muzzle="rhs_acc_pgs64_74u";
 							class primaryMuzzleMag
 							{
@@ -518,14 +726,14 @@ class items
 								items=1;
 								class Item0
 								{
-									name="SmokeShell";
-									count=4;
-									ammoLeft=1;
+									name="rhs_mag_9x19_17";
+									count=1;
+									ammoLeft=17;
 								};
 							};
 							class ItemCargo
 							{
-								items=5;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -538,15 +746,25 @@ class items
 								};
 								class Item2
 								{
+									name="ACE_tourniquet";
+									count=2;
+								};
+								class Item3
+								{
 									name="ACE_morphine";
 									count=1;
 								};
-								class Item3
+								class Item4
+								{
+									name="ACE_epinephrine";
+									count=1;
+								};
+								class Item5
 								{
 									name="rhs_acc_2dpZenit";
 									count=1;
 								};
-								class Item4
+								class Item6
 								{
 									name="ACRE_PRC343";
 									count=1;
@@ -559,39 +777,24 @@ class items
 							isBackpack=0;
 							class MagazineCargo
 							{
-								items=4;
+								items=3;
 								class Item0
-								{
-									name="rhs_mag_9x19_17";
-									count=1;
-									ammoLeft=17;
-								};
-								class Item1
-								{
-									name="HandGrenade";
-									count=2;
-									ammoLeft=1;
-								};
-								class Item2
 								{
 									name="rhs_30Rnd_545x39_7N22_plum_AK";
 									count=8;
 									ammoLeft=30;
 								};
-								class Item3
+								class Item1
 								{
 									name="rhs_30Rnd_545x39_AK_plum_green";
 									count=2;
 									ammoLeft=30;
 								};
-							};
-							class ItemCargo
-							{
-								items=1;
-								class Item0
+								class Item2
 								{
-									name="ACE_tourniquet";
+									name="HandGrenade";
 									count=2;
+									ammoLeft=1;
 								};
 							};
 						};
@@ -605,7 +808,7 @@ class items
 								class Item0
 								{
 									name="SmokeShell";
-									count=8;
+									count=10;
 									ammoLeft=1;
 								};
 								class Item1
@@ -679,10 +882,10 @@ class items
 						compass="ItemCompass";
 						watch="ItemWatch";
 						gps="ItemGPS";
-						headgear="rhs_6b26_green";
+						headgear="rhs_6b27m_green";
 					};
 				};
-				id=157;
+				id=3;
 				type="O_medic_F";
 				class CustomAttributes
 				{
@@ -724,7 +927,43 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="4";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=3;
 				};
 			};
 			class Item3
@@ -732,7 +971,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-3.0209961,0.0014390945,8.112793};
+					position[]={-3.0834961,0.0014390945,8.3409424};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -772,14 +1011,14 @@ class items
 								items=1;
 								class Item0
 								{
-									name="SmokeShell";
-									count=4;
-									ammoLeft=1;
+									name="rhs_mag_9x19_17";
+									count=1;
+									ammoLeft=17;
 								};
 							};
 							class ItemCargo
 							{
-								items=5;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -792,15 +1031,25 @@ class items
 								};
 								class Item2
 								{
+									name="ACE_tourniquet";
+									count=2;
+								};
+								class Item3
+								{
 									name="ACE_morphine";
 									count=1;
 								};
-								class Item3
+								class Item4
+								{
+									name="ACE_epinephrine";
+									count=1;
+								};
+								class Item5
 								{
 									name="rhs_acc_2dpZenit";
 									count=1;
 								};
-								class Item4
+								class Item6
 								{
 									name="ACRE_PRC343";
 									count=1;
@@ -816,46 +1065,37 @@ class items
 								items=4;
 								class Item0
 								{
-									name="rhs_mag_9x19_17";
-									count=1;
-									ammoLeft=17;
-								};
-								class Item1
-								{
-									name="HandGrenade";
-									count=2;
-									ammoLeft=1;
-								};
-								class Item2
-								{
 									name="rhs_30Rnd_545x39_7N22_plum_AK";
 									count=8;
 									ammoLeft=30;
 								};
-								class Item3
+								class Item1
 								{
 									name="rhs_30Rnd_545x39_AK_plum_green";
 									count=2;
 									ammoLeft=30;
 								};
-							};
-							class ItemCargo
-							{
-								items=1;
-								class Item0
+								class Item2
 								{
-									name="ACE_tourniquet";
+									name="HandGrenade";
 									count=2;
+									ammoLeft=1;
+								};
+								class Item3
+								{
+									name="SmokeShell";
+									count=4;
+									ammoLeft=1;
 								};
 							};
 						};
 						map="ItemMap";
 						compass="ItemCompass";
 						watch="ItemWatch";
-						headgear="rhs_6b26_ess_bala_green";
+						headgear="rhs_6b27m_green_ess_bala";
 					};
 				};
-				id=158;
+				id=4;
 				type="O_Soldier_F";
 				class CustomAttributes
 				{
@@ -897,14 +1137,50 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="4";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=3;
 				};
 			};
 		};
 		class Attributes
 		{
 		};
-		id=154;
+		id=0;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -941,7 +1217,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-6.2792969,0.0014390945,5.3803711};
+					position[]={-6.3413086,0.0014390945,5.6082764};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -991,14 +1267,14 @@ class items
 								items=1;
 								class Item0
 								{
-									name="SmokeShell";
-									count=2;
-									ammoLeft=1;
+									name="rhs_mag_9x19_17";
+									count=1;
+									ammoLeft=17;
 								};
 							};
 							class ItemCargo
 							{
-								items=8;
+								items=9;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -1011,17 +1287,17 @@ class items
 								};
 								class Item2
 								{
-									name="ACE_morphine";
-									count=1;
+									name="ACE_tourniquet";
+									count=2;
 								};
 								class Item3
 								{
-									name="rhs_acc_2dpZenit";
+									name="ACE_morphine";
 									count=1;
 								};
 								class Item4
 								{
-									name="ACRE_PRC343";
+									name="ACE_epinephrine";
 									count=1;
 								};
 								class Item5
@@ -1036,7 +1312,12 @@ class items
 								};
 								class Item7
 								{
-									name="ACRE_PRC152";
+									name="rhs_acc_2dpZenit";
+									count=1;
+								};
+								class Item8
+								{
+									name="ACRE_PRC343";
 									count=1;
 								};
 							};
@@ -1047,39 +1328,24 @@ class items
 							isBackpack=0;
 							class MagazineCargo
 							{
-								items=4;
+								items=3;
 								class Item0
-								{
-									name="SmokeShell";
-									count=2;
-									ammoLeft=1;
-								};
-								class Item1
-								{
-									name="rhs_mag_9x19_17";
-									count=1;
-									ammoLeft=17;
-								};
-								class Item2
 								{
 									name="rhs_30Rnd_545x39_7N22_plum_AK";
 									count=6;
 									ammoLeft=30;
 								};
-								class Item3
+								class Item1
 								{
 									name="rhs_30Rnd_545x39_AK_plum_green";
-									count=3;
+									count=4;
 									ammoLeft=30;
 								};
-							};
-							class ItemCargo
-							{
-								items=1;
-								class Item0
+								class Item2
 								{
-									name="ACE_tourniquet";
+									name="HandGrenade";
 									count=2;
+									ammoLeft=1;
 								};
 							};
 						};
@@ -1089,7 +1355,7 @@ class items
 							isBackpack=1;
 							class MagazineCargo
 							{
-								items=8;
+								items=7;
 								class Item0
 								{
 									name="rhs_VOG25";
@@ -1117,7 +1383,7 @@ class items
 								class Item4
 								{
 									name="SmokeShell";
-									count=3;
+									count=7;
 									ammoLeft=1;
 								};
 								class Item5
@@ -1132,19 +1398,18 @@ class items
 									count=2;
 									ammoLeft=1;
 								};
-								class Item7
-								{
-									name="HandGrenade";
-									count=2;
-									ammoLeft=1;
-								};
 							};
 							class ItemCargo
 							{
-								items=1;
+								items=2;
 								class Item0
 								{
 									name="ACE_IR_Strobe_Item";
+									count=1;
+								};
+								class Item1
+								{
+									name="ACRE_PRC152";
 									count=1;
 								};
 							};
@@ -1153,10 +1418,10 @@ class items
 						compass="ItemCompass";
 						watch="ItemWatch";
 						gps="ItemGPS";
-						headgear="rhs_6b27m_digi_ess";
+						headgear="rhs_6b27m_green_ess_bala";
 					};
 				};
-				id=160;
+				id=6;
 				type="O_Soldier_SL_F";
 				class CustomAttributes
 				{
@@ -1198,7 +1463,95 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=2;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+									class Item1
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute3
+					{
+						property="speaker";
+						expression="_this setspeaker _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="Male01PER";
+							};
+						};
+					};
+					class Attribute4
+					{
+						property="pitch";
+						expression="_this setpitch _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"SCALAR"
+									};
+								};
+								value=1.01;
+							};
+						};
+					};
+					nAttributes=5;
 				};
 			};
 			class Item1
@@ -1206,7 +1559,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-5.277832,0.0014390945,5.3911133};
+					position[]={-5.340332,0.0014390945,5.6192627};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -1220,7 +1573,7 @@ class items
 					{
 						class primaryWeapon
 						{
-							name="rhs_weap_aks74u";
+							name="rhs_weap_aks74un";
 							muzzle="rhs_acc_pgs64_74u";
 							class primaryMuzzleMag
 							{
@@ -1246,14 +1599,14 @@ class items
 								items=1;
 								class Item0
 								{
-									name="SmokeShell";
-									count=4;
-									ammoLeft=1;
+									name="rhs_mag_9x19_17";
+									count=1;
+									ammoLeft=17;
 								};
 							};
 							class ItemCargo
 							{
-								items=5;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -1266,15 +1619,25 @@ class items
 								};
 								class Item2
 								{
+									name="ACE_tourniquet";
+									count=2;
+								};
+								class Item3
+								{
 									name="ACE_morphine";
 									count=1;
 								};
-								class Item3
+								class Item4
+								{
+									name="ACE_epinephrine";
+									count=1;
+								};
+								class Item5
 								{
 									name="rhs_acc_2dpZenit";
 									count=1;
 								};
-								class Item4
+								class Item6
 								{
 									name="ACRE_PRC343";
 									count=1;
@@ -1287,39 +1650,24 @@ class items
 							isBackpack=0;
 							class MagazineCargo
 							{
-								items=4;
+								items=3;
 								class Item0
-								{
-									name="rhs_mag_9x19_17";
-									count=1;
-									ammoLeft=17;
-								};
-								class Item1
-								{
-									name="HandGrenade";
-									count=2;
-									ammoLeft=1;
-								};
-								class Item2
 								{
 									name="rhs_30Rnd_545x39_7N22_plum_AK";
 									count=8;
 									ammoLeft=30;
 								};
-								class Item3
+								class Item1
 								{
 									name="rhs_30Rnd_545x39_AK_plum_green";
 									count=2;
 									ammoLeft=30;
 								};
-							};
-							class ItemCargo
-							{
-								items=1;
-								class Item0
+								class Item2
 								{
-									name="ACE_tourniquet";
+									name="HandGrenade";
 									count=2;
+									ammoLeft=1;
 								};
 							};
 						};
@@ -1333,7 +1681,7 @@ class items
 								class Item0
 								{
 									name="SmokeShell";
-									count=8;
+									count=10;
 									ammoLeft=1;
 								};
 								class Item1
@@ -1410,7 +1758,7 @@ class items
 						headgear="rhs_6b27m_green";
 					};
 				};
-				id=161;
+				id=7;
 				type="O_medic_F";
 				class CustomAttributes
 				{
@@ -1452,7 +1800,43 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=3;
 				};
 			};
 			class Item2
@@ -1460,7 +1844,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-6.2568359,0.0014390945,3.3803711};
+					position[]={-6.3188477,0.0014390945,3.6085205};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -1510,14 +1894,14 @@ class items
 								items=1;
 								class Item0
 								{
-									name="SmokeShell";
-									count=4;
-									ammoLeft=1;
+									name="rhs_mag_9x19_17";
+									count=1;
+									ammoLeft=17;
 								};
 							};
 							class ItemCargo
 							{
-								items=7;
+								items=9;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -1530,17 +1914,17 @@ class items
 								};
 								class Item2
 								{
-									name="ACE_morphine";
-									count=1;
+									name="ACE_tourniquet";
+									count=2;
 								};
 								class Item3
 								{
-									name="rhs_acc_2dpZenit";
+									name="ACE_morphine";
 									count=1;
 								};
 								class Item4
 								{
-									name="ACRE_PRC343";
+									name="ACE_epinephrine";
 									count=1;
 								};
 								class Item5
@@ -1551,6 +1935,16 @@ class items
 								class Item6
 								{
 									name="ACE_MapTools";
+									count=1;
+								};
+								class Item7
+								{
+									name="rhs_acc_2dpZenit";
+									count=1;
+								};
+								class Item8
+								{
+									name="ACRE_PRC343";
 									count=1;
 								};
 							};
@@ -1564,30 +1958,21 @@ class items
 								items=3;
 								class Item0
 								{
-									name="rhs_mag_9x19_17";
-									count=1;
-									ammoLeft=17;
-								};
-								class Item1
-								{
 									name="rhs_30Rnd_545x39_7N22_plum_AK";
 									count=6;
 									ammoLeft=30;
 								};
-								class Item2
+								class Item1
 								{
 									name="rhs_30Rnd_545x39_AK_plum_green";
 									count=4;
 									ammoLeft=30;
 								};
-							};
-							class ItemCargo
-							{
-								items=1;
-								class Item0
+								class Item2
 								{
-									name="ACE_tourniquet";
+									name="HandGrenade";
 									count=2;
+									ammoLeft=1;
 								};
 							};
 						};
@@ -1597,7 +1982,7 @@ class items
 							isBackpack=1;
 							class MagazineCargo
 							{
-								items=7;
+								items=6;
 								class Item0
 								{
 									name="rhs_VOG25";
@@ -1619,7 +2004,7 @@ class items
 								class Item3
 								{
 									name="SmokeShell";
-									count=3;
+									count=7;
 									ammoLeft=1;
 								};
 								class Item4
@@ -1631,12 +2016,6 @@ class items
 								class Item5
 								{
 									name="SmokeShellBlue";
-									count=2;
-									ammoLeft=1;
-								};
-								class Item6
-								{
-									name="HandGrenade";
 									count=2;
 									ammoLeft=1;
 								};
@@ -1658,11 +2037,30 @@ class items
 						headgear="rhs_6b27m_green_bala";
 					};
 				};
-				id=162;
+				id=8;
 				type="O_Soldier_TL_F";
 				class CustomAttributes
 				{
 					class Attribute0
+					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="RED";
+							};
+						};
+					};
+					class Attribute1
 					{
 						property="lambs_danger_disableAI";
 						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
@@ -1681,7 +2079,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
@@ -1700,7 +2098,62 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute3
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute4
+					{
+						property="speaker";
+						expression="_this setspeaker _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="Male01PER";
+							};
+						};
+					};
+					nAttributes=5;
 				};
 			};
 			class Item3
@@ -1708,7 +2161,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-5.2568359,0.0014390945,3.3911133};
+					position[]={-5.3188477,0.0014390945,3.6192627};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -1748,14 +2201,14 @@ class items
 								items=1;
 								class Item0
 								{
-									name="SmokeShell";
-									count=4;
-									ammoLeft=1;
+									name="rhs_mag_9x19_17";
+									count=1;
+									ammoLeft=17;
 								};
 							};
 							class ItemCargo
 							{
-								items=5;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -1768,15 +2221,25 @@ class items
 								};
 								class Item2
 								{
+									name="ACE_tourniquet";
+									count=2;
+								};
+								class Item3
+								{
 									name="ACE_morphine";
 									count=1;
 								};
-								class Item3
+								class Item4
+								{
+									name="ACE_epinephrine";
+									count=1;
+								};
+								class Item5
 								{
 									name="rhs_acc_2dpZenit";
 									count=1;
 								};
-								class Item4
+								class Item6
 								{
 									name="ACRE_PRC343";
 									count=1;
@@ -1789,33 +2252,18 @@ class items
 							isBackpack=0;
 							class MagazineCargo
 							{
-								items=3;
+								items=2;
 								class Item0
 								{
-									name="rhs_mag_9x19_17";
-									count=1;
-									ammoLeft=17;
+									name="hlc_75Rnd_762x39_m_rpk";
+									count=2;
+									ammoLeft=75;
 								};
 								class Item1
 								{
 									name="HandGrenade";
 									count=2;
 									ammoLeft=1;
-								};
-								class Item2
-								{
-									name="hlc_75Rnd_762x39_m_rpk";
-									count=1;
-									ammoLeft=75;
-								};
-							};
-							class ItemCargo
-							{
-								items=1;
-								class Item0
-								{
-									name="ACE_tourniquet";
-									count=2;
 								};
 							};
 						};
@@ -1846,11 +2294,30 @@ class items
 						headgear="rhs_6b27m_green_ess";
 					};
 				};
-				id=163;
+				id=9;
 				type="O_Soldier_AR_F";
 				class CustomAttributes
 				{
 					class Attribute0
+					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="RED";
+							};
+						};
+					};
+					class Attribute1
 					{
 						property="lambs_danger_disableAI";
 						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
@@ -1869,7 +2336,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
@@ -1888,7 +2355,62 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute3
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute4
+					{
+						property="speaker";
+						expression="_this setspeaker _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="Male01PER";
+							};
+						};
+					};
+					nAttributes=5;
 				};
 			};
 			class Item4
@@ -1896,7 +2418,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-4.2568359,0.0014390945,3.4018555};
+					position[]={-4.3193359,0.0014390945,3.630249};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -1905,7 +2427,7 @@ class items
 				{
 					rank="CORPORAL";
 					init="call{this disableAI ""MOVE"";" \n "this setSpeaker ""NoVoice"";" \n "enableRadio false;}";
-					description="Alpha 1 Assist. autorifleman";
+					description="Alpha 1 Assist. Autorifleman";
 					isPlayable=1;
 					class Inventory
 					{
@@ -1941,14 +2463,14 @@ class items
 								items=1;
 								class Item0
 								{
-									name="SmokeShell";
-									count=4;
-									ammoLeft=1;
+									name="rhs_mag_9x19_17";
+									count=1;
+									ammoLeft=17;
 								};
 							};
 							class ItemCargo
 							{
-								items=7;
+								items=9;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -1961,17 +2483,17 @@ class items
 								};
 								class Item2
 								{
-									name="ACE_morphine";
-									count=1;
+									name="ACE_tourniquet";
+									count=2;
 								};
 								class Item3
 								{
-									name="rhs_acc_2dpZenit";
+									name="ACE_morphine";
 									count=1;
 								};
 								class Item4
 								{
-									name="ACRE_PRC343";
+									name="ACE_epinephrine";
 									count=1;
 								};
 								class Item5
@@ -1984,6 +2506,16 @@ class items
 									name="ACE_MapTools";
 									count=1;
 								};
+								class Item7
+								{
+									name="rhs_acc_2dpZenit";
+									count=1;
+								};
+								class Item8
+								{
+									name="ACRE_PRC343";
+									count=1;
+								};
 							};
 						};
 						class vest
@@ -1992,33 +2524,18 @@ class items
 							isBackpack=0;
 							class MagazineCargo
 							{
-								items=3;
+								items=2;
 								class Item0
 								{
-									name="rhs_mag_9x19_17";
-									count=1;
-									ammoLeft=17;
-								};
-								class Item1
-								{
 									name="rhs_30Rnd_545x39_7N22_plum_AK";
-									count=7;
+									count=8;
 									ammoLeft=30;
 								};
-								class Item2
+								class Item1
 								{
 									name="rhs_30Rnd_545x39_AK_plum_green";
 									count=2;
 									ammoLeft=30;
-								};
-							};
-							class ItemCargo
-							{
-								items=1;
-								class Item0
-								{
-									name="ACE_tourniquet";
-									count=2;
 								};
 							};
 						};
@@ -2031,39 +2548,39 @@ class items
 								items=6;
 								class Item0
 								{
-									name="SmokeShell";
-									count=3;
-									ammoLeft=1;
+									name="rhs_30Rnd_545x39_7N22_plum_AK";
+									count=9;
+									ammoLeft=30;
 								};
 								class Item1
 								{
-									name="SmokeShellGreen";
-									count=2;
-									ammoLeft=1;
+									name="hlc_75Rnd_762x39_m_rpk";
+									count=3;
+									ammoLeft=75;
 								};
 								class Item2
-								{
-									name="SmokeShellBlue";
-									count=1;
-									ammoLeft=1;
-								};
-								class Item3
 								{
 									name="HandGrenade";
 									count=4;
 									ammoLeft=1;
 								};
+								class Item3
+								{
+									name="SmokeShell";
+									count=4;
+									ammoLeft=1;
+								};
 								class Item4
 								{
-									name="rhs_30Rnd_545x39_7N22_plum_AK";
-									count=9;
-									ammoLeft=30;
+									name="SmokeShellGreen";
+									count=2;
+									ammoLeft=1;
 								};
 								class Item5
 								{
-									name="hlc_75Rnd_762x39_m_rpk";
-									count=3;
-									ammoLeft=75;
+									name="SmokeShellBlue";
+									count=1;
+									ammoLeft=1;
 								};
 							};
 							class ItemCargo
@@ -2083,11 +2600,30 @@ class items
 						headgear="rhs_6b27m_green";
 					};
 				};
-				id=164;
+				id=10;
 				type="O_Soldier_AAR_F";
 				class CustomAttributes
 				{
 					class Attribute0
+					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="RED";
+							};
+						};
+					};
+					class Attribute1
 					{
 						property="lambs_danger_disableAI";
 						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
@@ -2106,7 +2642,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
@@ -2125,7 +2661,81 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute3
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute4
+					{
+						property="speaker";
+						expression="_this setspeaker _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="Male01PER";
+							};
+						};
+					};
+					class Attribute5
+					{
+						property="pitch";
+						expression="_this setpitch _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"SCALAR"
+									};
+								};
+								value=1.03;
+							};
+						};
+					};
+					nAttributes=6;
 				};
 			};
 			class Item5
@@ -2133,7 +2743,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-3.2568359,0.0014390945,3.4116211};
+					position[]={-3.3188477,0.0014390945,3.6397705};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -2177,14 +2787,14 @@ class items
 								items=1;
 								class Item0
 								{
-									name="SmokeShell";
-									count=4;
-									ammoLeft=1;
+									name="rhs_mag_9x19_17";
+									count=1;
+									ammoLeft=17;
 								};
 							};
 							class ItemCargo
 							{
-								items=5;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -2197,15 +2807,25 @@ class items
 								};
 								class Item2
 								{
+									name="ACE_tourniquet";
+									count=2;
+								};
+								class Item3
+								{
 									name="ACE_morphine";
 									count=1;
 								};
-								class Item3
+								class Item4
+								{
+									name="ACE_epinephrine";
+									count=1;
+								};
+								class Item5
 								{
 									name="rhs_acc_2dpZenit";
 									count=1;
 								};
-								class Item4
+								class Item6
 								{
 									name="ACRE_PRC343";
 									count=1;
@@ -2221,36 +2841,27 @@ class items
 								items=4;
 								class Item0
 								{
-									name="HandGrenade";
-									count=2;
-									ammoLeft=1;
-								};
-								class Item1
-								{
 									name="rhs_30Rnd_545x39_7N22_plum_AK";
 									count=8;
 									ammoLeft=30;
 								};
-								class Item2
+								class Item1
 								{
 									name="rhs_30Rnd_545x39_AK_plum_green";
 									count=2;
 									ammoLeft=30;
 								};
+								class Item2
+								{
+									name="HandGrenade";
+									count=2;
+									ammoLeft=1;
+								};
 								class Item3
 								{
-									name="rhs_mag_9x19_17";
-									count=1;
-									ammoLeft=17;
-								};
-							};
-							class ItemCargo
-							{
-								items=1;
-								class Item0
-								{
-									name="ACE_tourniquet";
-									count=2;
+									name="SmokeShell";
+									count=4;
+									ammoLeft=1;
 								};
 							};
 						};
@@ -2260,11 +2871,30 @@ class items
 						headgear="rhs_6b27m_green";
 					};
 				};
-				id=165;
+				id=11;
 				type="O_Soldier_LAT_F";
 				class CustomAttributes
 				{
 					class Attribute0
+					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="RED";
+							};
+						};
+					};
+					class Attribute1
 					{
 						property="lambs_danger_disableAI";
 						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
@@ -2283,7 +2913,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
@@ -2302,7 +2932,62 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute3
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute4
+					{
+						property="speaker";
+						expression="_this setspeaker _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="Male01PER";
+							};
+						};
+					};
+					nAttributes=5;
 				};
 			};
 			class Item6
@@ -2310,7 +2995,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-6.2348633,0.0014390945,1.3803711};
+					position[]={-6.2973633,0.0014390945,1.6085205};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -2360,14 +3045,14 @@ class items
 								items=1;
 								class Item0
 								{
-									name="SmokeShell";
-									count=4;
-									ammoLeft=1;
+									name="rhs_mag_9x19_17";
+									count=1;
+									ammoLeft=17;
 								};
 							};
 							class ItemCargo
 							{
-								items=7;
+								items=9;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -2380,17 +3065,17 @@ class items
 								};
 								class Item2
 								{
-									name="ACE_morphine";
-									count=1;
+									name="ACE_tourniquet";
+									count=2;
 								};
 								class Item3
 								{
-									name="rhs_acc_2dpZenit";
+									name="ACE_morphine";
 									count=1;
 								};
 								class Item4
 								{
-									name="ACRE_PRC343";
+									name="ACE_epinephrine";
 									count=1;
 								};
 								class Item5
@@ -2401,6 +3086,16 @@ class items
 								class Item6
 								{
 									name="ACE_MapTools";
+									count=1;
+								};
+								class Item7
+								{
+									name="rhs_acc_2dpZenit";
+									count=1;
+								};
+								class Item8
+								{
+									name="ACRE_PRC343";
 									count=1;
 								};
 							};
@@ -2414,30 +3109,21 @@ class items
 								items=3;
 								class Item0
 								{
-									name="rhs_mag_9x19_17";
-									count=1;
-									ammoLeft=17;
-								};
-								class Item1
-								{
 									name="rhs_30Rnd_545x39_7N22_plum_AK";
 									count=6;
 									ammoLeft=30;
 								};
-								class Item2
+								class Item1
 								{
 									name="rhs_30Rnd_545x39_AK_plum_green";
 									count=4;
 									ammoLeft=30;
 								};
-							};
-							class ItemCargo
-							{
-								items=1;
-								class Item0
+								class Item2
 								{
-									name="ACE_tourniquet";
+									name="HandGrenade";
 									count=2;
+									ammoLeft=1;
 								};
 							};
 						};
@@ -2447,7 +3133,7 @@ class items
 							isBackpack=1;
 							class MagazineCargo
 							{
-								items=7;
+								items=6;
 								class Item0
 								{
 									name="rhs_VOG25";
@@ -2469,7 +3155,7 @@ class items
 								class Item3
 								{
 									name="SmokeShell";
-									count=3;
+									count=7;
 									ammoLeft=1;
 								};
 								class Item4
@@ -2481,12 +3167,6 @@ class items
 								class Item5
 								{
 									name="SmokeShellBlue";
-									count=2;
-									ammoLeft=1;
-								};
-								class Item6
-								{
-									name="HandGrenade";
 									count=2;
 									ammoLeft=1;
 								};
@@ -2508,11 +3188,30 @@ class items
 						headgear="rhs_6b27m_green";
 					};
 				};
-				id=166;
+				id=12;
 				type="O_Soldier_TL_F";
 				class CustomAttributes
 				{
 					class Attribute0
+					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="YELLOW";
+							};
+						};
+					};
+					class Attribute1
 					{
 						property="lambs_danger_disableAI";
 						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
@@ -2531,7 +3230,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
@@ -2550,7 +3249,62 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute3
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute4
+					{
+						property="speaker";
+						expression="_this setspeaker _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="Male02PER";
+							};
+						};
+					};
+					nAttributes=5;
 				};
 			};
 			class Item7
@@ -2558,7 +3312,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-5.2348633,0.0014390945,1.3911133};
+					position[]={-5.2973633,0.0014390945,1.6192627};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -2598,14 +3352,14 @@ class items
 								items=1;
 								class Item0
 								{
-									name="SmokeShell";
-									count=4;
-									ammoLeft=1;
+									name="rhs_mag_9x19_17";
+									count=1;
+									ammoLeft=17;
 								};
 							};
 							class ItemCargo
 							{
-								items=5;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -2618,15 +3372,25 @@ class items
 								};
 								class Item2
 								{
+									name="ACE_tourniquet";
+									count=2;
+								};
+								class Item3
+								{
 									name="ACE_morphine";
 									count=1;
 								};
-								class Item3
+								class Item4
+								{
+									name="ACE_epinephrine";
+									count=1;
+								};
+								class Item5
 								{
 									name="rhs_acc_2dpZenit";
 									count=1;
 								};
-								class Item4
+								class Item6
 								{
 									name="ACRE_PRC343";
 									count=1;
@@ -2639,33 +3403,18 @@ class items
 							isBackpack=0;
 							class MagazineCargo
 							{
-								items=3;
+								items=2;
 								class Item0
 								{
-									name="rhs_mag_9x19_17";
-									count=1;
-									ammoLeft=17;
+									name="hlc_75Rnd_762x39_m_rpk";
+									count=2;
+									ammoLeft=75;
 								};
 								class Item1
 								{
 									name="HandGrenade";
 									count=2;
 									ammoLeft=1;
-								};
-								class Item2
-								{
-									name="hlc_75Rnd_762x39_m_rpk";
-									count=1;
-									ammoLeft=75;
-								};
-							};
-							class ItemCargo
-							{
-								items=1;
-								class Item0
-								{
-									name="ACE_tourniquet";
-									count=2;
 								};
 							};
 						};
@@ -2696,11 +3445,30 @@ class items
 						headgear="rhs_6b27m_green";
 					};
 				};
-				id=167;
+				id=13;
 				type="O_Soldier_AR_F";
 				class CustomAttributes
 				{
 					class Attribute0
+					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="YELLOW";
+							};
+						};
+					};
+					class Attribute1
 					{
 						property="lambs_danger_disableAI";
 						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
@@ -2719,7 +3487,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
@@ -2738,7 +3506,62 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute3
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute4
+					{
+						property="speaker";
+						expression="_this setspeaker _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="Male02PER";
+							};
+						};
+					};
+					nAttributes=5;
 				};
 			};
 			class Item8
@@ -2746,7 +3569,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-4.2348633,0.0014390945,1.4018555};
+					position[]={-4.2973633,0.0014390945,1.630249};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -2755,7 +3578,7 @@ class items
 				{
 					rank="CORPORAL";
 					init="call{this disableAI ""MOVE"";" \n "this setSpeaker ""NoVoice"";" \n "enableRadio false;}";
-					description="Alpha 2 Assist. autorifleman";
+					description="Alpha 2 Assist. Autorifleman";
 					isPlayable=1;
 					class Inventory
 					{
@@ -2791,14 +3614,14 @@ class items
 								items=1;
 								class Item0
 								{
-									name="SmokeShell";
-									count=4;
-									ammoLeft=1;
+									name="rhs_mag_9x19_17";
+									count=1;
+									ammoLeft=17;
 								};
 							};
 							class ItemCargo
 							{
-								items=7;
+								items=9;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -2811,17 +3634,17 @@ class items
 								};
 								class Item2
 								{
-									name="ACE_morphine";
-									count=1;
+									name="ACE_tourniquet";
+									count=2;
 								};
 								class Item3
 								{
-									name="rhs_acc_2dpZenit";
+									name="ACE_morphine";
 									count=1;
 								};
 								class Item4
 								{
-									name="ACRE_PRC343";
+									name="ACE_epinephrine";
 									count=1;
 								};
 								class Item5
@@ -2834,6 +3657,16 @@ class items
 									name="ACE_MapTools";
 									count=1;
 								};
+								class Item7
+								{
+									name="rhs_acc_2dpZenit";
+									count=1;
+								};
+								class Item8
+								{
+									name="ACRE_PRC343";
+									count=1;
+								};
 							};
 						};
 						class vest
@@ -2842,33 +3675,18 @@ class items
 							isBackpack=0;
 							class MagazineCargo
 							{
-								items=3;
+								items=2;
 								class Item0
 								{
-									name="rhs_mag_9x19_17";
-									count=1;
-									ammoLeft=17;
-								};
-								class Item1
-								{
 									name="rhs_30Rnd_545x39_7N22_plum_AK";
-									count=7;
+									count=8;
 									ammoLeft=30;
 								};
-								class Item2
+								class Item1
 								{
 									name="rhs_30Rnd_545x39_AK_plum_green";
 									count=2;
 									ammoLeft=30;
-								};
-							};
-							class ItemCargo
-							{
-								items=1;
-								class Item0
-								{
-									name="ACE_tourniquet";
-									count=2;
 								};
 							};
 						};
@@ -2881,39 +3699,39 @@ class items
 								items=6;
 								class Item0
 								{
-									name="SmokeShell";
-									count=3;
-									ammoLeft=1;
+									name="rhs_30Rnd_545x39_7N22_plum_AK";
+									count=9;
+									ammoLeft=30;
 								};
 								class Item1
 								{
-									name="SmokeShellGreen";
-									count=2;
-									ammoLeft=1;
+									name="hlc_75Rnd_762x39_m_rpk";
+									count=3;
+									ammoLeft=75;
 								};
 								class Item2
-								{
-									name="SmokeShellBlue";
-									count=1;
-									ammoLeft=1;
-								};
-								class Item3
 								{
 									name="HandGrenade";
 									count=4;
 									ammoLeft=1;
 								};
+								class Item3
+								{
+									name="SmokeShell";
+									count=4;
+									ammoLeft=1;
+								};
 								class Item4
 								{
-									name="rhs_30Rnd_545x39_7N22_plum_AK";
-									count=9;
-									ammoLeft=30;
+									name="SmokeShellGreen";
+									count=2;
+									ammoLeft=1;
 								};
 								class Item5
 								{
-									name="hlc_75Rnd_762x39_m_rpk";
-									count=3;
-									ammoLeft=75;
+									name="SmokeShellBlue";
+									count=1;
+									ammoLeft=1;
 								};
 							};
 							class ItemCargo
@@ -2933,11 +3751,30 @@ class items
 						headgear="rhs_6b27m_green_bala";
 					};
 				};
-				id=168;
+				id=14;
 				type="O_Soldier_AAR_F";
 				class CustomAttributes
 				{
 					class Attribute0
+					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="YELLOW";
+							};
+						};
+					};
+					class Attribute1
 					{
 						property="lambs_danger_disableAI";
 						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
@@ -2956,7 +3793,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
@@ -2975,7 +3812,81 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute3
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute4
+					{
+						property="speaker";
+						expression="_this setspeaker _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="Male02PER";
+							};
+						};
+					};
+					class Attribute5
+					{
+						property="pitch";
+						expression="_this setpitch _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"SCALAR"
+									};
+								};
+								value=1.02;
+							};
+						};
+					};
+					nAttributes=6;
 				};
 			};
 			class Item9
@@ -2983,7 +3894,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-3.2348633,0.0014390945,1.4125977};
+					position[]={-3.2973633,0.0014390945,1.6407471};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -3027,14 +3938,14 @@ class items
 								items=1;
 								class Item0
 								{
-									name="SmokeShell";
-									count=4;
-									ammoLeft=1;
+									name="rhs_mag_9x19_17";
+									count=1;
+									ammoLeft=17;
 								};
 							};
 							class ItemCargo
 							{
-								items=5;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -3047,15 +3958,25 @@ class items
 								};
 								class Item2
 								{
+									name="ACE_tourniquet";
+									count=2;
+								};
+								class Item3
+								{
 									name="ACE_morphine";
 									count=1;
 								};
-								class Item3
+								class Item4
+								{
+									name="ACE_epinephrine";
+									count=1;
+								};
+								class Item5
 								{
 									name="rhs_acc_2dpZenit";
 									count=1;
 								};
-								class Item4
+								class Item6
 								{
 									name="ACRE_PRC343";
 									count=1;
@@ -3071,36 +3992,27 @@ class items
 								items=4;
 								class Item0
 								{
-									name="rhs_mag_9x19_17";
-									count=1;
-									ammoLeft=17;
-								};
-								class Item1
-								{
-									name="HandGrenade";
-									count=2;
-									ammoLeft=1;
-								};
-								class Item2
-								{
 									name="rhs_30Rnd_545x39_7N22_plum_AK";
 									count=8;
 									ammoLeft=30;
 								};
-								class Item3
+								class Item1
 								{
 									name="rhs_30Rnd_545x39_AK_plum_green";
 									count=2;
 									ammoLeft=30;
 								};
-							};
-							class ItemCargo
-							{
-								items=1;
-								class Item0
+								class Item2
 								{
-									name="ACE_tourniquet";
+									name="HandGrenade";
 									count=2;
+									ammoLeft=1;
+								};
+								class Item3
+								{
+									name="SmokeShell";
+									count=4;
+									ammoLeft=1;
 								};
 							};
 						};
@@ -3110,11 +4022,30 @@ class items
 						headgear="rhs_6b27m_green_ess";
 					};
 				};
-				id=169;
+				id=15;
 				type="O_Soldier_LAT_F";
 				class CustomAttributes
 				{
 					class Attribute0
+					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="YELLOW";
+							};
+						};
+					};
+					class Attribute1
 					{
 						property="lambs_danger_disableAI";
 						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
@@ -3133,7 +4064,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
@@ -3152,14 +4083,69 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute3
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute4
+					{
+						property="speaker";
+						expression="_this setspeaker _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="Male02PER";
+							};
+						};
+					};
+					nAttributes=5;
 				};
 			};
 		};
 		class Attributes
 		{
 		};
-		id=159;
+		id=5;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -3196,7 +4182,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-1.0688477,0.0014390945,5.8032227};
+					position[]={-1.1313477,0.0014390945,6.03125};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -3246,14 +4232,14 @@ class items
 								items=1;
 								class Item0
 								{
-									name="SmokeShell";
-									count=2;
-									ammoLeft=1;
+									name="rhs_mag_9x19_17";
+									count=1;
+									ammoLeft=17;
 								};
 							};
 							class ItemCargo
 							{
-								items=8;
+								items=9;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -3266,17 +4252,17 @@ class items
 								};
 								class Item2
 								{
-									name="ACE_morphine";
-									count=1;
+									name="ACE_tourniquet";
+									count=2;
 								};
 								class Item3
 								{
-									name="rhs_acc_2dpZenit";
+									name="ACE_morphine";
 									count=1;
 								};
 								class Item4
 								{
-									name="ACRE_PRC343";
+									name="ACE_epinephrine";
 									count=1;
 								};
 								class Item5
@@ -3291,7 +4277,12 @@ class items
 								};
 								class Item7
 								{
-									name="ACRE_PRC152";
+									name="rhs_acc_2dpZenit";
+									count=1;
+								};
+								class Item8
+								{
+									name="ACRE_PRC343";
 									count=1;
 								};
 							};
@@ -3302,39 +4293,24 @@ class items
 							isBackpack=0;
 							class MagazineCargo
 							{
-								items=4;
+								items=3;
 								class Item0
-								{
-									name="SmokeShell";
-									count=2;
-									ammoLeft=1;
-								};
-								class Item1
-								{
-									name="rhs_mag_9x19_17";
-									count=1;
-									ammoLeft=17;
-								};
-								class Item2
 								{
 									name="rhs_30Rnd_545x39_7N22_plum_AK";
 									count=6;
 									ammoLeft=30;
 								};
-								class Item3
+								class Item1
 								{
 									name="rhs_30Rnd_545x39_AK_plum_green";
-									count=3;
+									count=4;
 									ammoLeft=30;
 								};
-							};
-							class ItemCargo
-							{
-								items=1;
-								class Item0
+								class Item2
 								{
-									name="ACE_tourniquet";
+									name="HandGrenade";
 									count=2;
+									ammoLeft=1;
 								};
 							};
 						};
@@ -3344,7 +4320,7 @@ class items
 							isBackpack=1;
 							class MagazineCargo
 							{
-								items=8;
+								items=7;
 								class Item0
 								{
 									name="rhs_VOG25";
@@ -3372,7 +4348,7 @@ class items
 								class Item4
 								{
 									name="SmokeShell";
-									count=3;
+									count=7;
 									ammoLeft=1;
 								};
 								class Item5
@@ -3387,19 +4363,18 @@ class items
 									count=2;
 									ammoLeft=1;
 								};
-								class Item7
-								{
-									name="HandGrenade";
-									count=2;
-									ammoLeft=1;
-								};
 							};
 							class ItemCargo
 							{
-								items=1;
+								items=2;
 								class Item0
 								{
 									name="ACE_IR_Strobe_Item";
+									count=1;
+								};
+								class Item1
+								{
+									name="ACRE_PRC152";
 									count=1;
 								};
 							};
@@ -3408,10 +4383,10 @@ class items
 						compass="ItemCompass";
 						watch="ItemWatch";
 						gps="ItemGPS";
-						headgear="rhs_6b27m_digi_ess";
+						headgear="rhs_6b27m_green_ess_bala";
 					};
 				};
-				id=171;
+				id=17;
 				type="O_Soldier_SL_F";
 				class CustomAttributes
 				{
@@ -3453,7 +4428,95 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=2;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="2";
+										};
+									};
+									class Item1
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute3
+					{
+						property="speaker";
+						expression="_this setspeaker _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="Male03PER";
+							};
+						};
+					};
+					class Attribute4
+					{
+						property="pitch";
+						expression="_this setpitch _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"SCALAR"
+									};
+								};
+								value=1.04;
+							};
+						};
+					};
+					nAttributes=5;
 				};
 			};
 			class Item1
@@ -3461,7 +4524,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-0.067871094,0.0014390945,5.8139648};
+					position[]={-0.13037109,0.0014390945,6.0422363};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -3475,7 +4538,7 @@ class items
 					{
 						class primaryWeapon
 						{
-							name="rhs_weap_aks74u";
+							name="rhs_weap_aks74un";
 							muzzle="rhs_acc_pgs64_74u";
 							class primaryMuzzleMag
 							{
@@ -3501,14 +4564,14 @@ class items
 								items=1;
 								class Item0
 								{
-									name="SmokeShell";
-									count=4;
-									ammoLeft=1;
+									name="rhs_mag_9x19_17";
+									count=1;
+									ammoLeft=17;
 								};
 							};
 							class ItemCargo
 							{
-								items=5;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -3521,15 +4584,25 @@ class items
 								};
 								class Item2
 								{
+									name="ACE_tourniquet";
+									count=2;
+								};
+								class Item3
+								{
 									name="ACE_morphine";
 									count=1;
 								};
-								class Item3
+								class Item4
+								{
+									name="ACE_epinephrine";
+									count=1;
+								};
+								class Item5
 								{
 									name="rhs_acc_2dpZenit";
 									count=1;
 								};
-								class Item4
+								class Item6
 								{
 									name="ACRE_PRC343";
 									count=1;
@@ -3542,39 +4615,24 @@ class items
 							isBackpack=0;
 							class MagazineCargo
 							{
-								items=4;
+								items=3;
 								class Item0
-								{
-									name="rhs_mag_9x19_17";
-									count=1;
-									ammoLeft=17;
-								};
-								class Item1
-								{
-									name="HandGrenade";
-									count=2;
-									ammoLeft=1;
-								};
-								class Item2
 								{
 									name="rhs_30Rnd_545x39_7N22_plum_AK";
 									count=8;
 									ammoLeft=30;
 								};
-								class Item3
+								class Item1
 								{
 									name="rhs_30Rnd_545x39_AK_plum_green";
 									count=2;
 									ammoLeft=30;
 								};
-							};
-							class ItemCargo
-							{
-								items=1;
-								class Item0
+								class Item2
 								{
-									name="ACE_tourniquet";
+									name="HandGrenade";
 									count=2;
+									ammoLeft=1;
 								};
 							};
 						};
@@ -3588,7 +4646,7 @@ class items
 								class Item0
 								{
 									name="SmokeShell";
-									count=8;
+									count=10;
 									ammoLeft=1;
 								};
 								class Item1
@@ -3665,7 +4723,7 @@ class items
 						headgear="rhs_6b27m_green";
 					};
 				};
-				id=172;
+				id=18;
 				type="O_medic_F";
 				class CustomAttributes
 				{
@@ -3707,7 +4765,81 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="2";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute3
+					{
+						property="speaker";
+						expression="_this setspeaker _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="Male01PER";
+							};
+						};
+					};
+					class Attribute4
+					{
+						property="pitch";
+						expression="_this setpitch _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"SCALAR"
+									};
+								};
+								value=1;
+							};
+						};
+					};
+					nAttributes=5;
 				};
 			};
 			class Item2
@@ -3715,7 +4847,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-1.046875,0.0014390945,3.8032227};
+					position[]={-1.1088867,0.0014390945,4.0313721};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -3765,14 +4897,14 @@ class items
 								items=1;
 								class Item0
 								{
-									name="SmokeShell";
-									count=4;
-									ammoLeft=1;
+									name="rhs_mag_9x19_17";
+									count=1;
+									ammoLeft=17;
 								};
 							};
 							class ItemCargo
 							{
-								items=7;
+								items=9;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -3785,17 +4917,17 @@ class items
 								};
 								class Item2
 								{
-									name="ACE_morphine";
-									count=1;
+									name="ACE_tourniquet";
+									count=2;
 								};
 								class Item3
 								{
-									name="rhs_acc_2dpZenit";
+									name="ACE_morphine";
 									count=1;
 								};
 								class Item4
 								{
-									name="ACRE_PRC343";
+									name="ACE_epinephrine";
 									count=1;
 								};
 								class Item5
@@ -3806,6 +4938,16 @@ class items
 								class Item6
 								{
 									name="ACE_MapTools";
+									count=1;
+								};
+								class Item7
+								{
+									name="rhs_acc_2dpZenit";
+									count=1;
+								};
+								class Item8
+								{
+									name="ACRE_PRC343";
 									count=1;
 								};
 							};
@@ -3819,30 +4961,21 @@ class items
 								items=3;
 								class Item0
 								{
-									name="rhs_mag_9x19_17";
-									count=1;
-									ammoLeft=17;
-								};
-								class Item1
-								{
 									name="rhs_30Rnd_545x39_7N22_plum_AK";
 									count=6;
 									ammoLeft=30;
 								};
-								class Item2
+								class Item1
 								{
 									name="rhs_30Rnd_545x39_AK_plum_green";
 									count=4;
 									ammoLeft=30;
 								};
-							};
-							class ItemCargo
-							{
-								items=1;
-								class Item0
+								class Item2
 								{
-									name="ACE_tourniquet";
+									name="HandGrenade";
 									count=2;
+									ammoLeft=1;
 								};
 							};
 						};
@@ -3852,7 +4985,7 @@ class items
 							isBackpack=1;
 							class MagazineCargo
 							{
-								items=7;
+								items=6;
 								class Item0
 								{
 									name="rhs_VOG25";
@@ -3874,7 +5007,7 @@ class items
 								class Item3
 								{
 									name="SmokeShell";
-									count=3;
+									count=7;
 									ammoLeft=1;
 								};
 								class Item4
@@ -3886,12 +5019,6 @@ class items
 								class Item5
 								{
 									name="SmokeShellBlue";
-									count=2;
-									ammoLeft=1;
-								};
-								class Item6
-								{
-									name="HandGrenade";
 									count=2;
 									ammoLeft=1;
 								};
@@ -3913,11 +5040,30 @@ class items
 						headgear="rhs_6b27m_green";
 					};
 				};
-				id=173;
+				id=19;
 				type="O_Soldier_TL_F";
 				class CustomAttributes
 				{
 					class Attribute0
+					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="BLUE";
+							};
+						};
+					};
+					class Attribute1
 					{
 						property="lambs_danger_disableAI";
 						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
@@ -3936,7 +5082,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
@@ -3955,7 +5101,43 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute3
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="2";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=4;
 				};
 			};
 			class Item3
@@ -3963,7 +5145,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-0.046875,0.0014390945,3.8139648};
+					position[]={-0.10888672,0.0014390945,4.0421143};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -4003,14 +5185,14 @@ class items
 								items=1;
 								class Item0
 								{
-									name="SmokeShell";
-									count=4;
-									ammoLeft=1;
+									name="rhs_mag_9x19_17";
+									count=1;
+									ammoLeft=17;
 								};
 							};
 							class ItemCargo
 							{
-								items=5;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -4023,15 +5205,25 @@ class items
 								};
 								class Item2
 								{
+									name="ACE_tourniquet";
+									count=2;
+								};
+								class Item3
+								{
 									name="ACE_morphine";
 									count=1;
 								};
-								class Item3
+								class Item4
+								{
+									name="ACE_epinephrine";
+									count=1;
+								};
+								class Item5
 								{
 									name="rhs_acc_2dpZenit";
 									count=1;
 								};
-								class Item4
+								class Item6
 								{
 									name="ACRE_PRC343";
 									count=1;
@@ -4044,33 +5236,18 @@ class items
 							isBackpack=0;
 							class MagazineCargo
 							{
-								items=3;
+								items=2;
 								class Item0
 								{
-									name="rhs_mag_9x19_17";
-									count=1;
-									ammoLeft=17;
+									name="hlc_75Rnd_762x39_m_rpk";
+									count=2;
+									ammoLeft=75;
 								};
 								class Item1
 								{
 									name="HandGrenade";
 									count=2;
 									ammoLeft=1;
-								};
-								class Item2
-								{
-									name="hlc_75Rnd_762x39_m_rpk";
-									count=1;
-									ammoLeft=75;
-								};
-							};
-							class ItemCargo
-							{
-								items=1;
-								class Item0
-								{
-									name="ACE_tourniquet";
-									count=2;
 								};
 							};
 						};
@@ -4101,11 +5278,30 @@ class items
 						headgear="rhs_6b27m_green";
 					};
 				};
-				id=174;
+				id=20;
 				type="O_Soldier_AR_F";
 				class CustomAttributes
 				{
 					class Attribute0
+					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="BLUE";
+							};
+						};
+					};
+					class Attribute1
 					{
 						property="lambs_danger_disableAI";
 						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
@@ -4124,7 +5320,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
@@ -4143,7 +5339,43 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute3
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="2";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=4;
 				};
 			};
 			class Item4
@@ -4151,7 +5383,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={0.953125,0.0014390945,3.8237305};
+					position[]={0.890625,0.0014390945,4.0522461};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -4160,7 +5392,7 @@ class items
 				{
 					rank="CORPORAL";
 					init="call{this disableAI ""MOVE"";" \n "this setSpeaker ""NoVoice"";" \n "enableRadio false;}";
-					description="Bravo 1 Assist. autorifleman";
+					description="Bravo 1 Assist. Autorifleman";
 					isPlayable=1;
 					class Inventory
 					{
@@ -4196,14 +5428,14 @@ class items
 								items=1;
 								class Item0
 								{
-									name="SmokeShell";
-									count=4;
-									ammoLeft=1;
+									name="rhs_mag_9x19_17";
+									count=1;
+									ammoLeft=17;
 								};
 							};
 							class ItemCargo
 							{
-								items=7;
+								items=9;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -4216,17 +5448,17 @@ class items
 								};
 								class Item2
 								{
-									name="ACE_morphine";
-									count=1;
+									name="ACE_tourniquet";
+									count=2;
 								};
 								class Item3
 								{
-									name="rhs_acc_2dpZenit";
+									name="ACE_morphine";
 									count=1;
 								};
 								class Item4
 								{
-									name="ACRE_PRC343";
+									name="ACE_epinephrine";
 									count=1;
 								};
 								class Item5
@@ -4239,6 +5471,16 @@ class items
 									name="ACE_MapTools";
 									count=1;
 								};
+								class Item7
+								{
+									name="rhs_acc_2dpZenit";
+									count=1;
+								};
+								class Item8
+								{
+									name="ACRE_PRC343";
+									count=1;
+								};
 							};
 						};
 						class vest
@@ -4247,33 +5489,18 @@ class items
 							isBackpack=0;
 							class MagazineCargo
 							{
-								items=3;
+								items=2;
 								class Item0
 								{
-									name="rhs_mag_9x19_17";
-									count=1;
-									ammoLeft=17;
-								};
-								class Item1
-								{
 									name="rhs_30Rnd_545x39_7N22_plum_AK";
-									count=7;
+									count=8;
 									ammoLeft=30;
 								};
-								class Item2
+								class Item1
 								{
 									name="rhs_30Rnd_545x39_AK_plum_green";
 									count=2;
 									ammoLeft=30;
-								};
-							};
-							class ItemCargo
-							{
-								items=1;
-								class Item0
-								{
-									name="ACE_tourniquet";
-									count=2;
 								};
 							};
 						};
@@ -4286,39 +5513,39 @@ class items
 								items=6;
 								class Item0
 								{
-									name="SmokeShell";
-									count=3;
-									ammoLeft=1;
+									name="rhs_30Rnd_545x39_7N22_plum_AK";
+									count=9;
+									ammoLeft=30;
 								};
 								class Item1
 								{
-									name="SmokeShellGreen";
-									count=2;
-									ammoLeft=1;
+									name="hlc_75Rnd_762x39_m_rpk";
+									count=3;
+									ammoLeft=75;
 								};
 								class Item2
-								{
-									name="SmokeShellBlue";
-									count=1;
-									ammoLeft=1;
-								};
-								class Item3
 								{
 									name="HandGrenade";
 									count=4;
 									ammoLeft=1;
 								};
+								class Item3
+								{
+									name="SmokeShell";
+									count=4;
+									ammoLeft=1;
+								};
 								class Item4
 								{
-									name="rhs_30Rnd_545x39_7N22_plum_AK";
-									count=9;
-									ammoLeft=30;
+									name="SmokeShellGreen";
+									count=2;
+									ammoLeft=1;
 								};
 								class Item5
 								{
-									name="hlc_75Rnd_762x39_m_rpk";
-									count=3;
-									ammoLeft=75;
+									name="SmokeShellBlue";
+									count=1;
+									ammoLeft=1;
 								};
 							};
 							class ItemCargo
@@ -4338,11 +5565,30 @@ class items
 						headgear="rhs_6b27m_green_bala";
 					};
 				};
-				id=175;
+				id=21;
 				type="O_Soldier_AAR_F";
 				class CustomAttributes
 				{
 					class Attribute0
+					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="BLUE";
+							};
+						};
+					};
+					class Attribute1
 					{
 						property="lambs_danger_disableAI";
 						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
@@ -4361,7 +5607,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
@@ -4380,7 +5626,81 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute3
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="2";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute4
+					{
+						property="speaker";
+						expression="_this setspeaker _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="Male02PER";
+							};
+						};
+					};
+					class Attribute5
+					{
+						property="pitch";
+						expression="_this setpitch _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"SCALAR"
+									};
+								};
+								value=0.98000002;
+							};
+						};
+					};
+					nAttributes=6;
 				};
 			};
 			class Item5
@@ -4388,7 +5708,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={1.953125,0.0014390945,3.8354492};
+					position[]={1.8911133,0.0014390945,4.0635986};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -4432,14 +5752,14 @@ class items
 								items=1;
 								class Item0
 								{
-									name="SmokeShell";
-									count=4;
-									ammoLeft=1;
+									name="rhs_mag_9x19_17";
+									count=1;
+									ammoLeft=17;
 								};
 							};
 							class ItemCargo
 							{
-								items=5;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -4452,15 +5772,25 @@ class items
 								};
 								class Item2
 								{
+									name="ACE_tourniquet";
+									count=2;
+								};
+								class Item3
+								{
 									name="ACE_morphine";
 									count=1;
 								};
-								class Item3
+								class Item4
+								{
+									name="ACE_epinephrine";
+									count=1;
+								};
+								class Item5
 								{
 									name="rhs_acc_2dpZenit";
 									count=1;
 								};
-								class Item4
+								class Item6
 								{
 									name="ACRE_PRC343";
 									count=1;
@@ -4476,36 +5806,27 @@ class items
 								items=4;
 								class Item0
 								{
-									name="rhs_mag_9x19_17";
-									count=1;
-									ammoLeft=17;
-								};
-								class Item1
-								{
-									name="HandGrenade";
-									count=2;
-									ammoLeft=1;
-								};
-								class Item2
-								{
 									name="rhs_30Rnd_545x39_7N22_plum_AK";
 									count=8;
 									ammoLeft=30;
 								};
-								class Item3
+								class Item1
 								{
 									name="rhs_30Rnd_545x39_AK_plum_green";
 									count=2;
 									ammoLeft=30;
 								};
-							};
-							class ItemCargo
-							{
-								items=1;
-								class Item0
+								class Item2
 								{
-									name="ACE_tourniquet";
+									name="HandGrenade";
 									count=2;
+									ammoLeft=1;
+								};
+								class Item3
+								{
+									name="SmokeShell";
+									count=4;
+									ammoLeft=1;
 								};
 							};
 						};
@@ -4515,11 +5836,30 @@ class items
 						headgear="rhs_6b27m_green_ess";
 					};
 				};
-				id=176;
+				id=22;
 				type="O_Soldier_LAT_F";
 				class CustomAttributes
 				{
 					class Attribute0
+					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="BLUE";
+							};
+						};
+					};
+					class Attribute1
 					{
 						property="lambs_danger_disableAI";
 						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
@@ -4538,7 +5878,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
@@ -4557,7 +5897,43 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute3
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="2";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=4;
 				};
 			};
 			class Item6
@@ -4565,7 +5941,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-1.0249023,0.0014390945,1.8032227};
+					position[]={-1.0874023,0.0014390945,2.0313721};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -4615,14 +5991,14 @@ class items
 								items=1;
 								class Item0
 								{
-									name="SmokeShell";
-									count=4;
-									ammoLeft=1;
+									name="rhs_mag_9x19_17";
+									count=1;
+									ammoLeft=17;
 								};
 							};
 							class ItemCargo
 							{
-								items=7;
+								items=9;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -4635,17 +6011,17 @@ class items
 								};
 								class Item2
 								{
-									name="ACE_morphine";
-									count=1;
+									name="ACE_tourniquet";
+									count=2;
 								};
 								class Item3
 								{
-									name="rhs_acc_2dpZenit";
+									name="ACE_morphine";
 									count=1;
 								};
 								class Item4
 								{
-									name="ACRE_PRC343";
+									name="ACE_epinephrine";
 									count=1;
 								};
 								class Item5
@@ -4656,6 +6032,16 @@ class items
 								class Item6
 								{
 									name="ACE_MapTools";
+									count=1;
+								};
+								class Item7
+								{
+									name="rhs_acc_2dpZenit";
+									count=1;
+								};
+								class Item8
+								{
+									name="ACRE_PRC343";
 									count=1;
 								};
 							};
@@ -4669,30 +6055,21 @@ class items
 								items=3;
 								class Item0
 								{
-									name="rhs_mag_9x19_17";
-									count=1;
-									ammoLeft=17;
-								};
-								class Item1
-								{
 									name="rhs_30Rnd_545x39_7N22_plum_AK";
 									count=6;
 									ammoLeft=30;
 								};
-								class Item2
+								class Item1
 								{
 									name="rhs_30Rnd_545x39_AK_plum_green";
 									count=4;
 									ammoLeft=30;
 								};
-							};
-							class ItemCargo
-							{
-								items=1;
-								class Item0
+								class Item2
 								{
-									name="ACE_tourniquet";
+									name="HandGrenade";
 									count=2;
+									ammoLeft=1;
 								};
 							};
 						};
@@ -4702,7 +6079,7 @@ class items
 							isBackpack=1;
 							class MagazineCargo
 							{
-								items=7;
+								items=6;
 								class Item0
 								{
 									name="rhs_VOG25";
@@ -4724,7 +6101,7 @@ class items
 								class Item3
 								{
 									name="SmokeShell";
-									count=3;
+									count=7;
 									ammoLeft=1;
 								};
 								class Item4
@@ -4736,12 +6113,6 @@ class items
 								class Item5
 								{
 									name="SmokeShellBlue";
-									count=2;
-									ammoLeft=1;
-								};
-								class Item6
-								{
-									name="HandGrenade";
 									count=2;
 									ammoLeft=1;
 								};
@@ -4763,11 +6134,30 @@ class items
 						headgear="rhs_6b27m_green_bala";
 					};
 				};
-				id=177;
+				id=23;
 				type="O_Soldier_TL_F";
 				class CustomAttributes
 				{
 					class Attribute0
+					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="GREEN";
+							};
+						};
+					};
+					class Attribute1
 					{
 						property="lambs_danger_disableAI";
 						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
@@ -4786,7 +6176,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
@@ -4805,7 +6195,43 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute3
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="2";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=4;
 				};
 			};
 			class Item7
@@ -4813,7 +6239,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-0.024902344,0.0014390945,1.8139648};
+					position[]={-0.087402344,0.0014390945,2.0421143};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -4853,14 +6279,14 @@ class items
 								items=1;
 								class Item0
 								{
-									name="SmokeShell";
-									count=4;
-									ammoLeft=1;
+									name="rhs_mag_9x19_17";
+									count=1;
+									ammoLeft=17;
 								};
 							};
 							class ItemCargo
 							{
-								items=5;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -4873,15 +6299,25 @@ class items
 								};
 								class Item2
 								{
+									name="ACE_tourniquet";
+									count=2;
+								};
+								class Item3
+								{
 									name="ACE_morphine";
 									count=1;
 								};
-								class Item3
+								class Item4
+								{
+									name="ACE_epinephrine";
+									count=1;
+								};
+								class Item5
 								{
 									name="rhs_acc_2dpZenit";
 									count=1;
 								};
-								class Item4
+								class Item6
 								{
 									name="ACRE_PRC343";
 									count=1;
@@ -4894,33 +6330,18 @@ class items
 							isBackpack=0;
 							class MagazineCargo
 							{
-								items=3;
+								items=2;
 								class Item0
 								{
-									name="rhs_mag_9x19_17";
-									count=1;
-									ammoLeft=17;
+									name="hlc_75Rnd_762x39_m_rpk";
+									count=2;
+									ammoLeft=75;
 								};
 								class Item1
 								{
 									name="HandGrenade";
 									count=2;
 									ammoLeft=1;
-								};
-								class Item2
-								{
-									name="hlc_75Rnd_762x39_m_rpk";
-									count=1;
-									ammoLeft=75;
-								};
-							};
-							class ItemCargo
-							{
-								items=1;
-								class Item0
-								{
-									name="ACE_tourniquet";
-									count=2;
 								};
 							};
 						};
@@ -4951,11 +6372,30 @@ class items
 						headgear="rhs_6b27m_green_ess";
 					};
 				};
-				id=178;
+				id=24;
 				type="O_Soldier_AR_F";
 				class CustomAttributes
 				{
 					class Attribute0
+					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="GREEN";
+							};
+						};
+					};
+					class Attribute1
 					{
 						property="lambs_danger_disableAI";
 						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
@@ -4974,7 +6414,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
@@ -4993,7 +6433,43 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute3
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="2";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=4;
 				};
 			};
 			class Item8
@@ -5001,7 +6477,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={0.97509766,0.0014390945,1.8237305};
+					position[]={0.91259766,0.0014390945,2.0522461};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -5010,7 +6486,7 @@ class items
 				{
 					rank="CORPORAL";
 					init="call{this disableAI ""MOVE"";" \n "this setSpeaker ""NoVoice"";" \n "enableRadio false;}";
-					description="Bravo 2 Assist. autorifleman";
+					description="Bravo 2 Assist. Autorifleman";
 					isPlayable=1;
 					class Inventory
 					{
@@ -5046,14 +6522,14 @@ class items
 								items=1;
 								class Item0
 								{
-									name="SmokeShell";
-									count=4;
-									ammoLeft=1;
+									name="rhs_mag_9x19_17";
+									count=1;
+									ammoLeft=17;
 								};
 							};
 							class ItemCargo
 							{
-								items=7;
+								items=9;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -5066,17 +6542,17 @@ class items
 								};
 								class Item2
 								{
-									name="ACE_morphine";
-									count=1;
+									name="ACE_tourniquet";
+									count=2;
 								};
 								class Item3
 								{
-									name="rhs_acc_2dpZenit";
+									name="ACE_morphine";
 									count=1;
 								};
 								class Item4
 								{
-									name="ACRE_PRC343";
+									name="ACE_epinephrine";
 									count=1;
 								};
 								class Item5
@@ -5089,6 +6565,16 @@ class items
 									name="ACE_MapTools";
 									count=1;
 								};
+								class Item7
+								{
+									name="rhs_acc_2dpZenit";
+									count=1;
+								};
+								class Item8
+								{
+									name="ACRE_PRC343";
+									count=1;
+								};
 							};
 						};
 						class vest
@@ -5097,33 +6583,18 @@ class items
 							isBackpack=0;
 							class MagazineCargo
 							{
-								items=3;
+								items=2;
 								class Item0
 								{
-									name="rhs_mag_9x19_17";
-									count=1;
-									ammoLeft=17;
-								};
-								class Item1
-								{
 									name="rhs_30Rnd_545x39_7N22_plum_AK";
-									count=7;
+									count=8;
 									ammoLeft=30;
 								};
-								class Item2
+								class Item1
 								{
 									name="rhs_30Rnd_545x39_AK_plum_green";
 									count=2;
 									ammoLeft=30;
-								};
-							};
-							class ItemCargo
-							{
-								items=1;
-								class Item0
-								{
-									name="ACE_tourniquet";
-									count=2;
 								};
 							};
 						};
@@ -5136,39 +6607,39 @@ class items
 								items=6;
 								class Item0
 								{
-									name="SmokeShell";
-									count=3;
-									ammoLeft=1;
+									name="rhs_30Rnd_545x39_7N22_plum_AK";
+									count=9;
+									ammoLeft=30;
 								};
 								class Item1
 								{
-									name="SmokeShellGreen";
-									count=2;
-									ammoLeft=1;
+									name="hlc_75Rnd_762x39_m_rpk";
+									count=3;
+									ammoLeft=75;
 								};
 								class Item2
-								{
-									name="SmokeShellBlue";
-									count=1;
-									ammoLeft=1;
-								};
-								class Item3
 								{
 									name="HandGrenade";
 									count=4;
 									ammoLeft=1;
 								};
+								class Item3
+								{
+									name="SmokeShell";
+									count=4;
+									ammoLeft=1;
+								};
 								class Item4
 								{
-									name="rhs_30Rnd_545x39_7N22_plum_AK";
-									count=9;
-									ammoLeft=30;
+									name="SmokeShellGreen";
+									count=2;
+									ammoLeft=1;
 								};
 								class Item5
 								{
-									name="hlc_75Rnd_762x39_m_rpk";
-									count=3;
-									ammoLeft=75;
+									name="SmokeShellBlue";
+									count=1;
+									ammoLeft=1;
 								};
 							};
 							class ItemCargo
@@ -5188,11 +6659,30 @@ class items
 						headgear="rhs_6b27m_green";
 					};
 				};
-				id=179;
+				id=25;
 				type="O_Soldier_AAR_F";
 				class CustomAttributes
 				{
 					class Attribute0
+					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="GREEN";
+							};
+						};
+					};
+					class Attribute1
 					{
 						property="lambs_danger_disableAI";
 						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
@@ -5211,7 +6701,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
@@ -5230,7 +6720,81 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute3
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="2";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute4
+					{
+						property="speaker";
+						expression="_this setspeaker _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="Male02PER";
+							};
+						};
+					};
+					class Attribute5
+					{
+						property="pitch";
+						expression="_this setpitch _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"SCALAR"
+									};
+								};
+								value=0.99000001;
+							};
+						};
+					};
+					nAttributes=6;
 				};
 			};
 			class Item9
@@ -5238,7 +6802,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={1.9750977,0.0014390945,1.8354492};
+					position[]={1.9125977,0.0014390945,2.0635986};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -5282,14 +6846,14 @@ class items
 								items=1;
 								class Item0
 								{
-									name="SmokeShell";
-									count=4;
-									ammoLeft=1;
+									name="rhs_mag_9x19_17";
+									count=1;
+									ammoLeft=17;
 								};
 							};
 							class ItemCargo
 							{
-								items=5;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -5302,15 +6866,25 @@ class items
 								};
 								class Item2
 								{
+									name="ACE_tourniquet";
+									count=2;
+								};
+								class Item3
+								{
 									name="ACE_morphine";
 									count=1;
 								};
-								class Item3
+								class Item4
+								{
+									name="ACE_epinephrine";
+									count=1;
+								};
+								class Item5
 								{
 									name="rhs_acc_2dpZenit";
 									count=1;
 								};
-								class Item4
+								class Item6
 								{
 									name="ACRE_PRC343";
 									count=1;
@@ -5326,36 +6900,27 @@ class items
 								items=4;
 								class Item0
 								{
-									name="HandGrenade";
-									count=2;
-									ammoLeft=1;
-								};
-								class Item1
-								{
 									name="rhs_30Rnd_545x39_7N22_plum_AK";
 									count=8;
 									ammoLeft=30;
 								};
-								class Item2
+								class Item1
 								{
 									name="rhs_30Rnd_545x39_AK_plum_green";
 									count=2;
 									ammoLeft=30;
 								};
+								class Item2
+								{
+									name="HandGrenade";
+									count=2;
+									ammoLeft=1;
+								};
 								class Item3
 								{
-									name="rhs_mag_9x19_17";
-									count=1;
-									ammoLeft=17;
-								};
-							};
-							class ItemCargo
-							{
-								items=1;
-								class Item0
-								{
-									name="ACE_tourniquet";
-									count=2;
+									name="SmokeShell";
+									count=4;
+									ammoLeft=1;
 								};
 							};
 						};
@@ -5365,11 +6930,30 @@ class items
 						headgear="rhs_6b27m_green";
 					};
 				};
-				id=180;
+				id=26;
 				type="O_Soldier_LAT_F";
 				class CustomAttributes
 				{
 					class Attribute0
+					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="GREEN";
+							};
+						};
+					};
+					class Attribute1
 					{
 						property="lambs_danger_disableAI";
 						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
@@ -5388,7 +6972,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
@@ -5407,14 +6991,50 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute3
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="2";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=4;
 				};
 			};
 		};
 		class Attributes
 		{
 		};
-		id=170;
+		id=16;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -5451,7 +7071,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={4.3393555,0.0014390945,6.3276367};
+					position[]={4.2768555,0.0014390945,6.5562744};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -5501,14 +7121,14 @@ class items
 								items=1;
 								class Item0
 								{
-									name="SmokeShell";
-									count=2;
-									ammoLeft=1;
+									name="rhs_mag_9x19_17";
+									count=1;
+									ammoLeft=17;
 								};
 							};
 							class ItemCargo
 							{
-								items=8;
+								items=9;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -5521,17 +7141,17 @@ class items
 								};
 								class Item2
 								{
-									name="ACE_morphine";
-									count=1;
+									name="ACE_tourniquet";
+									count=2;
 								};
 								class Item3
 								{
-									name="rhs_acc_2dpZenit";
+									name="ACE_morphine";
 									count=1;
 								};
 								class Item4
 								{
-									name="ACRE_PRC343";
+									name="ACE_epinephrine";
 									count=1;
 								};
 								class Item5
@@ -5546,7 +7166,12 @@ class items
 								};
 								class Item7
 								{
-									name="ACRE_PRC152";
+									name="rhs_acc_2dpZenit";
+									count=1;
+								};
+								class Item8
+								{
+									name="ACRE_PRC343";
 									count=1;
 								};
 							};
@@ -5557,39 +7182,24 @@ class items
 							isBackpack=0;
 							class MagazineCargo
 							{
-								items=4;
+								items=3;
 								class Item0
-								{
-									name="SmokeShell";
-									count=2;
-									ammoLeft=1;
-								};
-								class Item1
-								{
-									name="rhs_mag_9x19_17";
-									count=1;
-									ammoLeft=17;
-								};
-								class Item2
 								{
 									name="rhs_30Rnd_545x39_7N22_plum_AK";
 									count=6;
 									ammoLeft=30;
 								};
-								class Item3
+								class Item1
 								{
 									name="rhs_30Rnd_545x39_AK_plum_green";
-									count=3;
+									count=4;
 									ammoLeft=30;
 								};
-							};
-							class ItemCargo
-							{
-								items=1;
-								class Item0
+								class Item2
 								{
-									name="ACE_tourniquet";
+									name="HandGrenade";
 									count=2;
+									ammoLeft=1;
 								};
 							};
 						};
@@ -5599,7 +7209,7 @@ class items
 							isBackpack=1;
 							class MagazineCargo
 							{
-								items=8;
+								items=7;
 								class Item0
 								{
 									name="rhs_VOG25";
@@ -5627,7 +7237,7 @@ class items
 								class Item4
 								{
 									name="SmokeShell";
-									count=3;
+									count=7;
 									ammoLeft=1;
 								};
 								class Item5
@@ -5642,19 +7252,18 @@ class items
 									count=2;
 									ammoLeft=1;
 								};
-								class Item7
-								{
-									name="HandGrenade";
-									count=2;
-									ammoLeft=1;
-								};
 							};
 							class ItemCargo
 							{
-								items=1;
+								items=2;
 								class Item0
 								{
 									name="ACE_IR_Strobe_Item";
+									count=1;
+								};
+								class Item1
+								{
+									name="ACRE_PRC152";
 									count=1;
 								};
 							};
@@ -5663,10 +7272,10 @@ class items
 						compass="ItemCompass";
 						watch="ItemWatch";
 						gps="ItemGPS";
-						headgear="rhs_6b27m_digi_ess";
+						headgear="rhs_6b27m_green_ess_bala";
 					};
 				};
-				id=182;
+				id=28;
 				type="O_Soldier_SL_F";
 				class CustomAttributes
 				{
@@ -5708,7 +7317,95 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=2;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="3";
+										};
+									};
+									class Item1
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute3
+					{
+						property="speaker";
+						expression="_this setspeaker _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="Male01PER";
+							};
+						};
+					};
+					class Attribute4
+					{
+						property="pitch";
+						expression="_this setpitch _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"SCALAR"
+									};
+								};
+								value=1.04;
+							};
+						};
+					};
+					nAttributes=5;
 				};
 			};
 			class Item1
@@ -5716,7 +7413,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={5.3383789,0.0014390945,6.3393555};
+					position[]={5.2758789,0.0014390945,6.5672607};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -5730,7 +7427,7 @@ class items
 					{
 						class primaryWeapon
 						{
-							name="rhs_weap_aks74u";
+							name="rhs_weap_aks74un";
 							muzzle="rhs_acc_pgs64_74u";
 							class primaryMuzzleMag
 							{
@@ -5756,14 +7453,14 @@ class items
 								items=1;
 								class Item0
 								{
-									name="SmokeShell";
-									count=4;
-									ammoLeft=1;
+									name="rhs_mag_9x19_17";
+									count=1;
+									ammoLeft=17;
 								};
 							};
 							class ItemCargo
 							{
-								items=5;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -5776,15 +7473,25 @@ class items
 								};
 								class Item2
 								{
+									name="ACE_tourniquet";
+									count=2;
+								};
+								class Item3
+								{
 									name="ACE_morphine";
 									count=1;
 								};
-								class Item3
+								class Item4
+								{
+									name="ACE_epinephrine";
+									count=1;
+								};
+								class Item5
 								{
 									name="rhs_acc_2dpZenit";
 									count=1;
 								};
-								class Item4
+								class Item6
 								{
 									name="ACRE_PRC343";
 									count=1;
@@ -5797,39 +7504,24 @@ class items
 							isBackpack=0;
 							class MagazineCargo
 							{
-								items=4;
+								items=3;
 								class Item0
-								{
-									name="rhs_mag_9x19_17";
-									count=1;
-									ammoLeft=17;
-								};
-								class Item1
-								{
-									name="HandGrenade";
-									count=2;
-									ammoLeft=1;
-								};
-								class Item2
 								{
 									name="rhs_30Rnd_545x39_7N22_plum_AK";
 									count=8;
 									ammoLeft=30;
 								};
-								class Item3
+								class Item1
 								{
 									name="rhs_30Rnd_545x39_AK_plum_green";
 									count=2;
 									ammoLeft=30;
 								};
-							};
-							class ItemCargo
-							{
-								items=1;
-								class Item0
+								class Item2
 								{
-									name="ACE_tourniquet";
+									name="HandGrenade";
 									count=2;
+									ammoLeft=1;
 								};
 							};
 						};
@@ -5843,7 +7535,7 @@ class items
 								class Item0
 								{
 									name="SmokeShell";
-									count=8;
+									count=10;
 									ammoLeft=1;
 								};
 								class Item1
@@ -5920,7 +7612,7 @@ class items
 						headgear="rhs_6b27m_green";
 					};
 				};
-				id=183;
+				id=29;
 				type="O_medic_F";
 				class CustomAttributes
 				{
@@ -5962,7 +7654,81 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="3";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute3
+					{
+						property="speaker";
+						expression="_this setspeaker _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="Male03PER";
+							};
+						};
+					};
+					class Attribute4
+					{
+						property="pitch";
+						expression="_this setpitch _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"SCALAR"
+									};
+								};
+								value=0.94999999;
+							};
+						};
+					};
+					nAttributes=5;
 				};
 			};
 			class Item2
@@ -5970,7 +7736,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={4.3603516,0.0014390945,4.3276367};
+					position[]={4.2988281,0.0014390945,4.5562744};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -6020,14 +7786,14 @@ class items
 								items=1;
 								class Item0
 								{
-									name="SmokeShell";
-									count=4;
-									ammoLeft=1;
+									name="rhs_mag_9x19_17";
+									count=1;
+									ammoLeft=17;
 								};
 							};
 							class ItemCargo
 							{
-								items=7;
+								items=9;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -6040,17 +7806,17 @@ class items
 								};
 								class Item2
 								{
-									name="ACE_morphine";
-									count=1;
+									name="ACE_tourniquet";
+									count=2;
 								};
 								class Item3
 								{
-									name="rhs_acc_2dpZenit";
+									name="ACE_morphine";
 									count=1;
 								};
 								class Item4
 								{
-									name="ACRE_PRC343";
+									name="ACE_epinephrine";
 									count=1;
 								};
 								class Item5
@@ -6061,6 +7827,16 @@ class items
 								class Item6
 								{
 									name="ACE_MapTools";
+									count=1;
+								};
+								class Item7
+								{
+									name="rhs_acc_2dpZenit";
+									count=1;
+								};
+								class Item8
+								{
+									name="ACRE_PRC343";
 									count=1;
 								};
 							};
@@ -6074,30 +7850,21 @@ class items
 								items=3;
 								class Item0
 								{
-									name="rhs_mag_9x19_17";
-									count=1;
-									ammoLeft=17;
-								};
-								class Item1
-								{
 									name="rhs_30Rnd_545x39_7N22_plum_AK";
 									count=6;
 									ammoLeft=30;
 								};
-								class Item2
+								class Item1
 								{
 									name="rhs_30Rnd_545x39_AK_plum_green";
 									count=4;
 									ammoLeft=30;
 								};
-							};
-							class ItemCargo
-							{
-								items=1;
-								class Item0
+								class Item2
 								{
-									name="ACE_tourniquet";
+									name="HandGrenade";
 									count=2;
+									ammoLeft=1;
 								};
 							};
 						};
@@ -6107,7 +7874,7 @@ class items
 							isBackpack=1;
 							class MagazineCargo
 							{
-								items=7;
+								items=6;
 								class Item0
 								{
 									name="rhs_VOG25";
@@ -6129,7 +7896,7 @@ class items
 								class Item3
 								{
 									name="SmokeShell";
-									count=3;
+									count=7;
 									ammoLeft=1;
 								};
 								class Item4
@@ -6141,12 +7908,6 @@ class items
 								class Item5
 								{
 									name="SmokeShellBlue";
-									count=2;
-									ammoLeft=1;
-								};
-								class Item6
-								{
-									name="HandGrenade";
 									count=2;
 									ammoLeft=1;
 								};
@@ -6168,11 +7929,30 @@ class items
 						headgear="rhs_6b27m_green_bala";
 					};
 				};
-				id=184;
+				id=30;
 				type="O_Soldier_TL_F";
 				class CustomAttributes
 				{
 					class Attribute0
+					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="RED";
+							};
+						};
+					};
+					class Attribute1
 					{
 						property="lambs_danger_disableAI";
 						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
@@ -6191,7 +7971,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
@@ -6210,7 +7990,81 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute3
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="3";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute4
+					{
+						property="speaker";
+						expression="_this setspeaker _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="Male01PER";
+							};
+						};
+					};
+					class Attribute5
+					{
+						property="pitch";
+						expression="_this setpitch _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"SCALAR"
+									};
+								};
+								value=0.97000003;
+							};
+						};
+					};
+					nAttributes=6;
 				};
 			};
 			class Item3
@@ -6218,7 +8072,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={5.3603516,0.0014390945,4.3393555};
+					position[]={5.2988281,0.0014390945,4.5672607};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -6258,14 +8112,14 @@ class items
 								items=1;
 								class Item0
 								{
-									name="SmokeShell";
-									count=4;
-									ammoLeft=1;
+									name="rhs_mag_9x19_17";
+									count=1;
+									ammoLeft=17;
 								};
 							};
 							class ItemCargo
 							{
-								items=5;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -6278,15 +8132,25 @@ class items
 								};
 								class Item2
 								{
+									name="ACE_tourniquet";
+									count=2;
+								};
+								class Item3
+								{
 									name="ACE_morphine";
 									count=1;
 								};
-								class Item3
+								class Item4
+								{
+									name="ACE_epinephrine";
+									count=1;
+								};
+								class Item5
 								{
 									name="rhs_acc_2dpZenit";
 									count=1;
 								};
-								class Item4
+								class Item6
 								{
 									name="ACRE_PRC343";
 									count=1;
@@ -6299,33 +8163,18 @@ class items
 							isBackpack=0;
 							class MagazineCargo
 							{
-								items=3;
+								items=2;
 								class Item0
 								{
-									name="rhs_mag_9x19_17";
-									count=1;
-									ammoLeft=17;
+									name="hlc_75Rnd_762x39_m_rpk";
+									count=2;
+									ammoLeft=75;
 								};
 								class Item1
 								{
 									name="HandGrenade";
 									count=2;
 									ammoLeft=1;
-								};
-								class Item2
-								{
-									name="hlc_75Rnd_762x39_m_rpk";
-									count=1;
-									ammoLeft=75;
-								};
-							};
-							class ItemCargo
-							{
-								items=1;
-								class Item0
-								{
-									name="ACE_tourniquet";
-									count=2;
 								};
 							};
 						};
@@ -6356,11 +8205,30 @@ class items
 						headgear="rhs_6b27m_green_ess";
 					};
 				};
-				id=185;
+				id=31;
 				type="O_Soldier_AR_F";
 				class CustomAttributes
 				{
 					class Attribute0
+					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="RED";
+							};
+						};
+					};
+					class Attribute1
 					{
 						property="lambs_danger_disableAI";
 						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
@@ -6379,7 +8247,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
@@ -6398,7 +8266,81 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute3
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="3";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute4
+					{
+						property="speaker";
+						expression="_this setspeaker _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="Male03PER";
+							};
+						};
+					};
+					class Attribute5
+					{
+						property="pitch";
+						expression="_this setpitch _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"SCALAR"
+									};
+								};
+								value=1.03;
+							};
+						};
+					};
+					nAttributes=6;
 				};
 			};
 			class Item4
@@ -6406,7 +8348,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={6.3603516,0.0014390945,4.3500977};
+					position[]={6.2988281,0.0014390945,4.5782471};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -6415,7 +8357,7 @@ class items
 				{
 					rank="CORPORAL";
 					init="call{this disableAI ""MOVE"";" \n "this setSpeaker ""NoVoice"";" \n "enableRadio false;}";
-					description="Charlie 1 Assist. autorifleman";
+					description="Charlie 1 Assist. Autorifleman";
 					isPlayable=1;
 					class Inventory
 					{
@@ -6451,14 +8393,14 @@ class items
 								items=1;
 								class Item0
 								{
-									name="SmokeShell";
-									count=4;
-									ammoLeft=1;
+									name="rhs_mag_9x19_17";
+									count=1;
+									ammoLeft=17;
 								};
 							};
 							class ItemCargo
 							{
-								items=7;
+								items=9;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -6471,17 +8413,17 @@ class items
 								};
 								class Item2
 								{
-									name="ACE_morphine";
-									count=1;
+									name="ACE_tourniquet";
+									count=2;
 								};
 								class Item3
 								{
-									name="rhs_acc_2dpZenit";
+									name="ACE_morphine";
 									count=1;
 								};
 								class Item4
 								{
-									name="ACRE_PRC343";
+									name="ACE_epinephrine";
 									count=1;
 								};
 								class Item5
@@ -6494,6 +8436,16 @@ class items
 									name="ACE_MapTools";
 									count=1;
 								};
+								class Item7
+								{
+									name="rhs_acc_2dpZenit";
+									count=1;
+								};
+								class Item8
+								{
+									name="ACRE_PRC343";
+									count=1;
+								};
 							};
 						};
 						class vest
@@ -6502,33 +8454,18 @@ class items
 							isBackpack=0;
 							class MagazineCargo
 							{
-								items=3;
+								items=2;
 								class Item0
 								{
-									name="rhs_mag_9x19_17";
-									count=1;
-									ammoLeft=17;
-								};
-								class Item1
-								{
 									name="rhs_30Rnd_545x39_7N22_plum_AK";
-									count=7;
+									count=8;
 									ammoLeft=30;
 								};
-								class Item2
+								class Item1
 								{
 									name="rhs_30Rnd_545x39_AK_plum_green";
 									count=2;
 									ammoLeft=30;
-								};
-							};
-							class ItemCargo
-							{
-								items=1;
-								class Item0
-								{
-									name="ACE_tourniquet";
-									count=2;
 								};
 							};
 						};
@@ -6541,39 +8478,39 @@ class items
 								items=6;
 								class Item0
 								{
-									name="SmokeShell";
-									count=3;
-									ammoLeft=1;
+									name="rhs_30Rnd_545x39_7N22_plum_AK";
+									count=9;
+									ammoLeft=30;
 								};
 								class Item1
 								{
-									name="SmokeShellGreen";
-									count=2;
-									ammoLeft=1;
+									name="hlc_75Rnd_762x39_m_rpk";
+									count=3;
+									ammoLeft=75;
 								};
 								class Item2
-								{
-									name="SmokeShellBlue";
-									count=1;
-									ammoLeft=1;
-								};
-								class Item3
 								{
 									name="HandGrenade";
 									count=4;
 									ammoLeft=1;
 								};
+								class Item3
+								{
+									name="SmokeShell";
+									count=4;
+									ammoLeft=1;
+								};
 								class Item4
 								{
-									name="rhs_30Rnd_545x39_7N22_plum_AK";
-									count=9;
-									ammoLeft=30;
+									name="SmokeShellGreen";
+									count=2;
+									ammoLeft=1;
 								};
 								class Item5
 								{
-									name="hlc_75Rnd_762x39_m_rpk";
-									count=3;
-									ammoLeft=75;
+									name="SmokeShellBlue";
+									count=1;
+									ammoLeft=1;
 								};
 							};
 							class ItemCargo
@@ -6593,11 +8530,30 @@ class items
 						headgear="rhs_6b27m_green";
 					};
 				};
-				id=186;
+				id=32;
 				type="O_Soldier_AAR_F";
 				class CustomAttributes
 				{
 					class Attribute0
+					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="RED";
+							};
+						};
+					};
+					class Attribute1
 					{
 						property="lambs_danger_disableAI";
 						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
@@ -6616,7 +8572,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
@@ -6635,7 +8591,81 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute3
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="3";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute4
+					{
+						property="speaker";
+						expression="_this setspeaker _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="Male01PER";
+							};
+						};
+					};
+					class Attribute5
+					{
+						property="pitch";
+						expression="_this setpitch _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"SCALAR"
+									};
+								};
+								value=1.05;
+							};
+						};
+					};
+					nAttributes=6;
 				};
 			};
 			class Item5
@@ -6643,7 +8673,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={7.3603516,0.0014390945,4.3608398};
+					position[]={7.2988281,0.0014390945,4.5892334};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -6687,14 +8717,14 @@ class items
 								items=1;
 								class Item0
 								{
-									name="SmokeShell";
-									count=4;
-									ammoLeft=1;
+									name="rhs_mag_9x19_17";
+									count=1;
+									ammoLeft=17;
 								};
 							};
 							class ItemCargo
 							{
-								items=5;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -6707,15 +8737,25 @@ class items
 								};
 								class Item2
 								{
+									name="ACE_tourniquet";
+									count=2;
+								};
+								class Item3
+								{
 									name="ACE_morphine";
 									count=1;
 								};
-								class Item3
+								class Item4
+								{
+									name="ACE_epinephrine";
+									count=1;
+								};
+								class Item5
 								{
 									name="rhs_acc_2dpZenit";
 									count=1;
 								};
-								class Item4
+								class Item6
 								{
 									name="ACRE_PRC343";
 									count=1;
@@ -6731,36 +8771,27 @@ class items
 								items=4;
 								class Item0
 								{
-									name="HandGrenade";
-									count=2;
-									ammoLeft=1;
-								};
-								class Item1
-								{
 									name="rhs_30Rnd_545x39_7N22_plum_AK";
 									count=8;
 									ammoLeft=30;
 								};
-								class Item2
+								class Item1
 								{
 									name="rhs_30Rnd_545x39_AK_plum_green";
 									count=2;
 									ammoLeft=30;
 								};
+								class Item2
+								{
+									name="HandGrenade";
+									count=2;
+									ammoLeft=1;
+								};
 								class Item3
 								{
-									name="rhs_mag_9x19_17";
-									count=1;
-									ammoLeft=17;
-								};
-							};
-							class ItemCargo
-							{
-								items=1;
-								class Item0
-								{
-									name="ACE_tourniquet";
-									count=2;
+									name="SmokeShell";
+									count=4;
+									ammoLeft=1;
 								};
 							};
 						};
@@ -6770,11 +8801,30 @@ class items
 						headgear="rhs_6b27m_green";
 					};
 				};
-				id=187;
+				id=33;
 				type="O_Soldier_LAT_F";
 				class CustomAttributes
 				{
 					class Attribute0
+					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="RED";
+							};
+						};
+					};
+					class Attribute1
 					{
 						property="lambs_danger_disableAI";
 						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
@@ -6793,7 +8843,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
@@ -6812,7 +8862,81 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute3
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="3";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute4
+					{
+						property="speaker";
+						expression="_this setspeaker _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="Male01PER";
+							};
+						};
+					};
+					class Attribute5
+					{
+						property="pitch";
+						expression="_this setpitch _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"SCALAR"
+									};
+								};
+								value=1.03;
+							};
+						};
+					};
+					nAttributes=6;
 				};
 			};
 			class Item6
@@ -6820,7 +8944,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={4.3823242,0.0014390945,2.3286133};
+					position[]={4.3198242,0.0014390945,2.557251};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -6870,14 +8994,14 @@ class items
 								items=1;
 								class Item0
 								{
-									name="SmokeShell";
-									count=4;
-									ammoLeft=1;
+									name="rhs_mag_9x19_17";
+									count=1;
+									ammoLeft=17;
 								};
 							};
 							class ItemCargo
 							{
-								items=7;
+								items=9;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -6890,17 +9014,17 @@ class items
 								};
 								class Item2
 								{
-									name="ACE_morphine";
-									count=1;
+									name="ACE_tourniquet";
+									count=2;
 								};
 								class Item3
 								{
-									name="rhs_acc_2dpZenit";
+									name="ACE_morphine";
 									count=1;
 								};
 								class Item4
 								{
-									name="ACRE_PRC343";
+									name="ACE_epinephrine";
 									count=1;
 								};
 								class Item5
@@ -6911,6 +9035,16 @@ class items
 								class Item6
 								{
 									name="ACE_MapTools";
+									count=1;
+								};
+								class Item7
+								{
+									name="rhs_acc_2dpZenit";
+									count=1;
+								};
+								class Item8
+								{
+									name="ACRE_PRC343";
 									count=1;
 								};
 							};
@@ -6924,30 +9058,21 @@ class items
 								items=3;
 								class Item0
 								{
-									name="rhs_mag_9x19_17";
-									count=1;
-									ammoLeft=17;
-								};
-								class Item1
-								{
 									name="rhs_30Rnd_545x39_7N22_plum_AK";
 									count=6;
 									ammoLeft=30;
 								};
-								class Item2
+								class Item1
 								{
 									name="rhs_30Rnd_545x39_AK_plum_green";
 									count=4;
 									ammoLeft=30;
 								};
-							};
-							class ItemCargo
-							{
-								items=1;
-								class Item0
+								class Item2
 								{
-									name="ACE_tourniquet";
+									name="HandGrenade";
 									count=2;
+									ammoLeft=1;
 								};
 							};
 						};
@@ -6957,7 +9082,7 @@ class items
 							isBackpack=1;
 							class MagazineCargo
 							{
-								items=7;
+								items=6;
 								class Item0
 								{
 									name="rhs_VOG25";
@@ -6979,7 +9104,7 @@ class items
 								class Item3
 								{
 									name="SmokeShell";
-									count=3;
+									count=7;
 									ammoLeft=1;
 								};
 								class Item4
@@ -6991,12 +9116,6 @@ class items
 								class Item5
 								{
 									name="SmokeShellBlue";
-									count=2;
-									ammoLeft=1;
-								};
-								class Item6
-								{
-									name="HandGrenade";
 									count=2;
 									ammoLeft=1;
 								};
@@ -7018,11 +9137,30 @@ class items
 						headgear="rhs_6b27m_green";
 					};
 				};
-				id=188;
+				id=34;
 				type="O_Soldier_TL_F";
 				class CustomAttributes
 				{
 					class Attribute0
+					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="YELLOW";
+							};
+						};
+					};
+					class Attribute1
 					{
 						property="lambs_danger_disableAI";
 						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
@@ -7041,7 +9179,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
@@ -7060,7 +9198,81 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute3
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="3";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute4
+					{
+						property="speaker";
+						expression="_this setspeaker _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="Male03PER";
+							};
+						};
+					};
+					class Attribute5
+					{
+						property="pitch";
+						expression="_this setpitch _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"SCALAR"
+									};
+								};
+								value=0.94999999;
+							};
+						};
+					};
+					nAttributes=6;
 				};
 			};
 			class Item7
@@ -7068,7 +9280,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={5.3823242,0.0014390945,2.340332};
+					position[]={5.3198242,0.0014390945,2.5682373};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -7108,14 +9320,14 @@ class items
 								items=1;
 								class Item0
 								{
-									name="SmokeShell";
-									count=4;
-									ammoLeft=1;
+									name="rhs_mag_9x19_17";
+									count=1;
+									ammoLeft=17;
 								};
 							};
 							class ItemCargo
 							{
-								items=5;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -7128,15 +9340,25 @@ class items
 								};
 								class Item2
 								{
+									name="ACE_tourniquet";
+									count=2;
+								};
+								class Item3
+								{
 									name="ACE_morphine";
 									count=1;
 								};
-								class Item3
+								class Item4
+								{
+									name="ACE_epinephrine";
+									count=1;
+								};
+								class Item5
 								{
 									name="rhs_acc_2dpZenit";
 									count=1;
 								};
-								class Item4
+								class Item6
 								{
 									name="ACRE_PRC343";
 									count=1;
@@ -7149,33 +9371,18 @@ class items
 							isBackpack=0;
 							class MagazineCargo
 							{
-								items=3;
+								items=2;
 								class Item0
 								{
-									name="rhs_mag_9x19_17";
-									count=1;
-									ammoLeft=17;
+									name="hlc_75Rnd_762x39_m_rpk";
+									count=2;
+									ammoLeft=75;
 								};
 								class Item1
 								{
 									name="HandGrenade";
 									count=2;
 									ammoLeft=1;
-								};
-								class Item2
-								{
-									name="hlc_75Rnd_762x39_m_rpk";
-									count=1;
-									ammoLeft=75;
-								};
-							};
-							class ItemCargo
-							{
-								items=1;
-								class Item0
-								{
-									name="ACE_tourniquet";
-									count=2;
 								};
 							};
 						};
@@ -7206,11 +9413,30 @@ class items
 						headgear="rhs_6b27m_green";
 					};
 				};
-				id=189;
+				id=35;
 				type="O_Soldier_AR_F";
 				class CustomAttributes
 				{
 					class Attribute0
+					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="YELLOW";
+							};
+						};
+					};
+					class Attribute1
 					{
 						property="lambs_danger_disableAI";
 						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
@@ -7229,7 +9455,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
@@ -7248,7 +9474,81 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute3
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="3";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute4
+					{
+						property="speaker";
+						expression="_this setspeaker _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="Male02PER";
+							};
+						};
+					};
+					class Attribute5
+					{
+						property="pitch";
+						expression="_this setpitch _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"SCALAR"
+									};
+								};
+								value=0.95999998;
+							};
+						};
+					};
+					nAttributes=6;
 				};
 			};
 			class Item8
@@ -7256,7 +9556,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={6.3813477,0.0014390945,2.3500977};
+					position[]={6.3188477,0.0014390945,2.5782471};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -7265,7 +9565,7 @@ class items
 				{
 					rank="CORPORAL";
 					init="call{this disableAI ""MOVE"";" \n "this setSpeaker ""NoVoice"";" \n "enableRadio false;}";
-					description="Charlie 2 Assist. autorifleman";
+					description="Charlie 2 Assist. Autorifleman";
 					isPlayable=1;
 					class Inventory
 					{
@@ -7301,14 +9601,14 @@ class items
 								items=1;
 								class Item0
 								{
-									name="SmokeShell";
-									count=4;
-									ammoLeft=1;
+									name="rhs_mag_9x19_17";
+									count=1;
+									ammoLeft=17;
 								};
 							};
 							class ItemCargo
 							{
-								items=7;
+								items=9;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -7321,17 +9621,17 @@ class items
 								};
 								class Item2
 								{
-									name="ACE_morphine";
-									count=1;
+									name="ACE_tourniquet";
+									count=2;
 								};
 								class Item3
 								{
-									name="rhs_acc_2dpZenit";
+									name="ACE_morphine";
 									count=1;
 								};
 								class Item4
 								{
-									name="ACRE_PRC343";
+									name="ACE_epinephrine";
 									count=1;
 								};
 								class Item5
@@ -7344,6 +9644,16 @@ class items
 									name="ACE_MapTools";
 									count=1;
 								};
+								class Item7
+								{
+									name="rhs_acc_2dpZenit";
+									count=1;
+								};
+								class Item8
+								{
+									name="ACRE_PRC343";
+									count=1;
+								};
 							};
 						};
 						class vest
@@ -7352,33 +9662,18 @@ class items
 							isBackpack=0;
 							class MagazineCargo
 							{
-								items=3;
+								items=2;
 								class Item0
 								{
-									name="rhs_mag_9x19_17";
-									count=1;
-									ammoLeft=17;
-								};
-								class Item1
-								{
 									name="rhs_30Rnd_545x39_7N22_plum_AK";
-									count=7;
+									count=8;
 									ammoLeft=30;
 								};
-								class Item2
+								class Item1
 								{
 									name="rhs_30Rnd_545x39_AK_plum_green";
 									count=2;
 									ammoLeft=30;
-								};
-							};
-							class ItemCargo
-							{
-								items=1;
-								class Item0
-								{
-									name="ACE_tourniquet";
-									count=2;
 								};
 							};
 						};
@@ -7391,39 +9686,39 @@ class items
 								items=6;
 								class Item0
 								{
-									name="SmokeShell";
-									count=3;
-									ammoLeft=1;
+									name="rhs_30Rnd_545x39_7N22_plum_AK";
+									count=9;
+									ammoLeft=30;
 								};
 								class Item1
 								{
-									name="SmokeShellGreen";
-									count=2;
-									ammoLeft=1;
+									name="hlc_75Rnd_762x39_m_rpk";
+									count=3;
+									ammoLeft=75;
 								};
 								class Item2
-								{
-									name="SmokeShellBlue";
-									count=1;
-									ammoLeft=1;
-								};
-								class Item3
 								{
 									name="HandGrenade";
 									count=4;
 									ammoLeft=1;
 								};
+								class Item3
+								{
+									name="SmokeShell";
+									count=4;
+									ammoLeft=1;
+								};
 								class Item4
 								{
-									name="rhs_30Rnd_545x39_7N22_plum_AK";
-									count=9;
-									ammoLeft=30;
+									name="SmokeShellGreen";
+									count=2;
+									ammoLeft=1;
 								};
 								class Item5
 								{
-									name="hlc_75Rnd_762x39_m_rpk";
-									count=3;
-									ammoLeft=75;
+									name="SmokeShellBlue";
+									count=1;
+									ammoLeft=1;
 								};
 							};
 							class ItemCargo
@@ -7443,11 +9738,30 @@ class items
 						headgear="rhs_6b27m_green_bala";
 					};
 				};
-				id=190;
+				id=36;
 				type="O_Soldier_AAR_F";
 				class CustomAttributes
 				{
 					class Attribute0
+					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="YELLOW";
+							};
+						};
+					};
+					class Attribute1
 					{
 						property="lambs_danger_disableAI";
 						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
@@ -7466,7 +9780,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
@@ -7485,7 +9799,81 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute3
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="3";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute4
+					{
+						property="speaker";
+						expression="_this setspeaker _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="Male03PER";
+							};
+						};
+					};
+					class Attribute5
+					{
+						property="pitch";
+						expression="_this setpitch _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"SCALAR"
+									};
+								};
+								value=1;
+							};
+						};
+					};
+					nAttributes=6;
 				};
 			};
 			class Item9
@@ -7493,7 +9881,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={7.3813477,0.0014390945,2.3608398};
+					position[]={7.3188477,0.0014390945,2.5892334};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -7537,14 +9925,14 @@ class items
 								items=1;
 								class Item0
 								{
-									name="SmokeShell";
-									count=4;
-									ammoLeft=1;
+									name="rhs_mag_9x19_17";
+									count=1;
+									ammoLeft=17;
 								};
 							};
 							class ItemCargo
 							{
-								items=5;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -7557,15 +9945,25 @@ class items
 								};
 								class Item2
 								{
+									name="ACE_tourniquet";
+									count=2;
+								};
+								class Item3
+								{
 									name="ACE_morphine";
 									count=1;
 								};
-								class Item3
+								class Item4
+								{
+									name="ACE_epinephrine";
+									count=1;
+								};
+								class Item5
 								{
 									name="rhs_acc_2dpZenit";
 									count=1;
 								};
-								class Item4
+								class Item6
 								{
 									name="ACRE_PRC343";
 									count=1;
@@ -7581,36 +9979,27 @@ class items
 								items=4;
 								class Item0
 								{
-									name="rhs_mag_9x19_17";
-									count=1;
-									ammoLeft=17;
-								};
-								class Item1
-								{
-									name="HandGrenade";
-									count=2;
-									ammoLeft=1;
-								};
-								class Item2
-								{
 									name="rhs_30Rnd_545x39_7N22_plum_AK";
 									count=8;
 									ammoLeft=30;
 								};
-								class Item3
+								class Item1
 								{
 									name="rhs_30Rnd_545x39_AK_plum_green";
 									count=2;
 									ammoLeft=30;
 								};
-							};
-							class ItemCargo
-							{
-								items=1;
-								class Item0
+								class Item2
 								{
-									name="ACE_tourniquet";
+									name="HandGrenade";
 									count=2;
+									ammoLeft=1;
+								};
+								class Item3
+								{
+									name="SmokeShell";
+									count=4;
+									ammoLeft=1;
 								};
 							};
 						};
@@ -7620,11 +10009,30 @@ class items
 						headgear="rhs_6b27m_green_ess";
 					};
 				};
-				id=191;
+				id=37;
 				type="O_Soldier_LAT_F";
 				class CustomAttributes
 				{
 					class Attribute0
+					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="YELLOW";
+							};
+						};
+					};
+					class Attribute1
 					{
 						property="lambs_danger_disableAI";
 						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
@@ -7643,7 +10051,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
@@ -7662,14 +10070,88 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute3
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="3";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute4
+					{
+						property="speaker";
+						expression="_this setspeaker _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="Male01PER";
+							};
+						};
+					};
+					class Attribute5
+					{
+						property="pitch";
+						expression="_this setpitch _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"SCALAR"
+									};
+								};
+								value=0.94999999;
+							};
+						};
+					};
+					nAttributes=6;
 				};
 			};
 		};
 		class Attributes
 		{
 		};
-		id=181;
+		id=27;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -7706,7 +10188,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-6.6049805,0.0014390945,-1.5522461};
+					position[]={-6.6669922,0.0014390945,-1.3237305};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -7756,14 +10238,14 @@ class items
 								items=1;
 								class Item0
 								{
-									name="SmokeShell";
-									count=2;
-									ammoLeft=1;
+									name="rhs_mag_9x19_17";
+									count=1;
+									ammoLeft=17;
 								};
 							};
 							class ItemCargo
 							{
-								items=8;
+								items=9;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -7776,17 +10258,17 @@ class items
 								};
 								class Item2
 								{
-									name="ACE_morphine";
-									count=1;
+									name="ACE_tourniquet";
+									count=2;
 								};
 								class Item3
 								{
-									name="rhs_acc_2dpZenit";
+									name="ACE_morphine";
 									count=1;
 								};
 								class Item4
 								{
-									name="ACRE_PRC343";
+									name="ACE_epinephrine";
 									count=1;
 								};
 								class Item5
@@ -7801,7 +10283,12 @@ class items
 								};
 								class Item7
 								{
-									name="ACRE_PRC152";
+									name="rhs_acc_2dpZenit";
+									count=1;
+								};
+								class Item8
+								{
+									name="ACRE_PRC343";
 									count=1;
 								};
 							};
@@ -7812,39 +10299,24 @@ class items
 							isBackpack=0;
 							class MagazineCargo
 							{
-								items=4;
+								items=3;
 								class Item0
-								{
-									name="SmokeShell";
-									count=2;
-									ammoLeft=1;
-								};
-								class Item1
-								{
-									name="rhs_mag_9x19_17";
-									count=1;
-									ammoLeft=17;
-								};
-								class Item2
 								{
 									name="rhs_30Rnd_545x39_7N22_plum_AK";
 									count=6;
 									ammoLeft=30;
 								};
-								class Item3
+								class Item1
 								{
 									name="rhs_30Rnd_545x39_AK_plum_green";
-									count=3;
+									count=4;
 									ammoLeft=30;
 								};
-							};
-							class ItemCargo
-							{
-								items=1;
-								class Item0
+								class Item2
 								{
-									name="ACE_tourniquet";
+									name="HandGrenade";
 									count=2;
+									ammoLeft=1;
 								};
 							};
 						};
@@ -7854,7 +10326,7 @@ class items
 							isBackpack=1;
 							class MagazineCargo
 							{
-								items=8;
+								items=7;
 								class Item0
 								{
 									name="rhs_VOG25";
@@ -7882,7 +10354,7 @@ class items
 								class Item4
 								{
 									name="SmokeShell";
-									count=3;
+									count=7;
 									ammoLeft=1;
 								};
 								class Item5
@@ -7897,19 +10369,18 @@ class items
 									count=2;
 									ammoLeft=1;
 								};
-								class Item7
-								{
-									name="HandGrenade";
-									count=2;
-									ammoLeft=1;
-								};
 							};
 							class ItemCargo
 							{
-								items=1;
+								items=2;
 								class Item0
 								{
 									name="ACE_IR_Strobe_Item";
+									count=1;
+								};
+								class Item1
+								{
+									name="ACRE_PRC152";
 									count=1;
 								};
 							};
@@ -7918,10 +10389,10 @@ class items
 						compass="ItemCompass";
 						watch="ItemWatch";
 						gps="ItemGPS";
-						headgear="rhs_6b27m_digi";
+						headgear="rhs_6b27m_green_bala";
 					};
 				};
-				id=193;
+				id=39;
 				type="O_Soldier_TL_F";
 				class CustomAttributes
 				{
@@ -7963,7 +10434,95 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=2;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="5";
+										};
+									};
+									class Item1
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute3
+					{
+						property="speaker";
+						expression="_this setspeaker _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="Male02PER";
+							};
+						};
+					};
+					class Attribute4
+					{
+						property="pitch";
+						expression="_this setpitch _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"SCALAR"
+									};
+								};
+								value=1.03;
+							};
+						};
+					};
+					nAttributes=5;
 				};
 			};
 			class Item1
@@ -7971,7 +10530,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-5.6049805,0.0014390945,-1.5415039};
+					position[]={-5.6674805,0.0014390945,-1.3133545};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -8010,14 +10569,14 @@ class items
 								items=1;
 								class Item0
 								{
-									name="SmokeShell";
-									count=4;
-									ammoLeft=1;
+									name="rhs_mag_9x19_17";
+									count=1;
+									ammoLeft=17;
 								};
 							};
 							class ItemCargo
 							{
-								items=5;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -8030,15 +10589,25 @@ class items
 								};
 								class Item2
 								{
+									name="ACE_tourniquet";
+									count=2;
+								};
+								class Item3
+								{
 									name="ACE_morphine";
 									count=1;
 								};
-								class Item3
+								class Item4
+								{
+									name="ACE_epinephrine";
+									count=1;
+								};
+								class Item5
 								{
 									name="rhs_acc_2dpZenit";
 									count=1;
 								};
-								class Item4
+								class Item6
 								{
 									name="ACRE_PRC343";
 									count=1;
@@ -8054,24 +10623,15 @@ class items
 								items=2;
 								class Item0
 								{
-									name="rhs_mag_9x19_17";
-									count=1;
-									ammoLeft=17;
-								};
-								class Item1
-								{
 									name="HandGrenade";
 									count=2;
 									ammoLeft=1;
 								};
-							};
-							class ItemCargo
-							{
-								items=1;
-								class Item0
+								class Item1
 								{
-									name="ACE_tourniquet";
-									count=2;
+									name="SmokeShell";
+									count=4;
+									ammoLeft=1;
 								};
 							};
 						};
@@ -8096,7 +10656,7 @@ class items
 						headgear="rhs_6b27m_green_ess";
 					};
 				};
-				id=194;
+				id=40;
 				type="O_Soldier_AR_F";
 				class CustomAttributes
 				{
@@ -8138,7 +10698,43 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="5";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=3;
 				};
 			};
 			class Item2
@@ -8146,7 +10742,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-4.6049805,0.0014390945,-1.5307617};
+					position[]={-4.6674805,0.0014390945,-1.3026123};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -8186,14 +10782,14 @@ class items
 								items=1;
 								class Item0
 								{
-									name="SmokeShell";
-									count=4;
-									ammoLeft=1;
+									name="rhs_mag_9x19_17";
+									count=1;
+									ammoLeft=17;
 								};
 							};
 							class ItemCargo
 							{
-								items=5;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -8206,15 +10802,25 @@ class items
 								};
 								class Item2
 								{
+									name="ACE_tourniquet";
+									count=2;
+								};
+								class Item3
+								{
 									name="ACE_morphine";
 									count=1;
 								};
-								class Item3
+								class Item4
+								{
+									name="ACE_epinephrine";
+									count=1;
+								};
+								class Item5
 								{
 									name="rhs_acc_2dpZenit";
 									count=1;
 								};
-								class Item4
+								class Item6
 								{
 									name="ACRE_PRC343";
 									count=1;
@@ -8230,36 +10836,27 @@ class items
 								items=4;
 								class Item0
 								{
-									name="rhs_mag_9x19_17";
-									count=1;
-									ammoLeft=17;
-								};
-								class Item1
-								{
-									name="HandGrenade";
-									count=2;
-									ammoLeft=1;
-								};
-								class Item2
-								{
 									name="rhs_30Rnd_545x39_7N22_plum_AK";
 									count=8;
 									ammoLeft=30;
 								};
-								class Item3
+								class Item1
 								{
 									name="rhs_30Rnd_545x39_AK_plum_green";
 									count=2;
 									ammoLeft=30;
 								};
-							};
-							class ItemCargo
-							{
-								items=1;
-								class Item0
+								class Item2
 								{
-									name="ACE_tourniquet";
+									name="HandGrenade";
 									count=2;
+									ammoLeft=1;
+								};
+								class Item3
+								{
+									name="SmokeShell";
+									count=4;
+									ammoLeft=1;
 								};
 							};
 						};
@@ -8284,7 +10881,7 @@ class items
 						headgear="rhs_6b27m_green";
 					};
 				};
-				id=195;
+				id=41;
 				type="O_Soldier_AAR_F";
 				class CustomAttributes
 				{
@@ -8326,14 +10923,50 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="5";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=3;
 				};
 			};
 		};
 		class Attributes
 		{
 		};
-		id=192;
+		id=38;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -8370,7 +11003,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-1.0009766,0.0014390945,-1.7827148};
+					position[]={-1.0629883,0.0014390945,-1.5546875};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -8420,14 +11053,14 @@ class items
 								items=1;
 								class Item0
 								{
-									name="SmokeShell";
-									count=2;
-									ammoLeft=1;
+									name="rhs_mag_9x19_17";
+									count=1;
+									ammoLeft=17;
 								};
 							};
 							class ItemCargo
 							{
-								items=8;
+								items=9;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -8440,17 +11073,17 @@ class items
 								};
 								class Item2
 								{
-									name="ACE_morphine";
-									count=1;
+									name="ACE_tourniquet";
+									count=2;
 								};
 								class Item3
 								{
-									name="rhs_acc_2dpZenit";
+									name="ACE_morphine";
 									count=1;
 								};
 								class Item4
 								{
-									name="ACRE_PRC343";
+									name="ACE_epinephrine";
 									count=1;
 								};
 								class Item5
@@ -8465,7 +11098,12 @@ class items
 								};
 								class Item7
 								{
-									name="ACRE_PRC152";
+									name="rhs_acc_2dpZenit";
+									count=1;
+								};
+								class Item8
+								{
+									name="ACRE_PRC343";
 									count=1;
 								};
 							};
@@ -8476,39 +11114,24 @@ class items
 							isBackpack=0;
 							class MagazineCargo
 							{
-								items=4;
+								items=3;
 								class Item0
-								{
-									name="SmokeShell";
-									count=2;
-									ammoLeft=1;
-								};
-								class Item1
-								{
-									name="rhs_mag_9x19_17";
-									count=1;
-									ammoLeft=17;
-								};
-								class Item2
 								{
 									name="rhs_30Rnd_545x39_7N22_plum_AK";
 									count=6;
 									ammoLeft=30;
 								};
-								class Item3
+								class Item1
 								{
 									name="rhs_30Rnd_545x39_AK_plum_green";
-									count=3;
+									count=4;
 									ammoLeft=30;
 								};
-							};
-							class ItemCargo
-							{
-								items=1;
-								class Item0
+								class Item2
 								{
-									name="ACE_tourniquet";
+									name="HandGrenade";
 									count=2;
+									ammoLeft=1;
 								};
 							};
 						};
@@ -8518,7 +11141,7 @@ class items
 							isBackpack=1;
 							class MagazineCargo
 							{
-								items=8;
+								items=7;
 								class Item0
 								{
 									name="rhs_VOG25";
@@ -8546,7 +11169,7 @@ class items
 								class Item4
 								{
 									name="SmokeShell";
-									count=3;
+									count=7;
 									ammoLeft=1;
 								};
 								class Item5
@@ -8561,19 +11184,18 @@ class items
 									count=2;
 									ammoLeft=1;
 								};
-								class Item7
-								{
-									name="HandGrenade";
-									count=2;
-									ammoLeft=1;
-								};
 							};
 							class ItemCargo
 							{
-								items=1;
+								items=2;
 								class Item0
 								{
 									name="ACE_IR_Strobe_Item";
+									count=1;
+								};
+								class Item1
+								{
+									name="ACRE_PRC152";
 									count=1;
 								};
 							};
@@ -8582,10 +11204,10 @@ class items
 						compass="ItemCompass";
 						watch="ItemWatch";
 						gps="ItemGPS";
-						headgear="rhs_6b27m_digi";
+						headgear="rhs_6b27m_green_bala";
 					};
 				};
-				id=197;
+				id=43;
 				type="O_Soldier_TL_F";
 				class CustomAttributes
 				{
@@ -8627,7 +11249,95 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=2;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="6";
+										};
+									};
+									class Item1
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute3
+					{
+						property="speaker";
+						expression="_this setspeaker _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="Male02PER";
+							};
+						};
+					};
+					class Attribute4
+					{
+						property="pitch";
+						expression="_this setpitch _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"SCALAR"
+									};
+								};
+								value=0.95999998;
+							};
+						};
+					};
+					nAttributes=5;
 				};
 			};
 			class Item1
@@ -8635,7 +11345,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-0.001953125,0.0014390945,-1.7719727};
+					position[]={-0.063964844,0.0014390945,-1.5438232};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -8685,14 +11395,14 @@ class items
 								items=1;
 								class Item0
 								{
-									name="SmokeShell";
-									count=4;
-									ammoLeft=1;
+									name="rhs_mag_9x19_17";
+									count=1;
+									ammoLeft=17;
 								};
 							};
 							class ItemCargo
 							{
-								items=5;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -8705,15 +11415,25 @@ class items
 								};
 								class Item2
 								{
+									name="ACE_tourniquet";
+									count=2;
+								};
+								class Item3
+								{
 									name="ACE_morphine";
 									count=1;
 								};
-								class Item3
+								class Item4
+								{
+									name="ACE_epinephrine";
+									count=1;
+								};
+								class Item5
 								{
 									name="rhs_acc_2dpZenit";
 									count=1;
 								};
-								class Item4
+								class Item6
 								{
 									name="ACRE_PRC343";
 									count=1;
@@ -8729,36 +11449,27 @@ class items
 								items=4;
 								class Item0
 								{
-									name="rhs_mag_9x19_17";
-									count=1;
-									ammoLeft=17;
-								};
-								class Item1
-								{
-									name="HandGrenade";
-									count=2;
-									ammoLeft=1;
-								};
-								class Item2
-								{
 									name="rhs_30Rnd_545x39_7N22_plum_AK";
 									count=8;
 									ammoLeft=30;
 								};
-								class Item3
+								class Item1
 								{
 									name="rhs_30Rnd_545x39_AK_plum_green";
 									count=2;
 									ammoLeft=30;
 								};
-							};
-							class ItemCargo
-							{
-								items=1;
-								class Item0
+								class Item2
 								{
-									name="ACE_tourniquet";
+									name="HandGrenade";
 									count=2;
+									ammoLeft=1;
+								};
+								class Item3
+								{
+									name="SmokeShell";
+									count=4;
+									ammoLeft=1;
 								};
 							};
 						};
@@ -8789,7 +11500,7 @@ class items
 						headgear="rhs_6b27m_green_ess";
 					};
 				};
-				id=198;
+				id=44;
 				type="O_Soldier_AT_F";
 				class CustomAttributes
 				{
@@ -8831,7 +11542,57 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=2;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="6";
+										};
+									};
+									class Item1
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=3;
 				};
 			};
 			class Item2
@@ -8839,7 +11600,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={0.99804688,0.0014390945,-1.7612305};
+					position[]={0.93603516,0.0014390945,-1.5330811};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -8879,14 +11640,14 @@ class items
 								items=1;
 								class Item0
 								{
-									name="SmokeShell";
-									count=4;
-									ammoLeft=1;
+									name="rhs_mag_9x19_17";
+									count=1;
+									ammoLeft=17;
 								};
 							};
 							class ItemCargo
 							{
-								items=5;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -8899,15 +11660,25 @@ class items
 								};
 								class Item2
 								{
+									name="ACE_tourniquet";
+									count=2;
+								};
+								class Item3
+								{
 									name="ACE_morphine";
 									count=1;
 								};
-								class Item3
+								class Item4
+								{
+									name="ACE_epinephrine";
+									count=1;
+								};
+								class Item5
 								{
 									name="rhs_acc_2dpZenit";
 									count=1;
 								};
-								class Item4
+								class Item6
 								{
 									name="ACRE_PRC343";
 									count=1;
@@ -8920,33 +11691,18 @@ class items
 							isBackpack=0;
 							class MagazineCargo
 							{
-								items=3;
+								items=2;
 								class Item0
 								{
-									name="rhs_mag_9x19_17";
-									count=1;
-									ammoLeft=17;
+									name="rhs_30Rnd_545x39_7N22_plum_AK";
+									count=8;
+									ammoLeft=30;
 								};
 								class Item1
 								{
-									name="HandGrenade";
+									name="rhs_30Rnd_545x39_AK_plum_green";
 									count=2;
-									ammoLeft=1;
-								};
-								class Item2
-								{
-									name="rhs_30Rnd_545x39_7N22_plum_AK";
-									count=7;
 									ammoLeft=30;
-								};
-							};
-							class ItemCargo
-							{
-								items=1;
-								class Item0
-								{
-									name="ACE_tourniquet";
-									count=2;
 								};
 							};
 						};
@@ -8971,15 +11727,15 @@ class items
 								};
 								class Item2
 								{
-									name="rhs_30Rnd_545x39_7N22_plum_AK";
-									count=1;
-									ammoLeft=30;
+									name="HandGrenade";
+									count=2;
+									ammoLeft=1;
 								};
 								class Item3
 								{
-									name="rhs_30Rnd_545x39_AK_plum_green";
-									count=1;
-									ammoLeft=30;
+									name="SmokeShell";
+									count=4;
+									ammoLeft=1;
 								};
 							};
 						};
@@ -8989,7 +11745,7 @@ class items
 						headgear="rhs_6b27m_green";
 					};
 				};
-				id=199;
+				id=45;
 				type="O_Soldier_AAT_F";
 				class CustomAttributes
 				{
@@ -9031,14 +11787,64 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=2;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="6";
+										};
+									};
+									class Item1
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=3;
 				};
 			};
 		};
 		class Attributes
 		{
 		};
-		id=196;
+		id=42;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -9075,227 +11881,11 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-6.6181641,0.0014390945,-4.5874023};
-					angles[]={0,6.2723818,0};
+					position[]={-5.6811523,0.0014390945,-4.3487549};
+					angles[]={-0,6.2723818,0};
 				};
 				side="East";
-				flags=7;
-				class Attributes
-				{
-					rank="SERGEANT";
-					init="call{this disableAI ""MOVE"";" \n "this setSpeaker ""NoVoice"";" \n "enableRadio false;}";
-					description="DMT Team Leader@DESIGNATED MARKSMAN TEAM";
-					isPlayable=1;
-					class Inventory
-					{
-						class primaryWeapon
-						{
-							name="rhs_weap_ak105";
-							muzzle="rhs_acc_tgpa";
-							flashlight="rhs_acc_perst1ik";
-							class primaryMuzzleMag
-							{
-								name="rhs_30Rnd_545x39_7N22_plum_AK";
-								ammoLeft=30;
-							};
-						};
-						class handgun
-						{
-							name="rhs_weap_pya";
-							class primaryMuzzleMag
-							{
-								name="rhs_mag_9x19_17";
-								ammoLeft=17;
-							};
-						};
-						class binocular
-						{
-							name="ACE_VectorDay";
-						};
-						class uniform
-						{
-							typeName="rhs_uniform_emr_patchless";
-							isBackpack=0;
-							class MagazineCargo
-							{
-								items=1;
-								class Item0
-								{
-									name="SmokeShell";
-									count=2;
-									ammoLeft=1;
-								};
-							};
-							class ItemCargo
-							{
-								items=9;
-								class Item0
-								{
-									name="ACE_fieldDressing";
-									count=4;
-								};
-								class Item1
-								{
-									name="ACE_quikclot";
-									count=6;
-								};
-								class Item2
-								{
-									name="ACE_morphine";
-									count=1;
-								};
-								class Item3
-								{
-									name="ACE_tourniquet";
-									count=1;
-								};
-								class Item4
-								{
-									name="rhs_acc_2dpZenit";
-									count=1;
-								};
-								class Item5
-								{
-									name="ACE_CableTie";
-									count=2;
-								};
-								class Item6
-								{
-									name="ACE_MapTools";
-									count=1;
-								};
-								class Item7
-								{
-									name="ACRE_PRC343";
-									count=1;
-								};
-								class Item8
-								{
-									name="ACRE_PRC152";
-									count=1;
-								};
-							};
-						};
-						class vest
-						{
-							typeName="rhsgref_6b23_ttsko_digi";
-							isBackpack=0;
-							class MagazineCargo
-							{
-								items=5;
-								class Item0
-								{
-									name="SmokeShellBlue";
-									count=1;
-									ammoLeft=1;
-								};
-								class Item1
-								{
-									name="rhs_GRD40_Red";
-									count=1;
-									ammoLeft=1;
-								};
-								class Item2
-								{
-									name="rhs_GDM40";
-									count=4;
-									ammoLeft=1;
-								};
-								class Item3
-								{
-									name="rhs_mag_9x19_17";
-									count=1;
-									ammoLeft=17;
-								};
-								class Item4
-								{
-									name="rhs_30Rnd_545x39_7N22_plum_AK";
-									count=4;
-									ammoLeft=30;
-								};
-							};
-							class ItemCargo
-							{
-								items=3;
-								class Item0
-								{
-									name="ACE_IR_Strobe_Item";
-									count=1;
-								};
-								class Item1
-								{
-									name="ACE_microDAGR";
-									count=1;
-								};
-								class Item2
-								{
-									name="ACE_tourniquet";
-									count=1;
-								};
-							};
-						};
-						map="ItemMap";
-						compass="ItemCompass";
-						watch="ItemWatch";
-						gps="ItemGPS";
-						headgear="rhs_fieldcap_digi2";
-					};
-				};
-				id=201;
-				type="B_spotter_F";
-				class CustomAttributes
-				{
-					class Attribute0
-					{
-						property="lambs_danger_disableAI";
-						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
-						class Value
-						{
-							class data
-							{
-								class type
-								{
-									type[]=
-									{
-										"BOOL"
-									};
-								};
-								value=1;
-							};
-						};
-					};
-					class Attribute1
-					{
-						property="a3aa_ee_extended_gear_insignia";
-						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
-						class Value
-						{
-							class data
-							{
-								class type
-								{
-									type[]=
-									{
-										"STRING"
-									};
-								};
-								value="CNTOpatchAlt";
-							};
-						};
-					};
-					nAttributes=2;
-				};
-			};
-			class Item1
-			{
-				dataType="Object";
-				class PositionInfo
-				{
-					position[]={-5.6186523,0.0014390945,-4.5766602};
-					angles[]={0,6.2723818,0};
-				};
-				side="East";
-				flags=5;
+				flags=4;
 				class Attributes
 				{
 					init="call{this disableAI ""MOVE"";" \n "this setSpeaker ""NoVoice"";" \n "enableRadio false;}";
@@ -9340,9 +11930,9 @@ class items
 								items=1;
 								class Item0
 								{
-									name="SmokeShell";
-									count=2;
-									ammoLeft=1;
+									name="rhs_mag_9x19_17";
+									count=1;
+									ammoLeft=17;
 								};
 							};
 							class ItemCargo
@@ -9360,17 +11950,17 @@ class items
 								};
 								class Item2
 								{
-									name="ACE_morphine";
-									count=1;
+									name="ACE_tourniquet";
+									count=2;
 								};
 								class Item3
 								{
-									name="ACE_tourniquet";
+									name="ACE_morphine";
 									count=1;
 								};
 								class Item4
 								{
-									name="rhs_acc_2dpZenit";
+									name="ACE_epinephrine";
 									count=1;
 								};
 								class Item5
@@ -9385,17 +11975,17 @@ class items
 								};
 								class Item7
 								{
-									name="ACE_Kestrel4500";
+									name="rhs_acc_2dpZenit";
 									count=1;
 								};
 								class Item8
 								{
-									name="ACE_RangeCard";
+									name="ACE_Kestrel4500";
 									count=1;
 								};
 								class Item9
 								{
-									name="ACE_microDAGR";
+									name="ACE_RangeCard";
 									count=1;
 								};
 								class Item10
@@ -9414,15 +12004,15 @@ class items
 								items=2;
 								class Item0
 								{
-									name="rhs_mag_9x19_17";
-									count=1;
-									ammoLeft=17;
-								};
-								class Item1
-								{
 									name="rhs_10Rnd_762x54mmR_7N14";
 									count=8;
 									ammoLeft=10;
+								};
+								class Item1
+								{
+									name="SmokeShell";
+									count=2;
+									ammoLeft=1;
 								};
 							};
 							class ItemCargo
@@ -9435,7 +12025,7 @@ class items
 								};
 								class Item1
 								{
-									name="ACE_tourniquet";
+									name="ACE_microDAGR";
 									count=1;
 								};
 								class Item2
@@ -9452,8 +12042,8 @@ class items
 						headgear="rhs_fieldcap_digi2";
 					};
 				};
-				id=202;
-				type="B_spotter_F";
+				id=47;
+				type="O_soldier_M_F";
 				class CustomAttributes
 				{
 					class Attribute0
@@ -9494,14 +12084,382 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="speaker";
+						expression="_this setspeaker _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="Male11ENG";
+							};
+						};
+					};
+					class Attribute3
+					{
+						property="pitch";
+						expression="_this setpitch _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"SCALAR"
+									};
+								};
+								value=0.99000001;
+							};
+						};
+					};
+					class Attribute4
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="8";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=5;
+				};
+			};
+			class Item1
+			{
+				dataType="Object";
+				class PositionInfo
+				{
+					position[]={-6.6801758,0.0014390945,-4.3597412};
+					angles[]={-0,6.2723818,0};
+				};
+				side="East";
+				flags=6;
+				class Attributes
+				{
+					rank="SERGEANT";
+					init="call{this disableAI ""MOVE"";" \n "this setSpeaker ""NoVoice"";" \n "enableRadio false;}";
+					description="DMT Team Leader@DESIGNATED MARKSMAN TEAM";
+					isPlayable=1;
+					class Inventory
+					{
+						class primaryWeapon
+						{
+							name="rhs_weap_ak105";
+							muzzle="rhs_acc_tgpa";
+							flashlight="rhs_acc_perst1ik";
+							class primaryMuzzleMag
+							{
+								name="rhs_30Rnd_545x39_7N22_plum_AK";
+								ammoLeft=30;
+							};
+						};
+						class handgun
+						{
+							name="rhs_weap_pya";
+							class primaryMuzzleMag
+							{
+								name="rhs_mag_9x19_17";
+								ammoLeft=17;
+							};
+						};
+						class binocular
+						{
+							name="ACE_VectorDay";
+						};
+						class uniform
+						{
+							typeName="rhs_uniform_emr_patchless";
+							isBackpack=0;
+							class ItemCargo
+							{
+								items=10;
+								class Item0
+								{
+									name="ACE_fieldDressing";
+									count=4;
+								};
+								class Item1
+								{
+									name="ACE_quikclot";
+									count=6;
+								};
+								class Item2
+								{
+									name="ACE_tourniquet";
+									count=2;
+								};
+								class Item3
+								{
+									name="ACE_morphine";
+									count=1;
+								};
+								class Item4
+								{
+									name="ACE_epinephrine";
+									count=1;
+								};
+								class Item5
+								{
+									name="ACE_CableTie";
+									count=2;
+								};
+								class Item6
+								{
+									name="ACE_MapTools";
+									count=1;
+								};
+								class Item7
+								{
+									name="rhs_acc_2dpZenit";
+									count=1;
+								};
+								class Item8
+								{
+									name="ACRE_PRC343";
+									count=1;
+								};
+								class Item9
+								{
+									name="ACRE_PRC152";
+									count=1;
+								};
+							};
+						};
+						class vest
+						{
+							typeName="rhsgref_6b23_ttsko_digi";
+							isBackpack=0;
+							class MagazineCargo
+							{
+								items=5;
+								class Item0
+								{
+									name="rhs_30Rnd_545x39_7N22_plum_AK";
+									count=4;
+									ammoLeft=30;
+								};
+								class Item1
+								{
+									name="rhs_mag_9x19_17";
+									count=1;
+									ammoLeft=17;
+								};
+								class Item2
+								{
+									name="SmokeShell";
+									count=4;
+									ammoLeft=1;
+								};
+								class Item3
+								{
+									name="SmokeShellGreen";
+									count=2;
+									ammoLeft=1;
+								};
+								class Item4
+								{
+									name="SmokeShellBlue";
+									count=1;
+									ammoLeft=1;
+								};
+							};
+							class ItemCargo
+							{
+								items=2;
+								class Item0
+								{
+									name="ACE_IR_Strobe_Item";
+									count=1;
+								};
+								class Item1
+								{
+									name="ACE_microDAGR";
+									count=1;
+								};
+							};
+						};
+						map="ItemMap";
+						compass="ItemCompass";
+						watch="ItemWatch";
+						gps="ItemGPS";
+						headgear="rhs_fieldcap_digi2";
+					};
+				};
+				id=48;
+				type="O_spotter_F";
+				class CustomAttributes
+				{
+					class Attribute0
+					{
+						property="lambs_danger_disableAI";
+						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"BOOL"
+									};
+								};
+								value=1;
+							};
+						};
+					};
+					class Attribute1
+					{
+						property="a3aa_ee_extended_gear_insignia";
+						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="CNTOpatchAlt";
+							};
+						};
+					};
+					class Attribute2
+					{
+						property="speaker";
+						expression="_this setspeaker _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="Male10ENG";
+							};
+						};
+					};
+					class Attribute3
+					{
+						property="pitch";
+						expression="_this setpitch _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"SCALAR"
+									};
+								};
+								value=1.02;
+							};
+						};
+					};
+					class Attribute4
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=2;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="8";
+										};
+									};
+									class Item1
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=5;
 				};
 			};
 		};
 		class Attributes
 		{
 		};
-		id=200;
+		id=46;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -9538,7 +12496,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-0.85986328,0.0014390945,-4.9428711};
+					position[]={-0.92236328,0.0014390945,-4.7147217};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -9553,7 +12511,7 @@ class items
 					{
 						class primaryWeapon
 						{
-							name="rhs_weap_aks74u";
+							name="rhs_weap_aks74un";
 							muzzle="rhs_acc_pgs64_74u";
 							class primaryMuzzleMag
 							{
@@ -9578,19 +12536,9 @@ class items
 						{
 							typeName="rhs_uniform_flora_patchless";
 							isBackpack=0;
-							class MagazineCargo
-							{
-								items=1;
-								class Item0
-								{
-									name="SmokeShell";
-									count=2;
-									ammoLeft=1;
-								};
-							};
 							class ItemCargo
 							{
-								items=8;
+								items=11;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -9603,30 +12551,45 @@ class items
 								};
 								class Item2
 								{
-									name="ACE_morphine";
-									count=1;
+									name="ACE_tourniquet";
+									count=2;
 								};
 								class Item3
 								{
-									name="rhs_acc_2dpZenit";
+									name="ACE_morphine";
 									count=1;
 								};
 								class Item4
 								{
-									name="ACRE_PRC343";
+									name="ACE_epinephrine";
 									count=1;
 								};
 								class Item5
 								{
+									name="ACE_CableTie";
+									count=2;
+								};
+								class Item6
+								{
 									name="ACE_MapTools";
 									count=1;
 								};
-								class Item6
+								class Item7
+								{
+									name="rhs_acc_2dpZenit";
+									count=1;
+								};
+								class Item8
 								{
 									name="ACE_RangeTable_82mm";
 									count=1;
 								};
-								class Item7
+								class Item9
+								{
+									name="ACRE_PRC343";
+									count=1;
+								};
+								class Item10
 								{
 									name="ACRE_PRC152";
 									count=1;
@@ -9642,48 +12605,39 @@ class items
 								items=6;
 								class Item0
 								{
-									name="SmokeShell";
-									count=2;
-									ammoLeft=1;
+									name="rhs_30Rnd_545x39_7N22_plum_AK";
+									count=5;
+									ammoLeft=30;
 								};
 								class Item1
 								{
-									name="SmokeShellGreen";
-									count=2;
-									ammoLeft=1;
+									name="rhs_30Rnd_545x39_AK_plum_green";
+									count=1;
+									ammoLeft=30;
 								};
 								class Item2
-								{
-									name="SmokeShellBlue";
-									count=1;
-									ammoLeft=1;
-								};
-								class Item3
 								{
 									name="rhs_mag_9x19_17";
 									count=1;
 									ammoLeft=17;
 								};
+								class Item3
+								{
+									name="SmokeShell";
+									count=4;
+									ammoLeft=1;
+								};
 								class Item4
 								{
-									name="HandGrenade";
+									name="SmokeShellGreen";
 									count=2;
 									ammoLeft=1;
 								};
 								class Item5
 								{
-									name="rhs_30Rnd_545x39_7N22_plum_AK";
-									count=4;
-									ammoLeft=30;
-								};
-							};
-							class ItemCargo
-							{
-								items=1;
-								class Item0
-								{
-									name="ACE_tourniquet";
-									count=2;
+									name="SmokeShellBlue";
+									count=1;
+									ammoLeft=1;
 								};
 							};
 						};
@@ -9699,7 +12653,7 @@ class items
 						headgear="rhs_6b27m_green";
 					};
 				};
-				id=204;
+				id=50;
 				type="O_support_AMort_F";
 				class CustomAttributes
 				{
@@ -9749,7 +12703,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={0.14013672,0.0014390945,-4.9321289};
+					position[]={0.077636719,0.0014390945,-4.7039795};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -9763,8 +12717,8 @@ class items
 					{
 						class primaryWeapon
 						{
-							name="rhs_weap_aks74u";
-							muzzle="rhs_acc_dtk";
+							name="rhs_weap_aks74un";
+							muzzle="rhs_acc_pgs64_74u";
 							class primaryMuzzleMag
 							{
 								name="rhs_30Rnd_545x39_7N22_plum_AK";
@@ -9789,14 +12743,14 @@ class items
 								items=1;
 								class Item0
 								{
-									name="SmokeShell";
-									count=4;
-									ammoLeft=1;
+									name="rhs_mag_9x19_17";
+									count=1;
+									ammoLeft=17;
 								};
 							};
 							class ItemCargo
 							{
-								items=8;
+								items=9;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -9809,32 +12763,37 @@ class items
 								};
 								class Item2
 								{
-									name="ACE_morphine";
-									count=1;
+									name="ACE_tourniquet";
+									count=2;
 								};
 								class Item3
 								{
-									name="ACE_tourniquet";
+									name="ACE_morphine";
 									count=1;
 								};
 								class Item4
 								{
-									name="rhs_acc_2dpZenit";
+									name="ACE_epinephrine";
 									count=1;
 								};
 								class Item5
 								{
-									name="ACRE_PRC343";
+									name="ACE_MapTools";
 									count=1;
 								};
 								class Item6
 								{
-									name="ACE_MapTools";
+									name="rhs_acc_2dpZenit";
 									count=1;
 								};
 								class Item7
 								{
 									name="ACE_RangeTable_82mm";
+									count=1;
+								};
+								class Item8
+								{
+									name="ACRE_PRC343";
 									count=1;
 								};
 							};
@@ -9845,33 +12804,36 @@ class items
 							isBackpack=0;
 							class MagazineCargo
 							{
-								items=3;
+								items=5;
 								class Item0
-								{
-									name="rhs_mag_9x19_17";
-									count=1;
-									ammoLeft=17;
-								};
-								class Item1
-								{
-									name="HandGrenade";
-									count=2;
-									ammoLeft=1;
-								};
-								class Item2
 								{
 									name="rhs_30Rnd_545x39_7N22_plum_AK";
 									count=5;
 									ammoLeft=30;
 								};
-							};
-							class ItemCargo
-							{
-								items=1;
-								class Item0
+								class Item1
 								{
-									name="ACE_tourniquet";
+									name="rhs_30Rnd_545x39_AK_plum_green";
 									count=1;
+									ammoLeft=30;
+								};
+								class Item2
+								{
+									name="SmokeShell";
+									count=4;
+									ammoLeft=1;
+								};
+								class Item3
+								{
+									name="SmokeShellGreen";
+									count=2;
+									ammoLeft=1;
+								};
+								class Item4
+								{
+									name="SmokeShellBlue";
+									count=1;
+									ammoLeft=1;
 								};
 							};
 						};
@@ -9886,7 +12848,7 @@ class items
 						headgear="rhs_6b27m_green_ess";
 					};
 				};
-				id=205;
+				id=51;
 				type="O_support_Mort_F";
 				class CustomAttributes
 				{
@@ -9935,7 +12897,7 @@ class items
 		class Attributes
 		{
 		};
-		id=203;
+		id=49;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -9972,7 +12934,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={4.5112305,0.0014390945,-1.5942383};
+					position[]={4.4487305,0.0014390945,-1.3657227};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -10012,6 +12974,336 @@ class items
 						{
 							typeName="rhs_uniform_flora_patchless";
 							isBackpack=0;
+							class MagazineCargo
+							{
+								items=1;
+								class Item0
+								{
+									name="rhs_mag_9x19_17";
+									count=1;
+									ammoLeft=17;
+								};
+							};
+							class ItemCargo
+							{
+								items=9;
+								class Item0
+								{
+									name="ACE_fieldDressing";
+									count=4;
+								};
+								class Item1
+								{
+									name="ACE_quikclot";
+									count=6;
+								};
+								class Item2
+								{
+									name="ACE_tourniquet";
+									count=2;
+								};
+								class Item3
+								{
+									name="ACE_morphine";
+									count=1;
+								};
+								class Item4
+								{
+									name="ACE_epinephrine";
+									count=1;
+								};
+								class Item5
+								{
+									name="ACE_CableTie";
+									count=2;
+								};
+								class Item6
+								{
+									name="ACE_MapTools";
+									count=1;
+								};
+								class Item7
+								{
+									name="rhs_acc_2dpZenit";
+									count=1;
+								};
+								class Item8
+								{
+									name="ACRE_PRC343";
+									count=1;
+								};
+							};
+						};
+						class vest
+						{
+							typeName="rhs_6b13_EMR_6sh92_radio";
+							isBackpack=0;
+							class MagazineCargo
+							{
+								items=2;
+								class Item0
+								{
+									name="HandGrenade";
+									count=2;
+									ammoLeft=1;
+								};
+								class Item1
+								{
+									name="SmokeShell";
+									count=4;
+									ammoLeft=1;
+								};
+							};
+							class ItemCargo
+							{
+								items=4;
+								class Item0
+								{
+									name="ACE_M26_Clacker";
+									count=1;
+								};
+								class Item1
+								{
+									name="ACE_DefusalKit";
+									count=1;
+								};
+								class Item2
+								{
+									name="ACE_EntrenchingTool";
+									count=1;
+								};
+								class Item3
+								{
+									name="ACE_wirecutter";
+									count=1;
+								};
+							};
+						};
+						class backpack
+						{
+							typeName="B_Carryall_oli";
+							isBackpack=1;
+							class MagazineCargo
+							{
+								items=2;
+								class Item0
+								{
+									name="rhs_30Rnd_545x39_7N22_plum_AK";
+									count=5;
+									ammoLeft=30;
+								};
+								class Item1
+								{
+									name="rhs_30Rnd_545x39_AK_plum_green";
+									count=1;
+									ammoLeft=30;
+								};
+							};
+							class ItemCargo
+							{
+								items=2;
+								class Item0
+								{
+									name="ACRE_PRC152";
+									count=1;
+								};
+								class Item1
+								{
+									name="ToolKit";
+									count=1;
+								};
+							};
+						};
+						map="ItemMap";
+						compass="ItemCompass";
+						watch="ItemWatch";
+						gps="ItemGPS";
+						headgear="rhs_altyn";
+					};
+				};
+				id=53;
+				type="O_engineer_F";
+				class CustomAttributes
+				{
+					class Attribute0
+					{
+						property="lambs_danger_disableAI";
+						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"BOOL"
+									};
+								};
+								value=1;
+							};
+						};
+					};
+					class Attribute1
+					{
+						property="a3aa_ee_extended_gear_insignia";
+						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="CNTOpatchAlt";
+							};
+						};
+					};
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=2;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="7";
+										};
+									};
+									class Item1
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute3
+					{
+						property="speaker";
+						expression="_this setspeaker _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="Male02PER";
+							};
+						};
+					};
+					class Attribute4
+					{
+						property="pitch";
+						expression="_this setpitch _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"SCALAR"
+									};
+								};
+								value=1.03;
+							};
+						};
+					};
+					nAttributes=5;
+				};
+			};
+			class Item1
+			{
+				dataType="Object";
+				class PositionInfo
+				{
+					position[]={5.449707,0.0014390945,-1.3543701};
+					angles[]={0,6.2723818,0};
+				};
+				side="East";
+				flags=5;
+				class Attributes
+				{
+					init="call{this disableAI ""MOVE"";" \n "this setSpeaker ""NoVoice"";" \n "enableRadio false;}";
+					description="Engineer Rifleman";
+					isPlayable=1;
+					class Inventory
+					{
+						class primaryWeapon
+						{
+							name="rhs_weap_ak105";
+							muzzle="rhs_acc_dtk";
+							class primaryMuzzleMag
+							{
+								name="rhs_30Rnd_545x39_7N22_plum_AK";
+								ammoLeft=30;
+							};
+						};
+						class handgun
+						{
+							name="rhs_weap_pya";
+							class primaryMuzzleMag
+							{
+								name="rhs_mag_9x19_17";
+								ammoLeft=17;
+							};
+						};
+						class uniform
+						{
+							typeName="rhs_uniform_flora_patchless";
+							isBackpack=0;
+							class MagazineCargo
+							{
+								items=1;
+								class Item0
+								{
+									name="rhs_mag_9x19_17";
+									count=1;
+									ammoLeft=17;
+								};
+							};
 							class ItemCargo
 							{
 								items=7;
@@ -10027,27 +13319,27 @@ class items
 								};
 								class Item2
 								{
-									name="ACE_morphine";
-									count=1;
+									name="ACE_tourniquet";
+									count=2;
 								};
 								class Item3
 								{
-									name="rhs_acc_2dpZenit";
+									name="ACE_morphine";
 									count=1;
 								};
 								class Item4
 								{
-									name="ACE_MapTools";
+									name="ACE_epinephrine";
 									count=1;
 								};
 								class Item5
 								{
-									name="ACRE_PRC343";
+									name="rhs_acc_2dpZenit";
 									count=1;
 								};
 								class Item6
 								{
-									name="ACRE_PRC152";
+									name="ACRE_PRC343";
 									count=1;
 								};
 							};
@@ -10058,29 +13350,23 @@ class items
 							isBackpack=0;
 							class MagazineCargo
 							{
-								items=3;
+								items=2;
 								class Item0
-								{
-									name="SmokeShell";
-									count=4;
-									ammoLeft=1;
-								};
-								class Item1
 								{
 									name="HandGrenade";
 									count=2;
 									ammoLeft=1;
 								};
-								class Item2
+								class Item1
 								{
-									name="rhs_30Rnd_545x39_7N22_plum_AK";
+									name="SmokeShell";
 									count=4;
-									ammoLeft=30;
+									ammoLeft=1;
 								};
 							};
 							class ItemCargo
 							{
-								items=5;
+								items=4;
 								class Item0
 								{
 									name="ACE_M26_Clacker";
@@ -10101,218 +13387,28 @@ class items
 									name="ACE_wirecutter";
 									count=1;
 								};
-								class Item4
-								{
-									name="ACE_tourniquet";
-									count=2;
-								};
 							};
 						};
 						class backpack
 						{
 							typeName="B_Carryall_oli";
 							isBackpack=1;
-							class ItemCargo
-							{
-								items=1;
-								class Item0
-								{
-									name="ToolKit";
-									count=1;
-								};
-							};
-						};
-						map="ItemMap";
-						compass="ItemCompass";
-						watch="ItemWatch";
-						gps="ItemGPS";
-						headgear="rhs_altyn";
-					};
-				};
-				id=207;
-				type="O_engineer_F";
-				class CustomAttributes
-				{
-					class Attribute0
-					{
-						property="lambs_danger_disableAI";
-						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
-						class Value
-						{
-							class data
-							{
-								class type
-								{
-									type[]=
-									{
-										"BOOL"
-									};
-								};
-								value=1;
-							};
-						};
-					};
-					class Attribute1
-					{
-						property="a3aa_ee_extended_gear_insignia";
-						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
-						class Value
-						{
-							class data
-							{
-								class type
-								{
-									type[]=
-									{
-										"STRING"
-									};
-								};
-								value="CNTOpatchAlt";
-							};
-						};
-					};
-					nAttributes=2;
-				};
-			};
-			class Item1
-			{
-				dataType="Object";
-				class PositionInfo
-				{
-					position[]={5.512207,0.0014390945,-1.5825195};
-					angles[]={0,6.2723818,0};
-				};
-				side="East";
-				flags=5;
-				class Attributes
-				{
-					init="call{this disableAI ""MOVE"";" \n "this setSpeaker ""NoVoice"";" \n "enableRadio false;}";
-					description="Engineer Rifleman";
-					isPlayable=1;
-					class Inventory
-					{
-						class primaryWeapon
-						{
-							name="rhs_weap_ak105";
-							muzzle="rhs_acc_dtk";
-							class primaryMuzzleMag
-							{
-								name="rhs_30Rnd_545x39_7N22_plum_AK";
-								ammoLeft=30;
-							};
-						};
-						class handgun
-						{
-							name="rhs_weap_pya";
-							class primaryMuzzleMag
-							{
-								name="rhs_mag_9x19_17";
-								ammoLeft=17;
-							};
-						};
-						class binocular
-						{
-							name="ACE_VectorDay";
-						};
-						class uniform
-						{
-							typeName="rhs_uniform_flora_patchless";
-							isBackpack=0;
-							class ItemCargo
-							{
-								items=6;
-								class Item0
-								{
-									name="ACE_fieldDressing";
-									count=4;
-								};
-								class Item1
-								{
-									name="ACE_quikclot";
-									count=6;
-								};
-								class Item2
-								{
-									name="ACE_morphine";
-									count=1;
-								};
-								class Item3
-								{
-									name="rhs_acc_2dpZenit";
-									count=1;
-								};
-								class Item4
-								{
-									name="ACE_MapTools";
-									count=1;
-								};
-								class Item5
-								{
-									name="ACRE_PRC343";
-									count=1;
-								};
-							};
-						};
-						class vest
-						{
-							typeName="rhs_6b13_EMR_6sh92";
-							isBackpack=0;
 							class MagazineCargo
 							{
-								items=3;
+								items=2;
 								class Item0
 								{
-									name="SmokeShell";
-									count=4;
-									ammoLeft=1;
+									name="rhs_30Rnd_545x39_7N22_plum_AK";
+									count=5;
+									ammoLeft=30;
 								};
 								class Item1
 								{
-									name="HandGrenade";
-									count=2;
-									ammoLeft=1;
-								};
-								class Item2
-								{
-									name="rhs_30Rnd_545x39_7N22_plum_AK";
-									count=4;
+									name="rhs_30Rnd_545x39_AK_plum_green";
+									count=1;
 									ammoLeft=30;
 								};
 							};
-							class ItemCargo
-							{
-								items=5;
-								class Item0
-								{
-									name="ACE_M26_Clacker";
-									count=1;
-								};
-								class Item1
-								{
-									name="ACE_DefusalKit";
-									count=1;
-								};
-								class Item2
-								{
-									name="ACE_EntrenchingTool";
-									count=1;
-								};
-								class Item3
-								{
-									name="ACE_wirecutter";
-									count=1;
-								};
-								class Item4
-								{
-									name="ACE_tourniquet";
-									count=2;
-								};
-							};
-						};
-						class backpack
-						{
-							typeName="B_Carryall_oli";
-							isBackpack=1;
 							class ItemCargo
 							{
 								items=1;
@@ -10326,11 +13422,10 @@ class items
 						map="ItemMap";
 						compass="ItemCompass";
 						watch="ItemWatch";
-						gps="ItemGPS";
 						headgear="rhs_altyn_visordown";
 					};
 				};
-				id=208;
+				id=54;
 				type="O_engineer_F";
 				class CustomAttributes
 				{
@@ -10372,7 +13467,43 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="7";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=3;
 				};
 			};
 			class Item2
@@ -10380,7 +13511,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={6.512207,0.0014390945,-1.5717773};
+					position[]={6.449707,0.0014390945,-1.3436279};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -10411,17 +13542,23 @@ class items
 								ammoLeft=17;
 							};
 						};
-						class binocular
-						{
-							name="ACE_VectorDay";
-						};
 						class uniform
 						{
 							typeName="rhs_uniform_flora_patchless";
 							isBackpack=0;
+							class MagazineCargo
+							{
+								items=1;
+								class Item0
+								{
+									name="rhs_mag_9x19_17";
+									count=1;
+									ammoLeft=17;
+								};
+							};
 							class ItemCargo
 							{
-								items=6;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -10434,20 +13571,25 @@ class items
 								};
 								class Item2
 								{
-									name="ACE_morphine";
-									count=1;
+									name="ACE_tourniquet";
+									count=2;
 								};
 								class Item3
 								{
-									name="rhs_acc_2dpZenit";
+									name="ACE_morphine";
 									count=1;
 								};
 								class Item4
 								{
-									name="ACE_MapTools";
+									name="ACE_epinephrine";
 									count=1;
 								};
 								class Item5
+								{
+									name="rhs_acc_2dpZenit";
+									count=1;
+								};
+								class Item6
 								{
 									name="ACRE_PRC343";
 									count=1;
@@ -10456,33 +13598,27 @@ class items
 						};
 						class vest
 						{
-							typeName="rhs_6b13_EMR_6sh92";
+							typeName="rhs_6b13_EMR_6sh92_radio";
 							isBackpack=0;
 							class MagazineCargo
 							{
-								items=3;
+								items=2;
 								class Item0
-								{
-									name="SmokeShell";
-									count=4;
-									ammoLeft=1;
-								};
-								class Item1
 								{
 									name="HandGrenade";
 									count=2;
 									ammoLeft=1;
 								};
-								class Item2
+								class Item1
 								{
-									name="rhs_30Rnd_545x39_7N22_plum_AK";
+									name="SmokeShell";
 									count=4;
-									ammoLeft=30;
+									ammoLeft=1;
 								};
 							};
 							class ItemCargo
 							{
-								items=5;
+								items=4;
 								class Item0
 								{
 									name="ACE_M26_Clacker";
@@ -10503,17 +13639,28 @@ class items
 									name="ACE_wirecutter";
 									count=1;
 								};
-								class Item4
-								{
-									name="ACE_tourniquet";
-									count=2;
-								};
 							};
 						};
 						class backpack
 						{
 							typeName="B_Carryall_oli";
 							isBackpack=1;
+							class MagazineCargo
+							{
+								items=2;
+								class Item0
+								{
+									name="rhs_30Rnd_545x39_7N22_plum_AK";
+									count=5;
+									ammoLeft=30;
+								};
+								class Item1
+								{
+									name="rhs_30Rnd_545x39_AK_plum_green";
+									count=1;
+									ammoLeft=30;
+								};
+							};
 							class ItemCargo
 							{
 								items=1;
@@ -10527,11 +13674,10 @@ class items
 						map="ItemMap";
 						compass="ItemCompass";
 						watch="ItemWatch";
-						gps="ItemGPS";
 						headgear="rhs_altyn_bala";
 					};
 				};
-				id=209;
+				id=55;
 				type="O_engineer_F";
 				class CustomAttributes
 				{
@@ -10573,7 +13719,43 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="7";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=3;
 				};
 			};
 			class Item3
@@ -10581,7 +13763,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={7.512207,0.0014390945,-1.5610352};
+					position[]={7.449707,0.0014390945,-1.3328857};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -10612,17 +13794,23 @@ class items
 								ammoLeft=17;
 							};
 						};
-						class binocular
-						{
-							name="ACE_VectorDay";
-						};
 						class uniform
 						{
 							typeName="rhs_uniform_flora_patchless";
 							isBackpack=0;
+							class MagazineCargo
+							{
+								items=1;
+								class Item0
+								{
+									name="rhs_mag_9x19_17";
+									count=1;
+									ammoLeft=17;
+								};
+							};
 							class ItemCargo
 							{
-								items=6;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -10635,20 +13823,25 @@ class items
 								};
 								class Item2
 								{
-									name="ACE_morphine";
-									count=1;
+									name="ACE_tourniquet";
+									count=2;
 								};
 								class Item3
 								{
-									name="rhs_acc_2dpZenit";
+									name="ACE_morphine";
 									count=1;
 								};
 								class Item4
 								{
-									name="ACE_MapTools";
+									name="ACE_epinephrine";
 									count=1;
 								};
 								class Item5
+								{
+									name="rhs_acc_2dpZenit";
+									count=1;
+								};
+								class Item6
 								{
 									name="ACRE_PRC343";
 									count=1;
@@ -10657,33 +13850,27 @@ class items
 						};
 						class vest
 						{
-							typeName="rhs_6b13_EMR_6sh92";
+							typeName="rhs_6b13_EMR_6sh92_radio";
 							isBackpack=0;
 							class MagazineCargo
 							{
-								items=3;
+								items=2;
 								class Item0
-								{
-									name="SmokeShell";
-									count=4;
-									ammoLeft=1;
-								};
-								class Item1
 								{
 									name="HandGrenade";
 									count=2;
 									ammoLeft=1;
 								};
-								class Item2
+								class Item1
 								{
-									name="rhs_30Rnd_545x39_7N22_plum_AK";
+									name="SmokeShell";
 									count=4;
-									ammoLeft=30;
+									ammoLeft=1;
 								};
 							};
 							class ItemCargo
 							{
-								items=5;
+								items=4;
 								class Item0
 								{
 									name="ACE_M26_Clacker";
@@ -10704,17 +13891,28 @@ class items
 									name="ACE_wirecutter";
 									count=1;
 								};
-								class Item4
-								{
-									name="ACE_tourniquet";
-									count=2;
-								};
 							};
 						};
 						class backpack
 						{
 							typeName="B_Carryall_oli";
 							isBackpack=1;
+							class MagazineCargo
+							{
+								items=2;
+								class Item0
+								{
+									name="rhs_30Rnd_545x39_7N22_plum_AK";
+									count=5;
+									ammoLeft=30;
+								};
+								class Item1
+								{
+									name="rhs_30Rnd_545x39_AK_plum_green";
+									count=1;
+									ammoLeft=30;
+								};
+							};
 							class ItemCargo
 							{
 								items=1;
@@ -10728,11 +13926,10 @@ class items
 						map="ItemMap";
 						compass="ItemCompass";
 						watch="ItemWatch";
-						gps="ItemGPS";
 						headgear="rhs_altyn_visordown";
 					};
 				};
-				id=210;
+				id=56;
 				type="O_engineer_F";
 				class CustomAttributes
 				{
@@ -10774,14 +13971,50 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="7";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=3;
 				};
 			};
 		};
 		class Attributes
 		{
 		};
-		id=206;
+		id=52;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -10818,7 +14051,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-6.527832,0.0014390945,-7.7495117};
+					position[]={-6.590332,0.0014390945,-7.5217285};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -10859,45 +14092,55 @@ class items
 							isBackpack=0;
 							class ItemCargo
 							{
-								items=8;
+								items=10;
 								class Item0
 								{
-									name="ACE_quikclot";
-									count=10;
+									name="ACE_fieldDressing";
+									count=4;
 								};
 								class Item1
+								{
+									name="ACE_quikclot";
+									count=6;
+								};
+								class Item2
+								{
+									name="ACE_tourniquet";
+									count=2;
+								};
+								class Item3
 								{
 									name="ACE_morphine";
 									count=1;
 								};
-								class Item2
-								{
-									name="rhs_acc_2dpZenit";
-									count=1;
-								};
-								class Item3
-								{
-									name="ACRE_PRC343";
-									count=1;
-								};
 								class Item4
 								{
-									name="ACE_MapTools";
+									name="ACE_epinephrine";
 									count=1;
 								};
 								class Item5
 								{
-									name="ACRE_PRC152";
+									name="ACE_MapTools";
 									count=1;
 								};
 								class Item6
 								{
-									name="ACRE_PRC148";
+									name="rhs_acc_2dpZenit";
 									count=1;
 								};
 								class Item7
 								{
-									name="ACE_tourniquet";
+									name="ACRE_PRC343";
+									count=1;
+								};
+								class Item8
+								{
+									name="ACRE_PRC152";
+									count=1;
+								};
+								class Item9
+								{
+									name="ACRE_PRC148";
 									count=1;
 								};
 							};
@@ -10908,45 +14151,42 @@ class items
 							isBackpack=0;
 							class MagazineCargo
 							{
-								items=5;
+								items=6;
 								class Item0
-								{
-									name="SmokeShell";
-									count=2;
-									ammoLeft=1;
-								};
-								class Item1
-								{
-									name="SmokeShellGreen";
-									count=2;
-									ammoLeft=1;
-								};
-								class Item2
-								{
-									name="SmokeShellBlue";
-									count=2;
-									ammoLeft=1;
-								};
-								class Item3
 								{
 									name="rhs_mag_9x19mm_7n21_20";
 									count=6;
 									ammoLeft=20;
 								};
-								class Item4
+								class Item1
+								{
+									name="rhs_mag_9x19_17";
+									count=1;
+									ammoLeft=17;
+								};
+								class Item2
 								{
 									name="HandGrenade";
 									count=2;
 									ammoLeft=1;
 								};
-							};
-							class ItemCargo
-							{
-								items=1;
-								class Item0
+								class Item3
 								{
-									name="ACE_tourniquet";
+									name="SmokeShell";
+									count=4;
+									ammoLeft=1;
+								};
+								class Item4
+								{
+									name="SmokeShellGreen";
+									count=2;
+									ammoLeft=1;
+								};
+								class Item5
+								{
+									name="SmokeShellBlue";
 									count=1;
+									ammoLeft=1;
 								};
 							};
 						};
@@ -10958,7 +14198,7 @@ class items
 						headgear="rhs_tsh4";
 					};
 				};
-				id=212;
+				id=58;
 				type="O_crew_F";
 				class CustomAttributes
 				{
@@ -11000,7 +14240,109 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=3;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="0";
+										};
+									};
+									class Item1
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+									class Item2
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="2";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute3
+					{
+						property="speaker";
+						expression="_this setspeaker _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="Male03PER";
+							};
+						};
+					};
+					class Attribute4
+					{
+						property="pitch";
+						expression="_this setpitch _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"SCALAR"
+									};
+								};
+								value=1.01;
+							};
+						};
+					};
+					nAttributes=5;
 				};
 			};
 			class Item1
@@ -11008,7 +14350,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-5.527832,0.0014390945,-7.7387695};
+					position[]={-5.590332,0.0014390945,-7.5106201};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -11042,32 +14384,52 @@ class items
 						{
 							typeName="rhs_uniform_gorka_r_g";
 							isBackpack=0;
-							class ItemCargo
+							class MagazineCargo
 							{
-								items=5;
+								items=1;
 								class Item0
 								{
-									name="ACE_quikclot";
-									count=10;
+									name="rhs_mag_9x19_17";
+									count=1;
+									ammoLeft=17;
+								};
+							};
+							class ItemCargo
+							{
+								items=7;
+								class Item0
+								{
+									name="ACE_fieldDressing";
+									count=4;
 								};
 								class Item1
+								{
+									name="ACE_quikclot";
+									count=6;
+								};
+								class Item2
+								{
+									name="ACE_tourniquet";
+									count=2;
+								};
+								class Item3
 								{
 									name="ACE_morphine";
 									count=1;
 								};
-								class Item2
+								class Item4
+								{
+									name="ACE_epinephrine";
+									count=1;
+								};
+								class Item5
 								{
 									name="rhs_acc_2dpZenit";
 									count=1;
 								};
-								class Item3
+								class Item6
 								{
 									name="ACRE_PRC343";
-									count=1;
-								};
-								class Item4
-								{
-									name="ACE_tourniquet";
 									count=1;
 								};
 							};
@@ -11078,45 +14440,42 @@ class items
 							isBackpack=0;
 							class MagazineCargo
 							{
-								items=5;
+								items=6;
 								class Item0
-								{
-									name="SmokeShell";
-									count=2;
-									ammoLeft=1;
-								};
-								class Item1
-								{
-									name="SmokeShellGreen";
-									count=2;
-									ammoLeft=1;
-								};
-								class Item2
-								{
-									name="SmokeShellBlue";
-									count=2;
-									ammoLeft=1;
-								};
-								class Item3
 								{
 									name="rhs_mag_9x19mm_7n21_20";
 									count=6;
 									ammoLeft=20;
 								};
-								class Item4
+								class Item1
+								{
+									name="rhs_mag_9x19_17";
+									count=1;
+									ammoLeft=17;
+								};
+								class Item2
 								{
 									name="HandGrenade";
 									count=2;
 									ammoLeft=1;
 								};
-							};
-							class ItemCargo
-							{
-								items=1;
-								class Item0
+								class Item3
 								{
-									name="ACE_tourniquet";
+									name="SmokeShell";
+									count=4;
+									ammoLeft=1;
+								};
+								class Item4
+								{
+									name="SmokeShellGreen";
+									count=2;
+									ammoLeft=1;
+								};
+								class Item5
+								{
+									name="SmokeShellBlue";
 									count=1;
+									ammoLeft=1;
 								};
 							};
 						};
@@ -11142,7 +14501,7 @@ class items
 						headgear="rhs_tsh4";
 					};
 				};
-				id=213;
+				id=59;
 				type="O_crew_F";
 				class CustomAttributes
 				{
@@ -11211,7 +14570,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-4.527832,0.0014390945,-7.7280273};
+					position[]={-4.590332,0.0014390945,-7.4998779};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -11246,32 +14605,52 @@ class items
 						{
 							typeName="rhs_uniform_gorka_r_g";
 							isBackpack=0;
-							class ItemCargo
+							class MagazineCargo
 							{
-								items=5;
+								items=1;
 								class Item0
 								{
-									name="ACE_quikclot";
-									count=10;
+									name="rhs_mag_9x19_17";
+									count=1;
+									ammoLeft=17;
+								};
+							};
+							class ItemCargo
+							{
+								items=7;
+								class Item0
+								{
+									name="ACE_fieldDressing";
+									count=4;
 								};
 								class Item1
+								{
+									name="ACE_quikclot";
+									count=6;
+								};
+								class Item2
+								{
+									name="ACE_tourniquet";
+									count=2;
+								};
+								class Item3
 								{
 									name="ACE_morphine";
 									count=1;
 								};
-								class Item2
+								class Item4
+								{
+									name="ACE_epinephrine";
+									count=1;
+								};
+								class Item5
 								{
 									name="rhs_acc_2dpZenit";
 									count=1;
 								};
-								class Item3
+								class Item6
 								{
 									name="ACRE_PRC343";
-									count=1;
-								};
-								class Item4
-								{
-									name="ACE_tourniquet";
 									count=1;
 								};
 							};
@@ -11282,45 +14661,42 @@ class items
 							isBackpack=0;
 							class MagazineCargo
 							{
-								items=5;
+								items=6;
 								class Item0
-								{
-									name="SmokeShell";
-									count=2;
-									ammoLeft=1;
-								};
-								class Item1
-								{
-									name="SmokeShellGreen";
-									count=2;
-									ammoLeft=1;
-								};
-								class Item2
-								{
-									name="SmokeShellBlue";
-									count=2;
-									ammoLeft=1;
-								};
-								class Item3
 								{
 									name="rhs_mag_9x19mm_7n21_20";
 									count=6;
 									ammoLeft=20;
 								};
-								class Item4
+								class Item1
+								{
+									name="rhs_mag_9x19_17";
+									count=1;
+									ammoLeft=17;
+								};
+								class Item2
 								{
 									name="HandGrenade";
 									count=2;
 									ammoLeft=1;
 								};
-							};
-							class ItemCargo
-							{
-								items=1;
-								class Item0
+								class Item3
 								{
-									name="ACE_tourniquet";
+									name="SmokeShell";
+									count=4;
+									ammoLeft=1;
+								};
+								class Item4
+								{
+									name="SmokeShellGreen";
+									count=2;
+									ammoLeft=1;
+								};
+								class Item5
+								{
+									name="SmokeShellBlue";
 									count=1;
+									ammoLeft=1;
 								};
 							};
 						};
@@ -11331,7 +14707,7 @@ class items
 						headgear="rhs_tsh4";
 					};
 				};
-				id=214;
+				id=60;
 				type="O_crew_F";
 				class CustomAttributes
 				{
@@ -11399,7 +14775,7 @@ class items
 		class Attributes
 		{
 		};
-		id=211;
+		id=57;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -11436,7 +14812,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-0.70654297,0.0014390945,-8.0961914};
+					position[]={-0.76904297,0.0014390945,-7.8677979};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -11477,45 +14853,55 @@ class items
 							isBackpack=0;
 							class ItemCargo
 							{
-								items=8;
+								items=10;
 								class Item0
 								{
-									name="ACE_quikclot";
-									count=10;
+									name="ACE_fieldDressing";
+									count=4;
 								};
 								class Item1
+								{
+									name="ACE_quikclot";
+									count=6;
+								};
+								class Item2
+								{
+									name="ACE_tourniquet";
+									count=2;
+								};
+								class Item3
 								{
 									name="ACE_morphine";
 									count=1;
 								};
-								class Item2
-								{
-									name="rhs_acc_2dpZenit";
-									count=1;
-								};
-								class Item3
-								{
-									name="ACRE_PRC343";
-									count=1;
-								};
 								class Item4
 								{
-									name="ACE_MapTools";
+									name="ACE_epinephrine";
 									count=1;
 								};
 								class Item5
 								{
-									name="ACRE_PRC152";
+									name="ACE_MapTools";
 									count=1;
 								};
 								class Item6
 								{
-									name="ACRE_PRC148";
+									name="rhs_acc_2dpZenit";
 									count=1;
 								};
 								class Item7
 								{
-									name="ACE_tourniquet";
+									name="ACRE_PRC343";
+									count=1;
+								};
+								class Item8
+								{
+									name="ACRE_PRC152";
+									count=1;
+								};
+								class Item9
+								{
+									name="ACRE_PRC148";
 									count=1;
 								};
 							};
@@ -11526,45 +14912,42 @@ class items
 							isBackpack=0;
 							class MagazineCargo
 							{
-								items=5;
+								items=6;
 								class Item0
-								{
-									name="SmokeShell";
-									count=1;
-									ammoLeft=1;
-								};
-								class Item1
-								{
-									name="SmokeShellGreen";
-									count=2;
-									ammoLeft=1;
-								};
-								class Item2
-								{
-									name="SmokeShellBlue";
-									count=2;
-									ammoLeft=1;
-								};
-								class Item3
 								{
 									name="rhs_mag_9x19mm_7n21_20";
 									count=6;
 									ammoLeft=20;
 								};
-								class Item4
+								class Item1
+								{
+									name="rhs_mag_9x19_17";
+									count=1;
+									ammoLeft=17;
+								};
+								class Item2
 								{
 									name="HandGrenade";
+									count=1;
+									ammoLeft=1;
+								};
+								class Item3
+								{
+									name="SmokeShell";
+									count=4;
+									ammoLeft=1;
+								};
+								class Item4
+								{
+									name="SmokeShellGreen";
 									count=2;
 									ammoLeft=1;
 								};
-							};
-							class ItemCargo
-							{
-								items=1;
-								class Item0
+								class Item5
 								{
-									name="ACE_tourniquet";
+									name="SmokeShellBlue";
 									count=1;
+									ammoLeft=1;
 								};
 							};
 						};
@@ -11576,7 +14959,7 @@ class items
 						headgear="rhs_zsh7a_mike_green_alt";
 					};
 				};
-				id=216;
+				id=62;
 				type="O_Pilot_F";
 				class CustomAttributes
 				{
@@ -11637,7 +15020,109 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					class Attribute3
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=3;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="0";
+										};
+									};
+									class Item1
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+									class Item2
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="3";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute4
+					{
+						property="speaker";
+						expression="_this setspeaker _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="Male01PER";
+							};
+						};
+					};
+					class Attribute5
+					{
+						property="pitch";
+						expression="_this setpitch _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"SCALAR"
+									};
+								};
+								value=1.02;
+							};
+						};
+					};
+					nAttributes=6;
 				};
 			};
 			class Item1
@@ -11645,7 +15130,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={0.29345703,0.0014390945,-8.0864258};
+					position[]={0.23095703,0.0014390945,-7.8582764};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -11685,45 +15170,55 @@ class items
 							isBackpack=0;
 							class ItemCargo
 							{
-								items=8;
+								items=10;
 								class Item0
 								{
-									name="ACE_quikclot";
-									count=10;
+									name="ACE_fieldDressing";
+									count=4;
 								};
 								class Item1
+								{
+									name="ACE_quikclot";
+									count=6;
+								};
+								class Item2
+								{
+									name="ACE_tourniquet";
+									count=2;
+								};
+								class Item3
 								{
 									name="ACE_morphine";
 									count=1;
 								};
-								class Item2
-								{
-									name="rhs_acc_2dpZenit";
-									count=1;
-								};
-								class Item3
-								{
-									name="ACRE_PRC343";
-									count=1;
-								};
 								class Item4
 								{
-									name="ACE_MapTools";
+									name="ACE_epinephrine";
 									count=1;
 								};
 								class Item5
 								{
-									name="ACRE_PRC152";
+									name="ACE_MapTools";
 									count=1;
 								};
 								class Item6
 								{
-									name="ACRE_PRC148";
+									name="rhs_acc_2dpZenit";
 									count=1;
 								};
 								class Item7
 								{
-									name="ACE_tourniquet";
+									name="ACRE_PRC343";
+									count=1;
+								};
+								class Item8
+								{
+									name="ACRE_PRC152";
+									count=1;
+								};
+								class Item9
+								{
+									name="ACRE_PRC148";
 									count=1;
 								};
 							};
@@ -11734,45 +15229,42 @@ class items
 							isBackpack=0;
 							class MagazineCargo
 							{
-								items=5;
+								items=6;
 								class Item0
-								{
-									name="SmokeShell";
-									count=1;
-									ammoLeft=1;
-								};
-								class Item1
-								{
-									name="SmokeShellGreen";
-									count=2;
-									ammoLeft=1;
-								};
-								class Item2
-								{
-									name="SmokeShellBlue";
-									count=2;
-									ammoLeft=1;
-								};
-								class Item3
 								{
 									name="rhs_mag_9x19mm_7n21_20";
 									count=6;
 									ammoLeft=20;
 								};
-								class Item4
+								class Item1
+								{
+									name="rhs_mag_9x19_17";
+									count=1;
+									ammoLeft=17;
+								};
+								class Item2
 								{
 									name="HandGrenade";
+									count=1;
+									ammoLeft=1;
+								};
+								class Item3
+								{
+									name="SmokeShell";
+									count=4;
+									ammoLeft=1;
+								};
+								class Item4
+								{
+									name="SmokeShellGreen";
 									count=2;
 									ammoLeft=1;
 								};
-							};
-							class ItemCargo
-							{
-								items=1;
-								class Item0
+								class Item5
 								{
-									name="ACE_tourniquet";
+									name="SmokeShellBlue";
 									count=1;
+									ammoLeft=1;
 								};
 							};
 						};
@@ -11798,7 +15290,7 @@ class items
 						headgear="rhs_zsh7a_mike_green_alt";
 					};
 				};
-				id=217;
+				id=63;
 				type="O_Pilot_F";
 				class CustomAttributes
 				{
@@ -11859,14 +15351,97 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					class Attribute3
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=3;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="0";
+										};
+									};
+									class Item1
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+									class Item2
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="3";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute4
+					{
+						property="speaker";
+						expression="_this setspeaker _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="Male01PER";
+							};
+						};
+					};
+					nAttributes=5;
 				};
 			};
 		};
 		class Attributes
 		{
 		};
-		id=215;
+		id=61;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -11903,7 +15478,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={3.081543,0.0014390945,-8.2119141};
+					position[]={3.0185547,0.0014390945,-7.9837646};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -11944,45 +15519,55 @@ class items
 							isBackpack=0;
 							class ItemCargo
 							{
-								items=8;
+								items=10;
 								class Item0
 								{
-									name="ACE_quikclot";
-									count=10;
+									name="ACE_fieldDressing";
+									count=4;
 								};
 								class Item1
+								{
+									name="ACE_quikclot";
+									count=6;
+								};
+								class Item2
+								{
+									name="ACE_tourniquet";
+									count=2;
+								};
+								class Item3
 								{
 									name="ACE_morphine";
 									count=1;
 								};
-								class Item2
-								{
-									name="rhs_acc_2dpZenit";
-									count=1;
-								};
-								class Item3
-								{
-									name="ACRE_PRC343";
-									count=1;
-								};
 								class Item4
 								{
-									name="ACE_MapTools";
+									name="ACE_epinephrine";
 									count=1;
 								};
 								class Item5
 								{
-									name="ACRE_PRC152";
+									name="ACE_MapTools";
 									count=1;
 								};
 								class Item6
 								{
-									name="ACRE_PRC148";
+									name="rhs_acc_2dpZenit";
 									count=1;
 								};
 								class Item7
 								{
-									name="ACE_tourniquet";
+									name="ACRE_PRC343";
+									count=1;
+								};
+								class Item8
+								{
+									name="ACRE_PRC152";
+									count=1;
+								};
+								class Item9
+								{
+									name="ACRE_PRC148";
 									count=1;
 								};
 							};
@@ -11993,45 +15578,42 @@ class items
 							isBackpack=0;
 							class MagazineCargo
 							{
-								items=5;
+								items=6;
 								class Item0
-								{
-									name="SmokeShell";
-									count=1;
-									ammoLeft=1;
-								};
-								class Item1
-								{
-									name="SmokeShellGreen";
-									count=2;
-									ammoLeft=1;
-								};
-								class Item2
-								{
-									name="SmokeShellBlue";
-									count=2;
-									ammoLeft=1;
-								};
-								class Item3
-								{
-									name="HandGrenade";
-									count=2;
-									ammoLeft=1;
-								};
-								class Item4
 								{
 									name="rhs_mag_9x19mm_7n21_20";
 									count=6;
 									ammoLeft=20;
 								};
-							};
-							class ItemCargo
-							{
-								items=1;
-								class Item0
+								class Item1
 								{
-									name="ACE_tourniquet";
+									name="rhs_mag_9x19_17";
 									count=1;
+									ammoLeft=17;
+								};
+								class Item2
+								{
+									name="HandGrenade";
+									count=1;
+									ammoLeft=1;
+								};
+								class Item3
+								{
+									name="SmokeShell";
+									count=4;
+									ammoLeft=1;
+								};
+								class Item4
+								{
+									name="SmokeShellGreen";
+									count=2;
+									ammoLeft=1;
+								};
+								class Item5
+								{
+									name="SmokeShellBlue";
+									count=1;
+									ammoLeft=1;
 								};
 							};
 						};
@@ -12047,7 +15629,7 @@ class items
 						headgear="H_PilotHelmetFighter_O";
 					};
 				};
-				id=219;
+				id=65;
 				type="O_Pilot_F";
 				class CustomAttributes
 				{
@@ -12146,14 +15728,78 @@ class items
 							};
 						};
 					};
-					nAttributes=5;
+					class Attribute5
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=3;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="0";
+										};
+									};
+									class Item1
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+									class Item2
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="3";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=6;
 				};
 			};
 		};
 		class Attributes
 		{
 		};
-		id=218;
+		id=64;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -12181,38 +15827,40 @@ class items
 	class Item12
 	{
 		dataType="Marker";
-		position[]={2.3173828,2.4371225e+032,-4.8920898};
+		position[]={2.2553711,2.4371225e+032,-4.6639404};
 		name="respawn_east";
 		type="respawn_unknown";
 		angle=359.38113;
-		id=220;
+		id=66;
 		atlOffset=2.4371225e+032;
 	};
 	class Item13
 	{
 		dataType="Marker";
-		position[]={6.7553711,0,-6.6118164};
+		position[]={6.6928711,0,-6.383667};
 		name="resupply_marker_1";
 		text="Resupply";
 		type="mil_triangle";
 		colorName="ColorGreen";
 		angle=359.38086;
-		id=221;
+		id=67;
 	};
 	class Item14
 	{
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={5.3676758,0.14963102,-6.9575195};
+			position[]={5.3046875,0.14963102,-6.7297974};
 			angles[]={-0,1.5418237,0};
 		};
 		side="Empty";
 		flags=4;
 		class Attributes
 		{
+			name="MAT_Launcher_Supply_Box";
+			description="MAT Launcher Supply Box";
 		};
-		id=222;
+		id=68;
 		type="Box_East_WpsLaunch_F";
 		class CustomAttributes
 		{
@@ -12243,11 +15891,11 @@ class items
 		dataType="Comment";
 		class PositionInfo
 		{
-			position[]={2.5478516,0,-3.7329102};
+			position[]={2.4858398,0,-3.5047607};
 		};
-		title="v1.14.1";
-		description="-v1.14.1" \n " - A3EE box guard updated to A3AA." \n " - Custom location re-added." \n "" \n "-v1.14.0" \n "PL: " \n "- Headgear changed from RHS ""Field Cap EMR-Summer"" to RHS ""Field Cap VSR"". " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest changed from RHS ""6B23 (6Sh116/VOG)"" to RHS ""6B23 EMR-Summer (6Sh92/Headset/Mapcase)"" for more visual diversity in the platoon. " \n "- Vest content: moved 2x RGO grenades to backpack, removed 3x RHS ""30Rnd AK-74 (Plum) 7N22"" and added 4x RHS ""30Rnd AK-74 (Plum) 7T3M (tracer)"" to match TFN and US Army loadouts. " \n "- Backpack changed from vanilla ""Assaultpack green"" to RHS ""UMBTS Backpack"" for a more Russian look. " \n "- Backpack content: increased GL smoke white from 3x to 5x to match TFN and US Army loadouts. " \n "- Rifle mag changed from RHS ""30Rnd AK-74 (Plum) 7N10"" to RHS ""30Rnd AK-74 (Plum) 7N22"" to match the other mags in the vest. " \n " " \n " Platoon Sergeant: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" to RHS ""6B26 (ESS)"" to indicate association with platoon lead element and for more visual diversity in the platoon. " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest content: removed 3x RHS ""30Rnd AK-74 (Plum) 7N22"" and added 4x RHS ""30Rnd AK-74 (Plum) 7T3M (tracer)"" to match TFN and US Army loadouts. " \n "- Backpack added 3CB ""Radio Backpack MR3000"" and filled it with the ACRE2 ""AN/PRC-117F"" backpack radio. This gives more incentive to bring the PLT Sgt along since he is the only one who can act as a max range radio man for the platoon. " \n "- Rifle mag changed from RHS ""30Rnd AK-74 (Plum) 7N10"" to RHS ""30Rnd AK-74 (Plum) 7N22"" to match the other mags in the vest. " \n "  " \n "Platoon Medic: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" to RHS ""6B26"" to indicate association with platoon lead element and for more visual diversity in the platoon. " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest changed from RHS ""6B23 (6Sh116)"" to RHS ""6B23 EMR-Summer (Medic)"". " \n "- Vest content: removed 1x RHS ""30Rnd AK-74 (Plum) 7N22"" and added 2x RHS ""30Rnd AK-74 (Plum) 7T3M (tracer)"" to match TFN and US Army loadouts. " \n "- Backpack changed from vanilla ""Kitback (green)"" to 3CB ""Knapsack Medical (Khaki)"" to visually make the Vest medical bag look like the primary backpack. " \n "- Rifle changed from RHS ""AK-74M (Plum)"" to RHS ""AKS-74U"" for more rifle diversity in the platoon. Slightly lower accuracy at range but lighter carry weight. " \n "- Rifle mag changed from RHS ""30Rnd AK-74 (Plum) 7N10"" to RHS ""30Rnd AK-74 (Plum) 7N22"" to match the other mags in the vest. " \n " " \n "Platoon Rifleman: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" to RHS ""6B26 (ESS/Balaclava)"" to indicate association with platoon lead element and for more visual diversity in the platoon. " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest changed from RHS ""6B23 (6Sh116)"" to RHS ""6B23 EMR-Summer (6Sh116)"". " \n "- Vest content: removed 1x RHS ""30Rnd AK-74 (Plum) 7N22"" and added 2x RHS ""30Rnd AK-74 (Plum) 7T3M (tracer)"" to match TFN and US Army loadouts. " \n "- Rifle mag changed from RHS ""30Rnd AK-74 (Plum) 7N10"" to RHS ""30Rnd AK-74 (Plum) 7N22"" to match the other mags in the vest. " \n " " \n "SL: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" semi-randomly to RHS ""6B27M"" or RHS ""6B27M (ESS)"" or RHS ""6B27M (Balaclava)"". " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest changed from RHS ""6B23 (6Sh116/VOG)"" to RHS ""6B23 EMR-Summer (6Sh92/VOG/Radio) SpNz"".  " \n "- Vest content: moved 2x RGO grenades to backpack, removed 3x RHS ""30Rnd AK-74 (Plum) 7N22"" and added 4x RHS ""30Rnd AK-74 (Plum) 7T3M (tracer)"" to match TFN and US Army loadouts. " \n "- Backpack changed from vanilla ""Assaultpack green"" to RHS ""UMBTS Backpack"" for a more Russian look. " \n "- Backpack content: added 1x RHS ""VOG-25"" to match TFN and US Army loadouts. " \n "- Rifle mag changed from RHS ""30Rnd AK-74 (Plum) 7N10"" to RHS ""30Rnd AK-74 (Plum) 7N22"" to match the other mags in the vest.  " \n " " \n "SL Medic: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" semi-randomly to RHS ""6B27M"" or RHS ""6B27M (ESS)"" or RHS ""6B27M (Balaclava)"". " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest changed from RHS ""6B23 (6Sh116)"" semi-randomly to RHS ""6B23 EMR-Summer (Medic)"" or RHS ""6B23 (Medic)"". " \n "- Vest content: removed 1x RHS ""30Rnd AK-74 (Plum) 7N22"" and added 2x RHS ""30Rnd AK-74 (Plum) 7T3M (tracer)"" to match TFN and US Army loadouts. " \n "- Backpack changed from vanilla ""Kitback (green)"" to 3CB ""Knapsack Medical (Khaki)"" to visually make the Vest medical bag look like the primary backpack. " \n "- Rifle changed from RHS ""AK-74M (Plum)"" to RHS ""AKS-74U"" for more rifle diversity in the platoon. Slightly lower accuracy at range but lighter carry weight. " \n "- Rifle mag changed from RHS ""30Rnd AK-74 (Plum) 7N10"" to RHS ""30Rnd AK-74 (Plum) 7N22"" to match the other mags in the vest. " \n "  " \n "FTL: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" semi-randomly to RHS ""6B27M"" or RHS ""6B27M (ESS)"" or RHS ""6B27M (Balaclava)"". " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest changed from RHS ""6B23 (6Sh116/VOG)"" semi-randomly to RHS ""6B23 EMR-Summer (6Sh92/VOG/Headset)"" or RHS ""6B23 (6Sh92/VOG/Headset)"". " \n "- Vest content: moved 2x RGO grenades to backpack, removed 3x RHS ""30Rnd AK-74 (Plum) 7N22"" and added 4x RHS ""30Rnd AK-74 (Plum) 7T3M (tracer)"" to match TFN and US Army loadouts. " \n "- Backpack changed from vanilla ""Assaultpack green"" to RHS ""UMBTS Backpack (Engineer)"" for a more Russian/breacher look. " \n "- Backpack content: added 2x RHS ""VOG-25"" to match TFN and US Army loadouts. " \n "- Rifle mag changed from RHS ""30Rnd AK-74 (Plum) 7N10"" to RHS ""30Rnd AK-74 (Plum) 7N22"" to match the other mags in the vest. " \n "  " \n "AR: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" semi-randomly to RHS ""6B27M"" or RHS ""6B27M (ESS)"" or RHS ""6B27M (Balaclava)"". " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest changed from RHS ""6B23 (6Sh116)"" semi-randomly to RHS ""6B23 EMR-Summer (Vydra-3M)"" or RHS ""6B23 (Vydra-3M)"" " \n "- Vest content: added 1x HLC ""7.62mm 75Rnd FMJ RPK Magazine (Tracers every 3)"" " \n "- Backpack changed from vanilla ""Assaultpack (green)"" to RHS ""Sidor"" for a more Russian look. " \n "- Backpack content: added 2x HLC ""7.62mm 75Rnd FMJ RPK Magazine (Tracers every 3)"" and 1x HLC ""7.62mm 75Rnd FMJ RPK Magazine (Tracer)"" " \n "- Rifle changed from RHS ""PKP"" to HLC ""RPK"". " \n "- Rifle muzzle attachment added RHS ""Surefire SF3P-762"". " \n " " \n "AAR: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" semi-randomly to RHS ""6B27M"" or RHS ""6B27M (ESS)"" or RHS ""6B27M (Balaclava)"". " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest changed from RHS ""6B23 (6Sh116)"" semi-randomly to RHS ""6B23 EMR-Summer (6Sh92/Headset)"" or RHS ""6B23 (6Sh92/Headset)"". " \n "- Vest content: moved 2x RGO grenades to backpack, removed 3x RHS ""30Rnd AK-74 (Plum) 7N22"" and added 4x RHS ""30Rnd AK-74 (Plum) 7T3M (tracer)"" to match TFN and US Army loadouts. " \n "- Backpack content: added RHS 2x ""30Rnd AK-74 (Plum) 7N22"" and 3x HLC ""7.62mm 75Rnd FMJ RPK Magazine (Tracers every 3)"" to match TFN and US Army loadouts. " \n "- Rifle mag changed from RHS ""30Rnd AK-74 (Plum) 7N10"" to RHS ""30Rnd AK-74 (Plum) 7N22"" to match the other mags in the vest. " \n "" \n "LAT: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" semi-randomly to RHS ""6B27M"" or RHS ""6B27M (ESS)"" or RHS ""6B27M (Balaclava)"". " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest variety changed semi-randomly to RHS ""6B23 (6Sh116)"" and RHS ""6B23 EMR-Summer (6Sh116)"". " \n "- Vest content: removed 1x RHS ""30Rnd AK-74 (Plum) 7N22"" and added 2x RHS ""30Rnd AK-74 (Plum) 7T3M (tracer)"" to match TFN and US Army loadouts. " \n "- Rifle changed from RHS ""AK-74M"" to RHS ""AK-105"" for more weapon variety in the platoon. " \n "- Rifle mag changed from RHS ""30Rnd AK-74 (Plum) 7N10"" to RHS ""30Rnd AK-74 (Plum) 7N22"" to match the other mags in the vest. " \n " " \n "MMG Leader: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" to RHS ""6B27M EMR-Summer"" " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest changed from RHS ""6B23 (6Sh116/VOG)"" to RHS ""6B23 EMR-Summer (6Sh92/VOG/Radio) SpNz"".  " \n "- Vest content: moved 2x RGO grenades to backpack, removed 3x RHS ""30Rnd AK-74 (Plum) 7N22"" and added 4x RHS ""30Rnd AK-74 (Plum) 7T3M (tracer)"" to match TFN and US Army loadouts. " \n "- Backpack changed from vanilla ""Assaultpack green"" to RHS ""UMBTS Backpack"" for a more Russian look. " \n "- Backpack content: added 1x RHS ""VOG-25"" to match TFN and US Army loadouts. " \n "- Rifle mag changed from RHS ""30Rnd AK-74 (Plum) 7N10"" to RHS ""30Rnd AK-74 (Plum) 7N22"" to match the other mags in the vest. " \n "  " \n "MMG Gunner: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" to RHS ""6B27M (ESS)"". " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest changed from RHS ""6B23 (6Sh116)"" to RHS ""6B23 EMR-Summer (Rifleman)"". " \n " " \n "MMG Asst. Gunner: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" to RHS ""6B27M"". " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest content: removed 1x RHS ""30Rnd AK-74 (Plum) 7N22"" and added 2x RHS ""30Rnd AK-74 (Plum) 7T3M (tracer)"" to match TFN and US Army loadouts. " \n "- Rifle mag changed from RHS ""30Rnd AK-74 (Plum) 7N10"" to RHS ""30Rnd AK-74 (Plum) 7N22"" to match the other mags in the vest. " \n " " \n "MAT Leader: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" to RHS ""6B27M EMR-Summer"" " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest changed from RHS ""6B23 (6Sh116/VOG)"" to RHS ""6B23 EMR-Summer (6Sh92/VOG/Radio) SpNz"".  " \n "- Vest content: moved 2x RGO grenades to backpack, removed 3x RHS ""30Rnd AK-74 (Plum) 7N22"" and added 4x RHS ""30Rnd AK-74 (Plum) 7T3M (tracer)"" to match TFN and US Army loadouts. " \n "- Backpack changed from vanilla ""Assaultpack green"" to RHS ""UMBTS Backpack"" for a more Russian look. " \n "- Backpack content: added 1x RHS ""VOG-25"" to match TFN and US Army loadouts. " \n "- Rifle mag changed from RHS ""30Rnd AK-74 (Plum) 7N10"" to RHS ""30Rnd AK-74 (Plum) 7N22"" to match the other mags in the vest. " \n " " \n "MAT Gunner: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" to RHS ""6B27M (ESS)"". " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Rifle changed from RHS ""AK-74M"" to RHS ""AK-105"" for more weapon variety in the platoon. " \n "- Rifle mag changed from RHS ""30Rnd AK-74 (Plum) 7N10"" to RHS ""30Rnd AK-74 (Plum) 7N22"" to match the other mags in the vest. " \n " " \n "MAT Asst. Gunner: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" to RHS ""6B27M"". " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest changed from RHS ""6B23 (6Sh116)"" to RHS ""6B23 EMR-Summer ""(6Sh92/Headset)"". " \n "- Vest content: removed 1x RHS ""30Rnd AK-74 (Plum) 7N22"" and added 2x RHS ""30Rnd AK-74 (Plum) 7T3M (tracer)"" to match TFN and US Army loadouts. " \n "- Rifle mag changed from RHS ""30Rnd AK-74 (Plum) 7N10"" to RHS ""30Rnd AK-74 (Plum) 7N22"" to match the other mags in the vest. " \n "  " \n "DMT Marksman " \n "- Added scope RHS ""IPN34"" to the vest gear. This is a somewhat equivalent NVG scope to the US Army Faction. " \n "  " \n "ENG Leader: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" to RHS ""Altyn (visor up)"". " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest changed from RHS ""6B23 (6Sh116)"" to RHS ""6B13 EMR-Summer ""(6Sh92/Radio)"". " \n "- Rifle changed from RHS ""AK-74M"" to RHS ""AK-105"" for more weapon variety in the platoon. " \n "- Rifle mag changed from RHS ""30Rnd AK-74 (Plum) 7N10"" to RHS ""30Rnd AK-74 (Plum) 7N22"" to match the other mags in the vest. " \n "  " \n "ENG Rifleman: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" semi-randomly to RHS ""Altyn (visor down)"" or RHS ""Altyn (visor up Balaclava)"". " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest changed from RHS ""6B23 (6Sh116)"" to RHS ""6B13 EMR-Summer ""(6Sh92)"". " \n "- Rifle changed from RHS ""AK-74M"" to RHS ""AK-105"" for more weapon variety in the platoon. " \n "- Rifle mag changed from RHS ""30Rnd AK-74 (Plum) 7N10"" to RHS ""30Rnd AK-74 (Plum) 7N22"" to match the other mags in the vest. " \n "  " \n "Mortar Leader: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" to RHS ""6B27M"". " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest changed from RHS ""6B23 (6Sh116/VOG)"" to RHS ""6B23 EMR-Summer (6Sh92/Radio)"". " \n "- Rifle changed from RHS ""AK-74M (Plum)"" to RHS ""AKS-74U"" for more rifle diversity in the platoon. Slightly lower accuracy at range but lighter carry weight. " \n "- Rifle mag changed from RHS ""30Rnd AK-74 (Plum) 7N10"" to RHS ""30Rnd AK-74 (Plum) 7N22"" to match the other mags in the vest. " \n "  " \n "Mortar Gunner: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" to RHS ""6B27M (ESS)"". " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest changed from RHS ""6B23 (6Sh116/VOG)"" to RHS ""6B23 EMR-Summer (6Sh92)"". " \n "- Rifle changed from RHS ""AK-74M (Plum)"" to RHS ""AKS-74U"" for more rifle diversity in the platoon. Slightly lower accuracy at range but lighter carry weight. " \n "- Rifle mag changed from RHS ""30Rnd AK-74 (Plum) 7N10"" to RHS ""30Rnd AK-74 (Plum) 7N22"" to match the other mags in the vest. " \n "  " \n "All Units: " \n "- Disabled LAMBS AI " \n " " \n "Alpha SL: " \n "- Enabled ""is Player"". This makes it easier for Mission Makers to quickly test a mission in the editor by just hitting ""play"" instead of having to select a specific unit every time beforehand to avoid ending up in spectator mode by default. " \n " " \n "Crates: " \n "- Added an ACE3 medical crate with our usual base script. " \n "- Fireteam ammo crate: removed 4x 100Rnd PKM Box and replaced it with 4x 75Rnd RPK Mag and 1x 75Rnd RPK Tracer Mag. " \n "- Squad ammo crate: removed 13x 100Rnd PKM Tracer Box and added 12x 75Rnd RPK Mag & 4x 75Rnd RPK Tracer Mag" \n "" \n "" \n "-v1.13.6" \n "  - ALL Added persistent Call-Signs for all GM's (where not included in v1.13.4)" \n "  - ALL Added the code`this disableAI ""MOVE""; this setSpeaker ""NoVoice""; enableRadio false;` to all playable units to prevent them from running off and spamming the vanilla-radio during local testing." \n "  - ALL Changed persistent call-signs (map markers) to a consistent formula: ≤ 2 syllables = written out call-sing. ≥ 3 syllables = abbreviated call-sign." \n "  - ALL Added full changelog to all factions for quick in-game reference" \n "  - TFN Added new yellow owl insignia patches to all uniforms" \n "" \n "- v1.13.5" \n "  - ALL Added respective GM's to Standard Faction Compositions for convenience / time saving " \n "  - ALL Added base clean-up module to Standard Faction Compositions to ensure Mission Makers don't forget it in the future - radius set to 200x200 meters" \n "" \n "- v1.13.4 " \n "  - ALL Added @ Squad/Team names to leaders so that Team name appears in role select" \n "  - TFN Changed M249 to the FN MINIMI" \n "" \n "- v1.13.3" \n "  - US Added Improved Bipod/SAW Grip to AR M249" \n "  - US Removed M14 Mags" \n "  - TFN Added Bipod to M249" \n "" \n "- v1.13.2" \n "  - ALL Added 1 Extra Tourniquet to every Unit" \n "  - TFN DMT Lead Rifle Changed to D10 Version" \n "  - TFN DMT given extra pistol mag to bring in line with other units" \n "  - TFN AAR Weapon changed to HK416 D14.5" \n "  - TFN Lead Elements Given AN/PEQ-16A's" \n "  - US Alpha Fireteam 2 AAR vest changed to ALT variant to match rest of faction" \n "  - US Lead Elements Given AN/PEQ-16A's" \n "  - US DMT given extra pistol mag to bring in line with other units" \n "  - US DMT Sniper Rifle Given SU-260/P (MDO) to bring zoom level to the same as Russian and TFN factions" \n "  - US DMT Bipod Changed to Harris Bipod" \n "  - US DMT Marksman Rifle changed to black version of same rifle" \n "  - US DMT Marksman Magazines changed to SR-25 version, as RHS hotfix made M14 mags incompatible with MK11" \n "  - RUS DMT given extra pistol mag to bring in line with other units" \n "  - RUS DGR Helmets changed to TSH-4 to make distinct from US Helmets" \n "  - RUS NB Helmets changed to ZSH-7A to make distinct from US and TFN helmets" \n "  - RUS Removed RIS Rail adaptors from AK rifles" \n "  - RUS Added PG-7V rocket to MAT ammo crate. This rocket is lighter and packs less payload than the PG-7VL. This gives it an  increased effective range but is less powerful due to decreased payload" \n "" \n "- v1.12.2" \n "  - Hotfixed US Vests across the Squads to match V.12 changes. Whoops." \n "  - Added Angled Grip to TFN HK416s where possible. " \n "" \n "- v1.12" \n "  - Fixed TFN MMG Ammo preloaded into Rifle to 100RND mag from 50rnd." \n "  - Fixed TFN DMT Marksman Ammo loaded into Rifle to correct SBLR mag." \n "  - Changed TFN DMT Lead Suppressor to QDSS NT4 Black from Rotex-5 Grey" \n "  - Changed TFN Dagger Uniforms from Gorka R Green to FFCP Green Fatigues [RS]" \n "  - Changed US PLT Commander + Squad Leader Vest from SPCS Rifleman/OEF- CP to SPCS Squad Lead/OEF-CP" \n "  - Changed US Medic Vest from SPCS Rifleman/OEF-CP to SPCS Medic/OEF-CP" \n "  - Changed US PLT Rifleman Vest from SPCS OEF-CP to SPCS Rifleman Alt/OEF-CP" \n "  - Changed US FTL Vest from SPCS Rifleman/OEF-CP to SPCS Team Leader Alt/OEF-CP" \n "  - Changed US AR Vest from SPCS Rifleman/OEF-CP to SPCS SAW/OEF-CP" \n "  - Changed US AAR Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP" \n "  - Changed US Rifleman AT Vest from SPCS OEF-CP to SPCS Rifleman Alt/OEF-CP" \n "  - Changed US MAT/MMG/DMT/ENG/MTR Lead Vest from SPCS Rifleman/OEF-CP to SPCS Team Leader Alt/OEF-CP" \n "  - Changed US MMG Gunner Vest from SPCS Rifleman/OEF-CP to SPCS Machinegunner/OEF-CP" \n "  - Changed US MMG/MAT Ammo Bearer Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP" \n "  - Changed US MAT Gunner Vest from SPCS OEF-CP to SPCS Rifleman Alt/OEF-CP" \n "  - Changed US DMT Marksman vest from SPCS OEF-CP to SPCS Sniper/OEF-CP" \n "  - Fixed US DMT Marksman Rifle Loaded Mag to correct varient." \n "  - Changed US Engineer Rifleman Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP." \n "  - Changed US MTR Gunner Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP." \n "  - Changed US DGR Uniforms from FFCP ACU Fatigues to FFCP ACU Fatigues [RS]" \n "  - Changed US DGR Driver Backpack from Assault Pack Green to Assault Pack Black" \n "  - Changed US Heli Pilot/Copilot Uniforms from Heli pilot Coveralls to FFCP Nomad Fatigues [RS]" \n "  - Fixed US Heli/Jet Pilot Vest White Smoke grenade count to 2." \n "  - Changed US Heli Pilot/Copilot Helmet from Heli Pilot NATO to HGU-56/P (Black/Visor)" \n "  - Changed US Jet Pilot Uniform from Pilot Coveralls NATO to  FFCP Nomad Fatigues" \n "  - Changed RUS Vic/Heli/Jet Crew Weapons to PP-2000" \n "  - Upped RUS PP-2000 Ammo counts to 6x Mag to bring in line with ammo counts for TFN and US." \n "  - Changed RUS Heli Pilot Uniforms from Pilot Coveralls CSAT to FFCP-Fatigues EMR [RS]" \n "  - Changed RUS Heli Pilot Vest from 6B23 (6Sh116) to FFCP Tactical Vest TigerVRS" \n "  - Changed RUS Jet Pilot Uniforms from Pilot Coveralls CSAT to FFCP-Fatigues EMR [RS]" \n "  - Changed RUS Jet Pilot Vest from 6B23 (6Sh116) to FFCP Tactical Vest TigerVRS" \n "" \n "- v1.11" \n "  - changed m40 mini grenades to m67 fragmentation" \n "  - replaced mp7 weapons with mp5k-pdw" \n "  - changed ak105 to ak74m (plum) " \n "  - changed PKM to PKP" \n "  - changed RUS PKM ammo boxes. MMG now loads with 7TZ (AP rounds)" \n "  - added vert grip to us weapons" \n "  - replaced m14 with HK PSG1A1" \n "  - replaced m260e4 with mg3" \n "  - updated all ammo boxes respectively. " \n "" \n "- v1.10" \n "  - changed Medic loadouts from 6 x 1000ml blood bags to 2 x 1000ml and 8 x 500ml." \n "" \n "- v1.09" \n "  - updated Fireteam colours A1 Red A2 Yellow, B1 Green B2 Blue, C1 Red C2 Yellow." \n "" \n "- v1.08" \n "  - changed ""Reaper"" to ""Nightbird"", ""RPR"" to ""NB""" \n "  - changed ""Paladin"" to ""Falcon"", ""PAL"" to ""FC""" \n "  - changed ""DAGGER"" to ""DGR""" \n "" \n "- v1.07" \n "  - US and RU faction bumped to v1.07 to avoid confusion regarding version numbers (US and RU was 1.05, TFN was 1.06)" \n "  - overhauled the RU faction: updated helmets, uniforms, weapons to a more modern look" \n "  - overhauled the US faction: updated helmets and vests to armour rating of IV" \n "  - corrected some mistakes in all factions (grenade ammount of MMG gunner, ENG not having tourniquetes, DGR not having GPS-s)" \n "  - overhauled the medics of all factions to reflect recent cahnges to ACE medical (less QuikClots, more Elastic Bandages, etc.)" \n "" \n "- v1.05" \n "  - Added a MAT ammo box on spawn." \n "" \n "- v1.04" \n "  - All MAT Teams carrying RPG's got the ver3 scopes with ranges for all types" \n "    of ammo." \n "  - All Callsigns were changed to be uniformed throught no matter the faction." \n "" \n "- v1.03" \n "  - set crew driver/gunner and pilot/copilot/jetpilot as Engineers through the" \n "    Object: ACE Options menu in unit attributes" \n "  - overhauled the TFN faction (weapons, helmets, etc.), changes not applicable" \n "    to derived factions" \n "" \n "- v1.02" \n "  - loadout overhaul for DMT, made them lighter + gave them tools for recon" \n "  - specified preset ACRE2 radio channels for most units" \n "" \n "- v1.01" \n "  - updated team colors func to `a3ee_team_colors_fnc_setColor`, just load+save" \n "    the composition in editor, this fixes it" \n "  - changed RPG-7 using MAT teams to carry Kitbags" \n "  - removed one PKM ammo box from AAR, MMG gunner, MMG bearer (fixes overload)" \n "  - moved 1-2 AR boxes from AAR to AR, gave AR an Assaultpack" \n "  - added 1-2 more AR boxes to AR's Assaultpack (if enough space)" \n "  - changed HEDP to HE rockets for Carl Gustav (M3MAAWS)" \n "  - changed US crew uniform and helmet to match grey color scheme of US pilots" \n "  - changed backpacks of driver/copilot to use less contrasting colors compared" \n "    to their respective uniform/vest colors" \n "  - changed Carryall backpacks of TFN Engineers to use custom Flecktarn Carryall" \n "  - changed all (GP-25 and normal) AK74m rifles to be the non-NPZ variants" \n "  - removed secondary long-range (PRC148) from Engineers" \n "" \n "- v1.00 (and before)" \n "  - added a Comment object with version number (`v1.00`)" \n "  - added `respawn_west`, `respawn_east`, `respawn_guerrila` markers" \n "  - added `[this, 200] call a3ee_fnc_boxGuard` to init lines of resupply boxes" \n "  - added `Resupply` green triangle markers on the position of resupply boxes";
-		id=223;
+		title="v1.14.2";
+		description="- v1.14.2" \n "PL: " \n "- Headgear changed from RHS ""Field Cap VSR"" to RHS ""6B27M (ESS)"" to give leader a helmet (issue #82). " \n "- Uniform content: moved radios 152 & 148 to backpack (issue #95). " \n " " \n "Platoon Sergeant: " \n "- Headgear changed from RHS ""6B26 (ESS)"" to RHS ""6B27M (Balaclava)"" to fit the rest of the platoon (issue #112). " \n " " \n "Platoon Medic: " \n "- Headgear changed from RHS ""6B26"" to RHS ""6B27M"" to fit the rest of the platoon (issue #112). " \n "- Rifle changed from RHS ""AKS-74U"" to RHS ""AKS-74UN"" to allow for scope attachments (issue #108). " \n "  " \n "Platoon Rifleman: " \n "- Helmet changed from RHS ""6B26 (ESS/Balaclava)"" to RHS ""6B27M (ESS/Balaclava)"" to fit the rest of the platoon (issue #112). " \n "  " \n "SL: " \n "- Helmet changed from RHS ""6B27M EMR-Summer"" to RHS ""6B27M (Balaclava)"" to fit the rest of the platoon. " \n "- Uniform content: moved radio 152 to backpack (issue #95). " \n "  " \n "Medic: " \n "- Rifle changed from RHS ""AKS-74U"" to RHS ""AKS-74UN"" to allow for scope attachments (issue #108). " \n " " \n "MMG Leader: " \n "- Helmet changed from RHS ""6B27M EMR-Summer"" to RHS ""6B27M (Balaclava)"" to fit the rest of the platoon. " \n "- Uniform content: moved radio 152 to backpack (issue #95). " \n "  " \n "MAT Leader: " \n "- Headgear changed from RHS ""6B27M EMR-Summer"" to RHS ""6B27M (Balaclava)"" to fit the rest of the platoon. " \n "- Uniform content: moved radio 152 to backpack (issue #95). " \n " " \n "ENG Leader: " \n "- Uniform content: moved radio 152 to backpack (issue #95). " \n "- Backpack content: changed ammo count to 5 regular mags and 1 tracer mag (issue #83). " \n " " \n "ENG Rifleman: " \n "- Backpack content: changed ammo count to 5 regular mags and 1 tracer mag (issue #83). " \n " " \n "DMT Leader: " \n "- Soldier class changed from ""B_spotter_F"" to ""O_soldier_M_F"" (issue #94). " \n " " \n "DMT Marksman: " \n "- Soldier class changed from ""B_spotter_F"" to ""O_spotter_F"" (issue #94). " \n " " \n "MTR Leader: " \n "- Vest content: changed ammo count to 5 regular mags and 1 tracer mag (issue #83). " \n " " \n "MTR Gunner: " \n "- Vest content: changed ammo count to 5 regular mags and 1 tracer mag (issue #83). " \n " " \n "Zeus: " \n "- Fixed missing Zeus status (issue #113). " \n " " \n "All Units: " \n "- Fixed missing standard ACRE2 radio channels (issue #110). " \n "- Uniform content: added 1x epinephrine (issue #107) and sorted all items in a more logical manner (issue #111). " \n "- Vest content: sorted all items in a more logical manner (issue #111). " \n "- Backpack content: sorted all items in a more logical manner (issue #111). " \n "- Fireteam members: fixed ST HUD colours for fireteam members of Alpha, Bravo and Charlie (issue #117). " \n " " \n "Crates: " \n "- Added a mortar supply crate (issue #77)." \n "" \n "-v1.14.1" \n " - A3EE box guard updated to A3AA." \n " - Custom location re-added." \n "" \n "-v1.14.0" \n "PL: " \n "- Headgear changed from RHS ""Field Cap EMR-Summer"" to RHS ""Field Cap VSR"". " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest changed from RHS ""6B23 (6Sh116/VOG)"" to RHS ""6B23 EMR-Summer (6Sh92/Headset/Mapcase)"" for more visual diversity in the platoon. " \n "- Vest content: moved 2x RGO grenades to backpack, removed 3x RHS ""30Rnd AK-74 (Plum) 7N22"" and added 4x RHS ""30Rnd AK-74 (Plum) 7T3M (tracer)"" to match TFN and US Army loadouts. " \n "- Backpack changed from vanilla ""Assaultpack green"" to RHS ""UMBTS Backpack"" for a more Russian look. " \n "- Backpack content: increased GL smoke white from 3x to 5x to match TFN and US Army loadouts. " \n "- Rifle mag changed from RHS ""30Rnd AK-74 (Plum) 7N10"" to RHS ""30Rnd AK-74 (Plum) 7N22"" to match the other mags in the vest. " \n " " \n " Platoon Sergeant: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" to RHS ""6B26 (ESS)"" to indicate association with platoon lead element and for more visual diversity in the platoon. " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest content: removed 3x RHS ""30Rnd AK-74 (Plum) 7N22"" and added 4x RHS ""30Rnd AK-74 (Plum) 7T3M (tracer)"" to match TFN and US Army loadouts. " \n "- Backpack added 3CB ""Radio Backpack MR3000"" and filled it with the ACRE2 ""AN/PRC-117F"" backpack radio. This gives more incentive to bring the PLT Sgt along since he is the only one who can act as a max range radio man for the platoon. " \n "- Rifle mag changed from RHS ""30Rnd AK-74 (Plum) 7N10"" to RHS ""30Rnd AK-74 (Plum) 7N22"" to match the other mags in the vest. " \n "  " \n "Platoon Medic: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" to RHS ""6B26"" to indicate association with platoon lead element and for more visual diversity in the platoon. " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest changed from RHS ""6B23 (6Sh116)"" to RHS ""6B23 EMR-Summer (Medic)"". " \n "- Vest content: removed 1x RHS ""30Rnd AK-74 (Plum) 7N22"" and added 2x RHS ""30Rnd AK-74 (Plum) 7T3M (tracer)"" to match TFN and US Army loadouts. " \n "- Backpack changed from vanilla ""Kitback (green)"" to 3CB ""Knapsack Medical (Khaki)"" to visually make the Vest medical bag look like the primary backpack. " \n "- Rifle changed from RHS ""AK-74M (Plum)"" to RHS ""AKS-74U"" for more rifle diversity in the platoon. Slightly lower accuracy at range but lighter carry weight. " \n "- Rifle mag changed from RHS ""30Rnd AK-74 (Plum) 7N10"" to RHS ""30Rnd AK-74 (Plum) 7N22"" to match the other mags in the vest. " \n " " \n "Platoon Rifleman: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" to RHS ""6B26 (ESS/Balaclava)"" to indicate association with platoon lead element and for more visual diversity in the platoon. " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest changed from RHS ""6B23 (6Sh116)"" to RHS ""6B23 EMR-Summer (6Sh116)"". " \n "- Vest content: removed 1x RHS ""30Rnd AK-74 (Plum) 7N22"" and added 2x RHS ""30Rnd AK-74 (Plum) 7T3M (tracer)"" to match TFN and US Army loadouts. " \n "- Rifle mag changed from RHS ""30Rnd AK-74 (Plum) 7N10"" to RHS ""30Rnd AK-74 (Plum) 7N22"" to match the other mags in the vest. " \n " " \n "SL: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" semi-randomly to RHS ""6B27M"" or RHS ""6B27M (ESS)"" or RHS ""6B27M (Balaclava)"". " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest changed from RHS ""6B23 (6Sh116/VOG)"" to RHS ""6B23 EMR-Summer (6Sh92/VOG/Radio) SpNz"".  " \n "- Vest content: moved 2x RGO grenades to backpack, removed 3x RHS ""30Rnd AK-74 (Plum) 7N22"" and added 4x RHS ""30Rnd AK-74 (Plum) 7T3M (tracer)"" to match TFN and US Army loadouts. " \n "- Backpack changed from vanilla ""Assaultpack green"" to RHS ""UMBTS Backpack"" for a more Russian look. " \n "- Backpack content: added 1x RHS ""VOG-25"" to match TFN and US Army loadouts. " \n "- Rifle mag changed from RHS ""30Rnd AK-74 (Plum) 7N10"" to RHS ""30Rnd AK-74 (Plum) 7N22"" to match the other mags in the vest.  " \n " " \n "SL Medic: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" semi-randomly to RHS ""6B27M"" or RHS ""6B27M (ESS)"" or RHS ""6B27M (Balaclava)"". " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest changed from RHS ""6B23 (6Sh116)"" semi-randomly to RHS ""6B23 EMR-Summer (Medic)"" or RHS ""6B23 (Medic)"". " \n "- Vest content: removed 1x RHS ""30Rnd AK-74 (Plum) 7N22"" and added 2x RHS ""30Rnd AK-74 (Plum) 7T3M (tracer)"" to match TFN and US Army loadouts. " \n "- Backpack changed from vanilla ""Kitback (green)"" to 3CB ""Knapsack Medical (Khaki)"" to visually make the Vest medical bag look like the primary backpack. " \n "- Rifle changed from RHS ""AK-74M (Plum)"" to RHS ""AKS-74U"" for more rifle diversity in the platoon. Slightly lower accuracy at range but lighter carry weight. " \n "- Rifle mag changed from RHS ""30Rnd AK-74 (Plum) 7N10"" to RHS ""30Rnd AK-74 (Plum) 7N22"" to match the other mags in the vest. " \n "  " \n "FTL: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" semi-randomly to RHS ""6B27M"" or RHS ""6B27M (ESS)"" or RHS ""6B27M (Balaclava)"". " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest changed from RHS ""6B23 (6Sh116/VOG)"" semi-randomly to RHS ""6B23 EMR-Summer (6Sh92/VOG/Headset)"" or RHS ""6B23 (6Sh92/VOG/Headset)"". " \n "- Vest content: moved 2x RGO grenades to backpack, removed 3x RHS ""30Rnd AK-74 (Plum) 7N22"" and added 4x RHS ""30Rnd AK-74 (Plum) 7T3M (tracer)"" to match TFN and US Army loadouts. " \n "- Backpack changed from vanilla ""Assaultpack green"" to RHS ""UMBTS Backpack (Engineer)"" for a more Russian/breacher look. " \n "- Backpack content: added 2x RHS ""VOG-25"" to match TFN and US Army loadouts. " \n "- Rifle mag changed from RHS ""30Rnd AK-74 (Plum) 7N10"" to RHS ""30Rnd AK-74 (Plum) 7N22"" to match the other mags in the vest. " \n "  " \n "AR: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" semi-randomly to RHS ""6B27M"" or RHS ""6B27M (ESS)"" or RHS ""6B27M (Balaclava)"". " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest changed from RHS ""6B23 (6Sh116)"" semi-randomly to RHS ""6B23 EMR-Summer (Vydra-3M)"" or RHS ""6B23 (Vydra-3M)"" " \n "- Vest content: added 1x HLC ""7.62mm 75Rnd FMJ RPK Magazine (Tracers every 3)"" " \n "- Backpack changed from vanilla ""Assaultpack (green)"" to RHS ""Sidor"" for a more Russian look. " \n "- Backpack content: added 2x HLC ""7.62mm 75Rnd FMJ RPK Magazine (Tracers every 3)"" and 1x HLC ""7.62mm 75Rnd FMJ RPK Magazine (Tracer)"" " \n "- Rifle changed from RHS ""PKP"" to HLC ""RPK"". " \n "- Rifle muzzle attachment added RHS ""Surefire SF3P-762"". " \n " " \n "AAR: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" semi-randomly to RHS ""6B27M"" or RHS ""6B27M (ESS)"" or RHS ""6B27M (Balaclava)"". " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest changed from RHS ""6B23 (6Sh116)"" semi-randomly to RHS ""6B23 EMR-Summer (6Sh92/Headset)"" or RHS ""6B23 (6Sh92/Headset)"". " \n "- Vest content: moved 2x RGO grenades to backpack, removed 3x RHS ""30Rnd AK-74 (Plum) 7N22"" and added 4x RHS ""30Rnd AK-74 (Plum) 7T3M (tracer)"" to match TFN and US Army loadouts. " \n "- Backpack content: added RHS 2x ""30Rnd AK-74 (Plum) 7N22"" and 3x HLC ""7.62mm 75Rnd FMJ RPK Magazine (Tracers every 3)"" to match TFN and US Army loadouts. " \n "- Rifle mag changed from RHS ""30Rnd AK-74 (Plum) 7N10"" to RHS ""30Rnd AK-74 (Plum) 7N22"" to match the other mags in the vest. " \n "" \n "LAT: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" semi-randomly to RHS ""6B27M"" or RHS ""6B27M (ESS)"" or RHS ""6B27M (Balaclava)"". " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest variety changed semi-randomly to RHS ""6B23 (6Sh116)"" and RHS ""6B23 EMR-Summer (6Sh116)"". " \n "- Vest content: removed 1x RHS ""30Rnd AK-74 (Plum) 7N22"" and added 2x RHS ""30Rnd AK-74 (Plum) 7T3M (tracer)"" to match TFN and US Army loadouts. " \n "- Rifle changed from RHS ""AK-74M"" to RHS ""AK-105"" for more weapon variety in the platoon. " \n "- Rifle mag changed from RHS ""30Rnd AK-74 (Plum) 7N10"" to RHS ""30Rnd AK-74 (Plum) 7N22"" to match the other mags in the vest. " \n " " \n "MMG Leader: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" to RHS ""6B27M EMR-Summer"" " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest changed from RHS ""6B23 (6Sh116/VOG)"" to RHS ""6B23 EMR-Summer (6Sh92/VOG/Radio) SpNz"".  " \n "- Vest content: moved 2x RGO grenades to backpack, removed 3x RHS ""30Rnd AK-74 (Plum) 7N22"" and added 4x RHS ""30Rnd AK-74 (Plum) 7T3M (tracer)"" to match TFN and US Army loadouts. " \n "- Backpack changed from vanilla ""Assaultpack green"" to RHS ""UMBTS Backpack"" for a more Russian look. " \n "- Backpack content: added 1x RHS ""VOG-25"" to match TFN and US Army loadouts. " \n "- Rifle mag changed from RHS ""30Rnd AK-74 (Plum) 7N10"" to RHS ""30Rnd AK-74 (Plum) 7N22"" to match the other mags in the vest. " \n "  " \n "MMG Gunner: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" to RHS ""6B27M (ESS)"". " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest changed from RHS ""6B23 (6Sh116)"" to RHS ""6B23 EMR-Summer (Rifleman)"". " \n " " \n "MMG Asst. Gunner: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" to RHS ""6B27M"". " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest content: removed 1x RHS ""30Rnd AK-74 (Plum) 7N22"" and added 2x RHS ""30Rnd AK-74 (Plum) 7T3M (tracer)"" to match TFN and US Army loadouts. " \n "- Rifle mag changed from RHS ""30Rnd AK-74 (Plum) 7N10"" to RHS ""30Rnd AK-74 (Plum) 7N22"" to match the other mags in the vest. " \n " " \n "MAT Leader: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" to RHS ""6B27M EMR-Summer"" " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest changed from RHS ""6B23 (6Sh116/VOG)"" to RHS ""6B23 EMR-Summer (6Sh92/VOG/Radio) SpNz"".  " \n "- Vest content: moved 2x RGO grenades to backpack, removed 3x RHS ""30Rnd AK-74 (Plum) 7N22"" and added 4x RHS ""30Rnd AK-74 (Plum) 7T3M (tracer)"" to match TFN and US Army loadouts. " \n "- Backpack changed from vanilla ""Assaultpack green"" to RHS ""UMBTS Backpack"" for a more Russian look. " \n "- Backpack content: added 1x RHS ""VOG-25"" to match TFN and US Army loadouts. " \n "- Rifle mag changed from RHS ""30Rnd AK-74 (Plum) 7N10"" to RHS ""30Rnd AK-74 (Plum) 7N22"" to match the other mags in the vest. " \n " " \n "MAT Gunner: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" to RHS ""6B27M (ESS)"". " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Rifle changed from RHS ""AK-74M"" to RHS ""AK-105"" for more weapon variety in the platoon. " \n "- Rifle mag changed from RHS ""30Rnd AK-74 (Plum) 7N10"" to RHS ""30Rnd AK-74 (Plum) 7N22"" to match the other mags in the vest. " \n " " \n "MAT Asst. Gunner: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" to RHS ""6B27M"". " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest changed from RHS ""6B23 (6Sh116)"" to RHS ""6B23 EMR-Summer ""(6Sh92/Headset)"". " \n "- Vest content: removed 1x RHS ""30Rnd AK-74 (Plum) 7N22"" and added 2x RHS ""30Rnd AK-74 (Plum) 7T3M (tracer)"" to match TFN and US Army loadouts. " \n "- Rifle mag changed from RHS ""30Rnd AK-74 (Plum) 7N10"" to RHS ""30Rnd AK-74 (Plum) 7N22"" to match the other mags in the vest. " \n "  " \n "DMT Marksman " \n "- Added scope RHS ""IPN34"" to the vest gear. This is a somewhat equivalent NVG scope to the US Army Faction. " \n "  " \n "ENG Leader: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" to RHS ""Altyn (visor up)"". " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest changed from RHS ""6B23 (6Sh116)"" to RHS ""6B13 EMR-Summer ""(6Sh92/Radio)"". " \n "- Rifle changed from RHS ""AK-74M"" to RHS ""AK-105"" for more weapon variety in the platoon. " \n "- Rifle mag changed from RHS ""30Rnd AK-74 (Plum) 7N10"" to RHS ""30Rnd AK-74 (Plum) 7N22"" to match the other mags in the vest. " \n "  " \n "ENG Rifleman: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" semi-randomly to RHS ""Altyn (visor down)"" or RHS ""Altyn (visor up Balaclava)"". " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest changed from RHS ""6B23 (6Sh116)"" to RHS ""6B13 EMR-Summer ""(6Sh92)"". " \n "- Rifle changed from RHS ""AK-74M"" to RHS ""AK-105"" for more weapon variety in the platoon. " \n "- Rifle mag changed from RHS ""30Rnd AK-74 (Plum) 7N10"" to RHS ""30Rnd AK-74 (Plum) 7N22"" to match the other mags in the vest. " \n "  " \n "Mortar Leader: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" to RHS ""6B27M"". " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest changed from RHS ""6B23 (6Sh116/VOG)"" to RHS ""6B23 EMR-Summer (6Sh92/Radio)"". " \n "- Rifle changed from RHS ""AK-74M (Plum)"" to RHS ""AKS-74U"" for more rifle diversity in the platoon. Slightly lower accuracy at range but lighter carry weight. " \n "- Rifle mag changed from RHS ""30Rnd AK-74 (Plum) 7N10"" to RHS ""30Rnd AK-74 (Plum) 7N22"" to match the other mags in the vest. " \n "  " \n "Mortar Gunner: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" to RHS ""6B27M (ESS)"". " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest changed from RHS ""6B23 (6Sh116/VOG)"" to RHS ""6B23 EMR-Summer (6Sh92)"". " \n "- Rifle changed from RHS ""AK-74M (Plum)"" to RHS ""AKS-74U"" for more rifle diversity in the platoon. Slightly lower accuracy at range but lighter carry weight. " \n "- Rifle mag changed from RHS ""30Rnd AK-74 (Plum) 7N10"" to RHS ""30Rnd AK-74 (Plum) 7N22"" to match the other mags in the vest. " \n "  " \n "All Units: " \n "- Disabled LAMBS AI " \n " " \n "Alpha SL: " \n "- Enabled ""is Player"". This makes it easier for Mission Makers to quickly test a mission in the editor by just hitting ""play"" instead of having to select a specific unit every time beforehand to avoid ending up in spectator mode by default. " \n " " \n "Crates: " \n "- Added an ACE3 medical crate with our usual base script. " \n "- Fireteam ammo crate: removed 4x 100Rnd PKM Box and replaced it with 4x 75Rnd RPK Mag and 1x 75Rnd RPK Tracer Mag. " \n "- Squad ammo crate: removed 13x 100Rnd PKM Tracer Box and added 12x 75Rnd RPK Mag & 4x 75Rnd RPK Tracer Mag" \n "" \n "" \n "-v1.13.6" \n "  - ALL Added persistent Call-Signs for all GM's (where not included in v1.13.4)" \n "  - ALL Added the code`this disableAI ""MOVE""; this setSpeaker ""NoVoice""; enableRadio false;` to all playable units to prevent them from running off and spamming the vanilla-radio during local testing." \n "  - ALL Changed persistent call-signs (map markers) to a consistent formula: ≤ 2 syllables = written out call-sing. ≥ 3 syllables = abbreviated call-sign." \n "  - ALL Added full changelog to all factions for quick in-game reference" \n "  - TFN Added new yellow owl insignia patches to all uniforms" \n "" \n "- v1.13.5" \n "  - ALL Added respective GM's to Standard Faction Compositions for convenience / time saving " \n "  - ALL Added base clean-up module to Standard Faction Compositions to ensure Mission Makers don't forget it in the future - radius set to 200x200 meters" \n "" \n "- v1.13.4 " \n "  - ALL Added @ Squad/Team names to leaders so that Team name appears in role select" \n "  - TFN Changed M249 to the FN MINIMI" \n "" \n "- v1.13.3" \n "  - US Added Improved Bipod/SAW Grip to AR M249" \n "  - US Removed M14 Mags" \n "  - TFN Added Bipod to M249" \n "" \n "- v1.13.2" \n "  - ALL Added 1 Extra Tourniquet to every Unit" \n "  - TFN DMT Lead Rifle Changed to D10 Version" \n "  - TFN DMT given extra pistol mag to bring in line with other units" \n "  - TFN AAR Weapon changed to HK416 D14.5" \n "  - TFN Lead Elements Given AN/PEQ-16A's" \n "  - US Alpha Fireteam 2 AAR vest changed to ALT variant to match rest of faction" \n "  - US Lead Elements Given AN/PEQ-16A's" \n "  - US DMT given extra pistol mag to bring in line with other units" \n "  - US DMT Sniper Rifle Given SU-260/P (MDO) to bring zoom level to the same as Russian and TFN factions" \n "  - US DMT Bipod Changed to Harris Bipod" \n "  - US DMT Marksman Rifle changed to black version of same rifle" \n "  - US DMT Marksman Magazines changed to SR-25 version, as RHS hotfix made M14 mags incompatible with MK11" \n "  - RUS DMT given extra pistol mag to bring in line with other units" \n "  - RUS DGR Helmets changed to TSH-4 to make distinct from US Helmets" \n "  - RUS NB Helmets changed to ZSH-7A to make distinct from US and TFN helmets" \n "  - RUS Removed RIS Rail adaptors from AK rifles" \n "  - RUS Added PG-7V rocket to MAT ammo crate. This rocket is lighter and packs less payload than the PG-7VL. This gives it an  increased effective range but is less powerful due to decreased payload" \n "" \n "- v1.12.2" \n "  - Hotfixed US Vests across the Squads to match V.12 changes. Whoops." \n "  - Added Angled Grip to TFN HK416s where possible. " \n "" \n "- v1.12" \n "  - Fixed TFN MMG Ammo preloaded into Rifle to 100RND mag from 50rnd." \n "  - Fixed TFN DMT Marksman Ammo loaded into Rifle to correct SBLR mag." \n "  - Changed TFN DMT Lead Suppressor to QDSS NT4 Black from Rotex-5 Grey" \n "  - Changed TFN Dagger Uniforms from Gorka R Green to FFCP Green Fatigues [RS]" \n "  - Changed US PLT Commander + Squad Leader Vest from SPCS Rifleman/OEF- CP to SPCS Squad Lead/OEF-CP" \n "  - Changed US Medic Vest from SPCS Rifleman/OEF-CP to SPCS Medic/OEF-CP" \n "  - Changed US PLT Rifleman Vest from SPCS OEF-CP to SPCS Rifleman Alt/OEF-CP" \n "  - Changed US FTL Vest from SPCS Rifleman/OEF-CP to SPCS Team Leader Alt/OEF-CP" \n "  - Changed US AR Vest from SPCS Rifleman/OEF-CP to SPCS SAW/OEF-CP" \n "  - Changed US AAR Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP" \n "  - Changed US Rifleman AT Vest from SPCS OEF-CP to SPCS Rifleman Alt/OEF-CP" \n "  - Changed US MAT/MMG/DMT/ENG/MTR Lead Vest from SPCS Rifleman/OEF-CP to SPCS Team Leader Alt/OEF-CP" \n "  - Changed US MMG Gunner Vest from SPCS Rifleman/OEF-CP to SPCS Machinegunner/OEF-CP" \n "  - Changed US MMG/MAT Ammo Bearer Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP" \n "  - Changed US MAT Gunner Vest from SPCS OEF-CP to SPCS Rifleman Alt/OEF-CP" \n "  - Changed US DMT Marksman vest from SPCS OEF-CP to SPCS Sniper/OEF-CP" \n "  - Fixed US DMT Marksman Rifle Loaded Mag to correct varient." \n "  - Changed US Engineer Rifleman Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP." \n "  - Changed US MTR Gunner Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP." \n "  - Changed US DGR Uniforms from FFCP ACU Fatigues to FFCP ACU Fatigues [RS]" \n "  - Changed US DGR Driver Backpack from Assault Pack Green to Assault Pack Black" \n "  - Changed US Heli Pilot/Copilot Uniforms from Heli pilot Coveralls to FFCP Nomad Fatigues [RS]" \n "  - Fixed US Heli/Jet Pilot Vest White Smoke grenade count to 2." \n "  - Changed US Heli Pilot/Copilot Helmet from Heli Pilot NATO to HGU-56/P (Black/Visor)" \n "  - Changed US Jet Pilot Uniform from Pilot Coveralls NATO to  FFCP Nomad Fatigues" \n "  - Changed RUS Vic/Heli/Jet Crew Weapons to PP-2000" \n "  - Upped RUS PP-2000 Ammo counts to 6x Mag to bring in line with ammo counts for TFN and US." \n "  - Changed RUS Heli Pilot Uniforms from Pilot Coveralls CSAT to FFCP-Fatigues EMR [RS]" \n "  - Changed RUS Heli Pilot Vest from 6B23 (6Sh116) to FFCP Tactical Vest TigerVRS" \n "  - Changed RUS Jet Pilot Uniforms from Pilot Coveralls CSAT to FFCP-Fatigues EMR [RS]" \n "  - Changed RUS Jet Pilot Vest from 6B23 (6Sh116) to FFCP Tactical Vest TigerVRS" \n "" \n "- v1.11" \n "  - changed m40 mini grenades to m67 fragmentation" \n "  - replaced mp7 weapons with mp5k-pdw" \n "  - changed ak105 to ak74m (plum) " \n "  - changed PKM to PKP" \n "  - changed RUS PKM ammo boxes. MMG now loads with 7TZ (AP rounds)" \n "  - added vert grip to us weapons" \n "  - replaced m14 with HK PSG1A1" \n "  - replaced m260e4 with mg3" \n "  - updated all ammo boxes respectively. " \n "" \n "- v1.10" \n "  - changed Medic loadouts from 6 x 1000ml blood bags to 2 x 1000ml and 8 x 500ml." \n "" \n "- v1.09" \n "  - updated Fireteam colours A1 Red A2 Yellow, B1 Green B2 Blue, C1 Red C2 Yellow." \n "" \n "- v1.08" \n "  - changed ""Reaper"" to ""Nightbird"", ""RPR"" to ""NB""" \n "  - changed ""Paladin"" to ""Falcon"", ""PAL"" to ""FC""" \n "  - changed ""DAGGER"" to ""DGR""" \n "" \n "- v1.07" \n "  - US and RU faction bumped to v1.07 to avoid confusion regarding version numbers (US and RU was 1.05, TFN was 1.06)" \n "  - overhauled the RU faction: updated helmets, uniforms, weapons to a more modern look" \n "  - overhauled the US faction: updated helmets and vests to armour rating of IV" \n "  - corrected some mistakes in all factions (grenade ammount of MMG gunner, ENG not having tourniquetes, DGR not having GPS-s)" \n "  - overhauled the medics of all factions to reflect recent cahnges to ACE medical (less QuikClots, more Elastic Bandages, etc.)" \n "" \n "- v1.05" \n "  - Added a MAT ammo box on spawn." \n "" \n "- v1.04" \n "  - All MAT Teams carrying RPG's got the ver3 scopes with ranges for all types" \n "    of ammo." \n "  - All Callsigns were changed to be uniformed throught no matter the faction." \n "" \n "- v1.03" \n "  - set crew driver/gunner and pilot/copilot/jetpilot as Engineers through the" \n "    Object: ACE Options menu in unit attributes" \n "  - overhauled the TFN faction (weapons, helmets, etc.), changes not applicable" \n "    to derived factions" \n "" \n "- v1.02" \n "  - loadout overhaul for DMT, made them lighter + gave them tools for recon" \n "  - specified preset ACRE2 radio channels for most units" \n "" \n "- v1.01" \n "  - updated team colors func to `a3ee_team_colors_fnc_setColor`, just load+save" \n "    the composition in editor, this fixes it" \n "  - changed RPG-7 using MAT teams to carry Kitbags" \n "  - removed one PKM ammo box from AAR, MMG gunner, MMG bearer (fixes overload)" \n "  - moved 1-2 AR boxes from AAR to AR, gave AR an Assaultpack" \n "  - added 1-2 more AR boxes to AR's Assaultpack (if enough space)" \n "  - changed HEDP to HE rockets for Carl Gustav (M3MAAWS)" \n "  - changed US crew uniform and helmet to match grey color scheme of US pilots" \n "  - changed backpacks of driver/copilot to use less contrasting colors compared" \n "    to their respective uniform/vest colors" \n "  - changed Carryall backpacks of TFN Engineers to use custom Flecktarn Carryall" \n "  - changed all (GP-25 and normal) AK74m rifles to be the non-NPZ variants" \n "  - removed secondary long-range (PRC148) from Engineers" \n "" \n "- v1.00 (and before)" \n "  - added a Comment object with version number (`v1.00`)" \n "  - added `respawn_west`, `respawn_east`, `respawn_guerrila` markers" \n "  - added `[this, 200] call a3ee_fnc_boxGuard` to init lines of resupply boxes" \n "  - added `Resupply` green triangle markers on the position of resupply boxes";
+		id=69;
 	};
 	class Item16
 	{
@@ -12261,7 +15909,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={4.5131836,0.0014390945,-4.9428711};
+					position[]={4.4506836,0.0014390945,-4.7147217};
 				};
 				side="East";
 				flags=7;
@@ -12333,7 +15981,7 @@ class items
 						headgear="rhs_beret_mvd";
 					};
 				};
-				id=225;
+				id=71;
 				type="O_Protagonist_VR_F";
 				class CustomAttributes
 				{
@@ -12413,7 +16061,90 @@ class items
 							};
 						};
 					};
-					nAttributes=4;
+					class Attribute4
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=3;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="0";
+										};
+									};
+									class Item1
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+									class Item2
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="3";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute5
+					{
+						property="a3aa_insta_zeus_unit_curator";
+						expression="[_this, _value] call a3aa_insta_zeus_fnc_createUnitCurator";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"BOOL"
+									};
+								};
+								value=1;
+							};
+						};
+					};
+					nAttributes=6;
 				};
 			};
 			class Item1
@@ -12421,7 +16152,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={5.512207,0.0014390945,-4.9418945};
+					position[]={5.449707,0.0014390945,-4.7137451};
 				};
 				side="East";
 				flags=5;
@@ -12493,7 +16224,7 @@ class items
 						headgear="rhs_beret_mvd";
 					};
 				};
-				id=226;
+				id=72;
 				type="O_Protagonist_VR_F";
 				class CustomAttributes
 				{
@@ -12535,14 +16266,135 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=3;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="0";
+										};
+									};
+									class Item1
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+									class Item2
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="3";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute3
+					{
+						property="a3aa_insta_zeus_unit_curator";
+						expression="[_this, _value] call a3aa_insta_zeus_fnc_createUnitCurator";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"BOOL"
+									};
+								};
+								value=1;
+							};
+						};
+					};
+					class Attribute4
+					{
+						property="speaker";
+						expression="_this setspeaker _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="Male02PER";
+							};
+						};
+					};
+					class Attribute5
+					{
+						property="pitch";
+						expression="_this setpitch _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"SCALAR"
+									};
+								};
+								value=1.04;
+							};
+						};
+					};
+					nAttributes=6;
 				};
 			};
 		};
 		class Attributes
 		{
 		};
-		id=224;
+		id=70;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -12572,15 +16424,17 @@ class items
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={7.6342773,0,-3.6879883};
+			position[]={7.5717773,0,-3.4597778};
 		};
 		side="Empty";
 		flags=4;
 		class Attributes
 		{
 			init="call{[this, 200] call a3aa_fnc_boxGuard}";
+			name="Medical_Supply_Crate";
+			description="Medical Supply Crate";
 		};
-		id=227;
+		id=73;
 		type="ACE_medicalSupplyCrate";
 		class CustomAttributes
 		{
@@ -12611,15 +16465,17 @@ class items
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={7.5249023,0.89242268,-7.7070313};
+			position[]={7.4628906,0.89242268,-7.4787598};
 		};
 		side="Empty";
 		flags=4;
 		class Attributes
 		{
 			init="call{[this, 200] call a3aa_fnc_boxGuard}";
+			name="Platoon_Supply_Crate";
+			description="Platoon Supply Crate";
 		};
-		id=228;
+		id=74;
 		type="O_supplyCrate_F";
 		class CustomAttributes
 		{
@@ -12650,15 +16506,17 @@ class items
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={7.597168,0.28405476,-5.3432617};
+			position[]={7.534668,0.28405476,-5.1148071};
 		};
 		side="Empty";
 		flags=4;
 		class Attributes
 		{
 			init="call{[this, 200] call a3aa_fnc_boxGuard}";
+			name="Fireteam_Supply_Box";
+			description="Fireteam Supply Box";
 		};
-		id=229;
+		id=75;
 		type="Box_East_Ammo_F";
 		class CustomAttributes
 		{
@@ -12689,12 +16547,12 @@ class items
 		dataType="Logic";
 		class PositionInfo
 		{
-			position[]={-0.020996094,0,0.062988281};
+			position[]={-0.083496094,0,0.2911377};
 		};
 		areaSize[]={200,-1,200};
 		areaIsRectangle=1;
 		flags=1;
-		id=230;
+		id=76;
 		type="a3aa_ee_custom_location";
 		class CustomAttributes
 		{
@@ -12756,6 +16614,47 @@ class items
 				};
 			};
 			nAttributes=3;
+		};
+	};
+	class Item21
+	{
+		dataType="Object";
+		class PositionInfo
+		{
+			position[]={5.3647461,0.18872452,-8.6337891};
+		};
+		side="Empty";
+		flags=4;
+		class Attributes
+		{
+			init="call{[this, 200] call a3aa_fnc_boxGuard}";
+			name="Mortar_Supply_Box";
+			description="Mortar Supply Box";
+		};
+		id=77;
+		type="Box_East_Wps_F";
+		class CustomAttributes
+		{
+			class Attribute0
+			{
+				property="ammoBox";
+				expression="[_this,_value] call bis_fnc_initAmmoBox;";
+				class Value
+				{
+					class data
+					{
+						class type
+						{
+							type[]=
+							{
+								"STRING"
+							};
+						};
+						value="[[[[],[]],[[],[]],[[""ACE_MapTools"",""ACE_RangeTable_82mm""],[2,2]],[[""RHS_Podnos_Gun_Bag"",""RHS_Podnos_Bipod_Bag""],[2,2]]],false]";
+					};
+				};
+			};
+			nAttributes=1;
 		};
 	};
 };

--- a/reference/Russian%20Army/composition.sqe
+++ b/reference/Russian%20Army/composition.sqe
@@ -1,5 +1,5 @@
 version=53;
-center[]={2946.8403,5,6947.4375};
+center[]={3186.7532,5,6657.3584};
 class items
 {
 	items=22;
@@ -15,7 +15,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-6.0800781,0.0014390945,8.1240234};
+					position[]={-6.0483398,0.0014390945,8.1274414};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -218,7 +218,7 @@ class items
 						headgear="rhs_6b27m_green_ess";
 					};
 				};
-				id=1;
+				id=157;
 				type="O_officer_F";
 				class CustomAttributes
 				{
@@ -370,7 +370,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-5.0800781,0.0014390945,8.1020508};
+					position[]={-5.0483398,0.0014390945,8.1054688};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -534,7 +534,7 @@ class items
 						headgear="rhs_6b27m_green_bala";
 					};
 				};
-				id=2;
+				id=158;
 				type="O_Soldier_TL_F";
 				class CustomAttributes
 				{
@@ -686,7 +686,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-4.0805664,0.0014390945,8.1235352};
+					position[]={-4.0488281,0.0014390945,8.1269531};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -885,7 +885,7 @@ class items
 						headgear="rhs_6b27m_green";
 					};
 				};
-				id=3;
+				id=159;
 				type="O_medic_F";
 				class CustomAttributes
 				{
@@ -971,7 +971,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-3.0805664,0.0014390945,8.1235352};
+					position[]={-3.0488281,0.0014390945,8.1269531};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -1095,7 +1095,7 @@ class items
 						headgear="rhs_6b27m_green_ess_bala";
 					};
 				};
-				id=4;
+				id=160;
 				type="O_Soldier_F";
 				class CustomAttributes
 				{
@@ -1180,7 +1180,7 @@ class items
 		class Attributes
 		{
 		};
-		id=0;
+		id=156;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -1217,7 +1217,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-6.3383789,0.0014390945,5.3911133};
+					position[]={-6.3061523,0.0014390945,5.3945313};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -1227,6 +1227,7 @@ class items
 					rank="LIEUTENANT";
 					init="call{this disableAI ""MOVE"";" \n "this setSpeaker ""NoVoice"";" \n "enableRadio false;}";
 					description="Alpha Squad Leader@ALPHA";
+					isPlayer=1;
 					isPlayable=1;
 					class Inventory
 					{
@@ -1421,7 +1422,7 @@ class items
 						headgear="rhs_6b27m_green_ess_bala";
 					};
 				};
-				id=6;
+				id=162;
 				type="O_Soldier_SL_F";
 				class CustomAttributes
 				{
@@ -1559,7 +1560,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-5.3374023,0.0014390945,5.4018555};
+					position[]={-5.3056641,0.0014390945,5.4052734};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -1758,7 +1759,7 @@ class items
 						headgear="rhs_6b27m_green";
 					};
 				};
-				id=7;
+				id=163;
 				type="O_medic_F";
 				class CustomAttributes
 				{
@@ -1844,7 +1845,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-6.315918,0.0014390945,3.3911133};
+					position[]={-6.2841797,0.0014390945,3.3945313};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -2037,7 +2038,7 @@ class items
 						headgear="rhs_6b27m_green_bala";
 					};
 				};
-				id=8;
+				id=164;
 				type="O_Soldier_TL_F";
 				class CustomAttributes
 				{
@@ -2161,7 +2162,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-5.315918,0.0014390945,3.4018555};
+					position[]={-5.2841797,0.0014390945,3.4052734};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -2294,7 +2295,7 @@ class items
 						headgear="rhs_6b27m_green_ess";
 					};
 				};
-				id=9;
+				id=165;
 				type="O_Soldier_AR_F";
 				class CustomAttributes
 				{
@@ -2418,7 +2419,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-4.3164063,0.0014390945,3.4130859};
+					position[]={-4.284668,0.0014390945,3.4165039};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -2600,7 +2601,7 @@ class items
 						headgear="rhs_6b27m_green";
 					};
 				};
-				id=10;
+				id=166;
 				type="O_Soldier_AAR_F";
 				class CustomAttributes
 				{
@@ -2743,7 +2744,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-3.315918,0.0014390945,3.4223633};
+					position[]={-3.2841797,0.0014390945,3.4257813};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -2871,7 +2872,7 @@ class items
 						headgear="rhs_6b27m_green";
 					};
 				};
-				id=11;
+				id=167;
 				type="O_Soldier_LAT_F";
 				class CustomAttributes
 				{
@@ -2995,7 +2996,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-6.2944336,0.0014390945,1.3911133};
+					position[]={-6.2626953,0.0014390945,1.3945313};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -3188,7 +3189,7 @@ class items
 						headgear="rhs_6b27m_green";
 					};
 				};
-				id=12;
+				id=168;
 				type="O_Soldier_TL_F";
 				class CustomAttributes
 				{
@@ -3312,7 +3313,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-5.2944336,0.0014390945,1.4018555};
+					position[]={-5.2626953,0.0014390945,1.4052734};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -3445,7 +3446,7 @@ class items
 						headgear="rhs_6b27m_green";
 					};
 				};
-				id=13;
+				id=169;
 				type="O_Soldier_AR_F";
 				class CustomAttributes
 				{
@@ -3569,7 +3570,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-4.2944336,0.0014390945,1.4130859};
+					position[]={-4.2626953,0.0014390945,1.4165039};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -3751,7 +3752,7 @@ class items
 						headgear="rhs_6b27m_green_bala";
 					};
 				};
-				id=14;
+				id=170;
 				type="O_Soldier_AAR_F";
 				class CustomAttributes
 				{
@@ -3894,7 +3895,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-3.2944336,0.0014390945,1.4233398};
+					position[]={-3.2626953,0.0014390945,1.4267578};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -4022,7 +4023,7 @@ class items
 						headgear="rhs_6b27m_green_ess";
 					};
 				};
-				id=15;
+				id=171;
 				type="O_Soldier_LAT_F";
 				class CustomAttributes
 				{
@@ -4145,7 +4146,7 @@ class items
 		class Attributes
 		{
 		};
-		id=5;
+		id=161;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -4182,7 +4183,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-1.128418,0.0014390945,5.8139648};
+					position[]={-1.0966797,0.0014390945,5.8173828};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -4386,7 +4387,7 @@ class items
 						headgear="rhs_6b27m_green_ess_bala";
 					};
 				};
-				id=17;
+				id=173;
 				type="O_Soldier_SL_F";
 				class CustomAttributes
 				{
@@ -4524,7 +4525,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-0.12744141,0.0014390945,5.824707};
+					position[]={-0.095703125,0.0014390945,5.828125};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -4723,7 +4724,7 @@ class items
 						headgear="rhs_6b27m_green";
 					};
 				};
-				id=18;
+				id=174;
 				type="O_medic_F";
 				class CustomAttributes
 				{
@@ -4847,7 +4848,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-1.105957,0.0014390945,3.8139648};
+					position[]={-1.0742188,0.0014390945,3.8173828};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -5040,7 +5041,7 @@ class items
 						headgear="rhs_6b27m_green";
 					};
 				};
-				id=19;
+				id=175;
 				type="O_Soldier_TL_F";
 				class CustomAttributes
 				{
@@ -5145,7 +5146,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-0.10595703,0.0014390945,3.824707};
+					position[]={-0.07421875,0.0014390945,3.828125};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -5278,7 +5279,7 @@ class items
 						headgear="rhs_6b27m_green";
 					};
 				};
-				id=20;
+				id=176;
 				type="O_Soldier_AR_F";
 				class CustomAttributes
 				{
@@ -5383,7 +5384,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={0.89355469,0.0014390945,3.8349609};
+					position[]={0.92529297,0.0014390945,3.8383789};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -5565,7 +5566,7 @@ class items
 						headgear="rhs_6b27m_green_bala";
 					};
 				};
-				id=21;
+				id=177;
 				type="O_Soldier_AAR_F";
 				class CustomAttributes
 				{
@@ -5708,7 +5709,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={1.894043,0.0014390945,3.8461914};
+					position[]={1.9257813,0.0014390945,3.8496094};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -5836,7 +5837,7 @@ class items
 						headgear="rhs_6b27m_green_ess";
 					};
 				};
-				id=22;
+				id=178;
 				type="O_Soldier_LAT_F";
 				class CustomAttributes
 				{
@@ -5941,7 +5942,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-1.0844727,0.0014390945,1.8139648};
+					position[]={-1.0527344,0.0014390945,1.8173828};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -6134,7 +6135,7 @@ class items
 						headgear="rhs_6b27m_green_bala";
 					};
 				};
-				id=23;
+				id=179;
 				type="O_Soldier_TL_F";
 				class CustomAttributes
 				{
@@ -6239,7 +6240,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-0.084472656,0.0014390945,1.824707};
+					position[]={-0.052734375,0.0014390945,1.828125};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -6372,7 +6373,7 @@ class items
 						headgear="rhs_6b27m_green_ess";
 					};
 				};
-				id=24;
+				id=180;
 				type="O_Soldier_AR_F";
 				class CustomAttributes
 				{
@@ -6477,7 +6478,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={0.91552734,0.0014390945,1.8349609};
+					position[]={0.94726563,0.0014390945,1.8383789};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -6659,7 +6660,7 @@ class items
 						headgear="rhs_6b27m_green";
 					};
 				};
-				id=25;
+				id=181;
 				type="O_Soldier_AAR_F";
 				class CustomAttributes
 				{
@@ -6802,7 +6803,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={1.9155273,0.0014390945,1.8461914};
+					position[]={1.9472656,0.0014390945,1.8496094};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -6930,7 +6931,7 @@ class items
 						headgear="rhs_6b27m_green";
 					};
 				};
-				id=26;
+				id=182;
 				type="O_Soldier_LAT_F";
 				class CustomAttributes
 				{
@@ -7034,7 +7035,7 @@ class items
 		class Attributes
 		{
 		};
-		id=16;
+		id=172;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -7071,7 +7072,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={4.2797852,0.0014390945,6.3388672};
+					position[]={4.3115234,0.0014390945,6.3422852};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -7275,7 +7276,7 @@ class items
 						headgear="rhs_6b27m_green_ess_bala";
 					};
 				};
-				id=28;
+				id=184;
 				type="O_Soldier_SL_F";
 				class CustomAttributes
 				{
@@ -7413,7 +7414,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={5.2788086,0.0014390945,6.3500977};
+					position[]={5.3105469,0.0014390945,6.3535156};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -7612,7 +7613,7 @@ class items
 						headgear="rhs_6b27m_green";
 					};
 				};
-				id=29;
+				id=185;
 				type="O_medic_F";
 				class CustomAttributes
 				{
@@ -7736,7 +7737,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={4.3017578,0.0014390945,4.3388672};
+					position[]={4.3334961,0.0014390945,4.3422852};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -7929,7 +7930,7 @@ class items
 						headgear="rhs_6b27m_green_bala";
 					};
 				};
-				id=30;
+				id=186;
 				type="O_Soldier_TL_F";
 				class CustomAttributes
 				{
@@ -8072,7 +8073,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={5.3017578,0.0014390945,4.3500977};
+					position[]={5.3334961,0.0014390945,4.3535156};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -8205,7 +8206,7 @@ class items
 						headgear="rhs_6b27m_green_ess";
 					};
 				};
-				id=31;
+				id=187;
 				type="O_Soldier_AR_F";
 				class CustomAttributes
 				{
@@ -8348,7 +8349,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={6.3017578,0.0014390945,4.3608398};
+					position[]={6.3334961,0.0014390945,4.3642578};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -8530,7 +8531,7 @@ class items
 						headgear="rhs_6b27m_green";
 					};
 				};
-				id=32;
+				id=188;
 				type="O_Soldier_AAR_F";
 				class CustomAttributes
 				{
@@ -8673,7 +8674,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={7.3017578,0.0014390945,4.3720703};
+					position[]={7.3334961,0.0014390945,4.3754883};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -8801,7 +8802,7 @@ class items
 						headgear="rhs_6b27m_green";
 					};
 				};
-				id=33;
+				id=189;
 				type="O_Soldier_LAT_F";
 				class CustomAttributes
 				{
@@ -8944,7 +8945,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={4.3227539,0.0014390945,2.3398438};
+					position[]={4.3544922,0.0014390945,2.3432617};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -9137,7 +9138,7 @@ class items
 						headgear="rhs_6b27m_green";
 					};
 				};
-				id=34;
+				id=190;
 				type="O_Soldier_TL_F";
 				class CustomAttributes
 				{
@@ -9280,7 +9281,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={5.3227539,0.0014390945,2.3510742};
+					position[]={5.3544922,0.0014390945,2.3544922};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -9413,7 +9414,7 @@ class items
 						headgear="rhs_6b27m_green";
 					};
 				};
-				id=35;
+				id=191;
 				type="O_Soldier_AR_F";
 				class CustomAttributes
 				{
@@ -9556,7 +9557,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={6.3217773,0.0014390945,2.3608398};
+					position[]={6.3535156,0.0014390945,2.3642578};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -9738,7 +9739,7 @@ class items
 						headgear="rhs_6b27m_green_bala";
 					};
 				};
-				id=36;
+				id=192;
 				type="O_Soldier_AAR_F";
 				class CustomAttributes
 				{
@@ -9881,7 +9882,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={7.3217773,0.0014390945,2.3720703};
+					position[]={7.3535156,0.0014390945,2.3754883};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -10009,7 +10010,7 @@ class items
 						headgear="rhs_6b27m_green_ess";
 					};
 				};
-				id=37;
+				id=193;
 				type="O_Soldier_LAT_F";
 				class CustomAttributes
 				{
@@ -10151,7 +10152,7 @@ class items
 		class Attributes
 		{
 		};
-		id=27;
+		id=183;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -10188,7 +10189,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-6.6640625,0.0014390945,-1.5410156};
+					position[]={-6.6323242,0.0014390945,-1.5375977};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -10392,7 +10393,7 @@ class items
 						headgear="rhs_6b27m_green_bala";
 					};
 				};
-				id=39;
+				id=195;
 				type="O_Soldier_TL_F";
 				class CustomAttributes
 				{
@@ -10530,7 +10531,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-5.6645508,0.0014390945,-1.5307617};
+					position[]={-5.6328125,0.0014390945,-1.5273438};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -10656,7 +10657,7 @@ class items
 						headgear="rhs_6b27m_green_ess";
 					};
 				};
-				id=40;
+				id=196;
 				type="O_Soldier_AR_F";
 				class CustomAttributes
 				{
@@ -10742,7 +10743,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-4.6645508,0.0014390945,-1.5200195};
+					position[]={-4.6328125,0.0014390945,-1.5166016};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -10881,7 +10882,7 @@ class items
 						headgear="rhs_6b27m_green";
 					};
 				};
-				id=41;
+				id=197;
 				type="O_Soldier_AAR_F";
 				class CustomAttributes
 				{
@@ -10966,7 +10967,7 @@ class items
 		class Attributes
 		{
 		};
-		id=38;
+		id=194;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -11003,7 +11004,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-1.0600586,0.0014390945,-1.7719727};
+					position[]={-1.0283203,0.0014390945,-1.7685547};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -11207,7 +11208,7 @@ class items
 						headgear="rhs_6b27m_green_bala";
 					};
 				};
-				id=43;
+				id=199;
 				type="O_Soldier_TL_F";
 				class CustomAttributes
 				{
@@ -11345,7 +11346,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-0.061035156,0.0014390945,-1.7612305};
+					position[]={-0.029296875,0.0014390945,-1.7578125};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -11500,7 +11501,7 @@ class items
 						headgear="rhs_6b27m_green_ess";
 					};
 				};
-				id=44;
+				id=200;
 				type="O_Soldier_AT_F";
 				class CustomAttributes
 				{
@@ -11600,7 +11601,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={0.93896484,0.0014390945,-1.7504883};
+					position[]={0.97070313,0.0014390945,-1.7470703};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -11745,7 +11746,7 @@ class items
 						headgear="rhs_6b27m_green";
 					};
 				};
-				id=45;
+				id=201;
 				type="O_Soldier_AAT_F";
 				class CustomAttributes
 				{
@@ -11844,7 +11845,7 @@ class items
 		class Attributes
 		{
 		};
-		id=42;
+		id=198;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -11881,7 +11882,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-5.6782227,0.0014390945,-4.565918};
+					position[]={-5.6464844,0.0014390945,-4.5625};
 					angles[]={-0,6.2723818,0};
 				};
 				side="East";
@@ -12042,7 +12043,7 @@ class items
 						headgear="rhs_fieldcap_digi2";
 					};
 				};
-				id=47;
+				id=203;
 				type="O_soldier_M_F";
 				class CustomAttributes
 				{
@@ -12166,7 +12167,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-6.6772461,0.0014390945,-4.5771484};
+					position[]={-6.6455078,0.0014390945,-4.5737305};
 					angles[]={-0,6.2723818,0};
 				};
 				side="East";
@@ -12322,7 +12323,7 @@ class items
 						headgear="rhs_fieldcap_digi2";
 					};
 				};
-				id=48;
+				id=204;
 				type="O_spotter_F";
 				class CustomAttributes
 				{
@@ -12459,7 +12460,7 @@ class items
 		class Attributes
 		{
 		};
-		id=46;
+		id=202;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -12496,7 +12497,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-0.91943359,0.0014390945,-4.9321289};
+					position[]={-0.88769531,0.0014390945,-4.9287109};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -12653,7 +12654,7 @@ class items
 						headgear="rhs_6b27m_green";
 					};
 				};
-				id=50;
+				id=206;
 				type="O_support_AMort_F";
 				class CustomAttributes
 				{
@@ -12703,7 +12704,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={0.080566406,0.0014390945,-4.9213867};
+					position[]={0.11230469,0.0014390945,-4.9179688};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -12848,7 +12849,7 @@ class items
 						headgear="rhs_6b27m_green_ess";
 					};
 				};
-				id=51;
+				id=207;
 				type="O_support_Mort_F";
 				class CustomAttributes
 				{
@@ -12897,7 +12898,7 @@ class items
 		class Attributes
 		{
 		};
-		id=49;
+		id=205;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -12934,7 +12935,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={4.4516602,0.0014390945,-1.5830078};
+					position[]={4.4833984,0.0014390945,-1.5795898};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -13121,7 +13122,7 @@ class items
 						headgear="rhs_altyn";
 					};
 				};
-				id=53;
+				id=209;
 				type="O_engineer_F";
 				class CustomAttributes
 				{
@@ -13259,7 +13260,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={5.4526367,0.0014390945,-1.5717773};
+					position[]={5.484375,0.0014390945,-1.5683594};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -13425,7 +13426,7 @@ class items
 						headgear="rhs_altyn_visordown";
 					};
 				};
-				id=54;
+				id=210;
 				type="O_engineer_F";
 				class CustomAttributes
 				{
@@ -13511,7 +13512,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={6.4526367,0.0014390945,-1.5610352};
+					position[]={6.484375,0.0014390945,-1.5576172};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -13677,7 +13678,7 @@ class items
 						headgear="rhs_altyn_bala";
 					};
 				};
-				id=55;
+				id=211;
 				type="O_engineer_F";
 				class CustomAttributes
 				{
@@ -13763,7 +13764,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={7.4526367,0.0014390945,-1.550293};
+					position[]={7.484375,0.0014390945,-1.546875};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -13929,7 +13930,7 @@ class items
 						headgear="rhs_altyn_visordown";
 					};
 				};
-				id=56;
+				id=212;
 				type="O_engineer_F";
 				class CustomAttributes
 				{
@@ -14014,7 +14015,7 @@ class items
 		class Attributes
 		{
 		};
-		id=52;
+		id=208;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -14051,7 +14052,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-6.5874023,0.0014390945,-7.7387695};
+					position[]={-6.5556641,0.0014390945,-7.7353516};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -14198,7 +14199,7 @@ class items
 						headgear="rhs_tsh4";
 					};
 				};
-				id=58;
+				id=214;
 				type="O_crew_F";
 				class CustomAttributes
 				{
@@ -14350,7 +14351,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-5.5874023,0.0014390945,-7.7280273};
+					position[]={-5.5556641,0.0014390945,-7.7246094};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -14501,7 +14502,7 @@ class items
 						headgear="rhs_tsh4";
 					};
 				};
-				id=59;
+				id=215;
 				type="O_crew_F";
 				class CustomAttributes
 				{
@@ -14570,7 +14571,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-4.5874023,0.0014390945,-7.7172852};
+					position[]={-4.5556641,0.0014390945,-7.7138672};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -14707,7 +14708,7 @@ class items
 						headgear="rhs_tsh4";
 					};
 				};
-				id=60;
+				id=216;
 				type="O_crew_F";
 				class CustomAttributes
 				{
@@ -14775,7 +14776,7 @@ class items
 		class Attributes
 		{
 		};
-		id=57;
+		id=213;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -14812,7 +14813,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-0.76611328,0.0014390945,-8.0849609};
+					position[]={-0.734375,0.0014390945,-8.081543};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -14959,7 +14960,7 @@ class items
 						headgear="rhs_zsh7a_mike_green_alt";
 					};
 				};
-				id=62;
+				id=218;
 				type="O_Pilot_F";
 				class CustomAttributes
 				{
@@ -15130,7 +15131,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={0.23388672,0.0014390945,-8.0756836};
+					position[]={0.265625,0.0014390945,-8.0722656};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -15290,7 +15291,7 @@ class items
 						headgear="rhs_zsh7a_mike_green_alt";
 					};
 				};
-				id=63;
+				id=219;
 				type="O_Pilot_F";
 				class CustomAttributes
 				{
@@ -15441,7 +15442,7 @@ class items
 		class Attributes
 		{
 		};
-		id=61;
+		id=217;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -15478,7 +15479,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={3.0214844,0.0014390945,-8.2011719};
+					position[]={3.0532227,0.0014390945,-8.1977539};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -15629,7 +15630,7 @@ class items
 						headgear="H_PilotHelmetFighter_O";
 					};
 				};
-				id=65;
+				id=221;
 				type="O_Pilot_F";
 				class CustomAttributes
 				{
@@ -15799,7 +15800,7 @@ class items
 		class Attributes
 		{
 		};
-		id=64;
+		id=220;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -15827,30 +15828,30 @@ class items
 	class Item12
 	{
 		dataType="Marker";
-		position[]={2.2583008,2.4371225e+032,-4.8813477};
+		position[]={2.2900391,2.4371225e+032,-4.8779297};
 		name="respawn_east";
 		type="respawn_unknown";
 		angle=359.38113;
-		id=66;
+		id=222;
 		atlOffset=2.4371225e+032;
 	};
 	class Item13
 	{
 		dataType="Marker";
-		position[]={6.6958008,0,-6.6010742};
+		position[]={6.7275391,0,-6.5976563};
 		name="resupply_marker_1";
 		text="Resupply";
 		type="mil_triangle";
 		colorName="ColorGreen";
 		angle=359.38086;
-		id=67;
+		id=223;
 	};
 	class Item14
 	{
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={5.3076172,0.14963102,-6.9472656};
+			position[]={5.3393555,0.14963102,-6.9438477};
 			angles[]={-0,1.5418237,0};
 		};
 		side="Empty";
@@ -15860,7 +15861,7 @@ class items
 			name="MAT_Launcher_Supply_Box";
 			description="MAT Launcher Supply Box";
 		};
-		id=68;
+		id=224;
 		type="Box_East_WpsLaunch_F";
 		class CustomAttributes
 		{
@@ -15891,11 +15892,11 @@ class items
 		dataType="Comment";
 		class PositionInfo
 		{
-			position[]={2.4887695,0,-3.7226563};
+			position[]={2.5205078,0,-3.7192383};
 		};
 		title="v1.14.2";
 		description="- v1.14.2" \n "PL: " \n "- Headgear changed from RHS ""Field Cap VSR"" to RHS ""6B27M (ESS)"" to give leader a helmet (issue #82). " \n "- Uniform content: moved radios 152 & 148 to backpack (issue #95). " \n " " \n "Platoon Sergeant: " \n "- Headgear changed from RHS ""6B26 (ESS)"" to RHS ""6B27M (Balaclava)"" to fit the rest of the platoon (issue #112). " \n " " \n "Platoon Medic: " \n "- Headgear changed from RHS ""6B26"" to RHS ""6B27M"" to fit the rest of the platoon (issue #112). " \n "- Rifle changed from RHS ""AKS-74U"" to RHS ""AKS-74UN"" to allow for scope attachments (issue #108). " \n "  " \n "Platoon Rifleman: " \n "- Helmet changed from RHS ""6B26 (ESS/Balaclava)"" to RHS ""6B27M (ESS/Balaclava)"" to fit the rest of the platoon (issue #112). " \n "  " \n "SL: " \n "- Helmet changed from RHS ""6B27M EMR-Summer"" to RHS ""6B27M (Balaclava)"" to fit the rest of the platoon. " \n "- Uniform content: moved radio 152 to backpack (issue #95). " \n "  " \n "Medic: " \n "- Rifle changed from RHS ""AKS-74U"" to RHS ""AKS-74UN"" to allow for scope attachments (issue #108). " \n " " \n "MMG Leader: " \n "- Helmet changed from RHS ""6B27M EMR-Summer"" to RHS ""6B27M (Balaclava)"" to fit the rest of the platoon. " \n "- Uniform content: moved radio 152 to backpack (issue #95). " \n "  " \n "MAT Leader: " \n "- Headgear changed from RHS ""6B27M EMR-Summer"" to RHS ""6B27M (Balaclava)"" to fit the rest of the platoon. " \n "- Uniform content: moved radio 152 to backpack (issue #95). " \n " " \n "ENG Leader: " \n "- Uniform content: moved radio 152 to backpack (issue #95). " \n "- Backpack content: changed ammo count to 4 regular mags and 2 tracer mag (issue #83). " \n " " \n "ENG Rifleman: " \n "- Backpack content: changed ammo count to 5 regular mags and 1 tracer mag (issue #83). " \n " " \n "DMT Leader: " \n "- Soldier class changed from ""B_spotter_F"" to ""O_soldier_M_F"" (issue #94). " \n " " \n "DMT Marksman: " \n "- Soldier class changed from ""B_spotter_F"" to ""O_spotter_F"" (issue #94). " \n " " \n "MTR Leader: " \n "- Vest content: changed ammo count to 5 regular mags and 1 tracer mag (issue #83). " \n " " \n "MTR Gunner: " \n "- Vest content: changed ammo count to 5 regular mags and 1 tracer mag (issue #83). " \n " " \n "Zeus: " \n "- Fixed missing Zeus status (issue #113). " \n " " \n "All Units: " \n "- Fixed missing standard ACRE2 radio channels (issue #110). " \n "- Uniform content: added 1x epinephrine (issue #107) and sorted all items in a more logical manner (issue #111). " \n "- Vest content: sorted all items in a more logical manner (issue #111). " \n "- Backpack content: sorted all items in a more logical manner (issue #111). " \n "- Fireteam members: fixed ST HUD colours for fireteam members of Alpha, Bravo and Charlie (issue #117). " \n " " \n "Crates: " \n "- Added a mortar supply crate (issue #77)." \n "" \n "-v1.14.1" \n " - A3EE box guard updated to A3AA." \n " - Custom location re-added." \n "" \n "-v1.14.0" \n "PL: " \n "- Headgear changed from RHS ""Field Cap EMR-Summer"" to RHS ""Field Cap VSR"". " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest changed from RHS ""6B23 (6Sh116/VOG)"" to RHS ""6B23 EMR-Summer (6Sh92/Headset/Mapcase)"" for more visual diversity in the platoon. " \n "- Vest content: moved 2x RGO grenades to backpack, removed 3x RHS ""30Rnd AK-74 (Plum) 7N22"" and added 4x RHS ""30Rnd AK-74 (Plum) 7T3M (tracer)"" to match TFN and US Army loadouts. " \n "- Backpack changed from vanilla ""Assaultpack green"" to RHS ""UMBTS Backpack"" for a more Russian look. " \n "- Backpack content: increased GL smoke white from 3x to 5x to match TFN and US Army loadouts. " \n "- Rifle mag changed from RHS ""30Rnd AK-74 (Plum) 7N10"" to RHS ""30Rnd AK-74 (Plum) 7N22"" to match the other mags in the vest. " \n " " \n " Platoon Sergeant: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" to RHS ""6B26 (ESS)"" to indicate association with platoon lead element and for more visual diversity in the platoon. " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest content: removed 3x RHS ""30Rnd AK-74 (Plum) 7N22"" and added 4x RHS ""30Rnd AK-74 (Plum) 7T3M (tracer)"" to match TFN and US Army loadouts. " \n "- Backpack added 3CB ""Radio Backpack MR3000"" and filled it with the ACRE2 ""AN/PRC-117F"" backpack radio. This gives more incentive to bring the PLT Sgt along since he is the only one who can act as a max range radio man for the platoon. " \n "- Rifle mag changed from RHS ""30Rnd AK-74 (Plum) 7N10"" to RHS ""30Rnd AK-74 (Plum) 7N22"" to match the other mags in the vest. " \n "  " \n "Platoon Medic: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" to RHS ""6B26"" to indicate association with platoon lead element and for more visual diversity in the platoon. " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest changed from RHS ""6B23 (6Sh116)"" to RHS ""6B23 EMR-Summer (Medic)"". " \n "- Vest content: removed 1x RHS ""30Rnd AK-74 (Plum) 7N22"" and added 2x RHS ""30Rnd AK-74 (Plum) 7T3M (tracer)"" to match TFN and US Army loadouts. " \n "- Backpack changed from vanilla ""Kitback (green)"" to 3CB ""Knapsack Medical (Khaki)"" to visually make the Vest medical bag look like the primary backpack. " \n "- Rifle changed from RHS ""AK-74M (Plum)"" to RHS ""AKS-74U"" for more rifle diversity in the platoon. Slightly lower accuracy at range but lighter carry weight. " \n "- Rifle mag changed from RHS ""30Rnd AK-74 (Plum) 7N10"" to RHS ""30Rnd AK-74 (Plum) 7N22"" to match the other mags in the vest. " \n " " \n "Platoon Rifleman: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" to RHS ""6B26 (ESS/Balaclava)"" to indicate association with platoon lead element and for more visual diversity in the platoon. " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest changed from RHS ""6B23 (6Sh116)"" to RHS ""6B23 EMR-Summer (6Sh116)"". " \n "- Vest content: removed 1x RHS ""30Rnd AK-74 (Plum) 7N22"" and added 2x RHS ""30Rnd AK-74 (Plum) 7T3M (tracer)"" to match TFN and US Army loadouts. " \n "- Rifle mag changed from RHS ""30Rnd AK-74 (Plum) 7N10"" to RHS ""30Rnd AK-74 (Plum) 7N22"" to match the other mags in the vest. " \n " " \n "SL: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" semi-randomly to RHS ""6B27M"" or RHS ""6B27M (ESS)"" or RHS ""6B27M (Balaclava)"". " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest changed from RHS ""6B23 (6Sh116/VOG)"" to RHS ""6B23 EMR-Summer (6Sh92/VOG/Radio) SpNz"".  " \n "- Vest content: moved 2x RGO grenades to backpack, removed 3x RHS ""30Rnd AK-74 (Plum) 7N22"" and added 4x RHS ""30Rnd AK-74 (Plum) 7T3M (tracer)"" to match TFN and US Army loadouts. " \n "- Backpack changed from vanilla ""Assaultpack green"" to RHS ""UMBTS Backpack"" for a more Russian look. " \n "- Backpack content: added 1x RHS ""VOG-25"" to match TFN and US Army loadouts. " \n "- Rifle mag changed from RHS ""30Rnd AK-74 (Plum) 7N10"" to RHS ""30Rnd AK-74 (Plum) 7N22"" to match the other mags in the vest.  " \n " " \n "SL Medic: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" semi-randomly to RHS ""6B27M"" or RHS ""6B27M (ESS)"" or RHS ""6B27M (Balaclava)"". " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest changed from RHS ""6B23 (6Sh116)"" semi-randomly to RHS ""6B23 EMR-Summer (Medic)"" or RHS ""6B23 (Medic)"". " \n "- Vest content: removed 1x RHS ""30Rnd AK-74 (Plum) 7N22"" and added 2x RHS ""30Rnd AK-74 (Plum) 7T3M (tracer)"" to match TFN and US Army loadouts. " \n "- Backpack changed from vanilla ""Kitback (green)"" to 3CB ""Knapsack Medical (Khaki)"" to visually make the Vest medical bag look like the primary backpack. " \n "- Rifle changed from RHS ""AK-74M (Plum)"" to RHS ""AKS-74U"" for more rifle diversity in the platoon. Slightly lower accuracy at range but lighter carry weight. " \n "- Rifle mag changed from RHS ""30Rnd AK-74 (Plum) 7N10"" to RHS ""30Rnd AK-74 (Plum) 7N22"" to match the other mags in the vest. " \n "  " \n "FTL: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" semi-randomly to RHS ""6B27M"" or RHS ""6B27M (ESS)"" or RHS ""6B27M (Balaclava)"". " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest changed from RHS ""6B23 (6Sh116/VOG)"" semi-randomly to RHS ""6B23 EMR-Summer (6Sh92/VOG/Headset)"" or RHS ""6B23 (6Sh92/VOG/Headset)"". " \n "- Vest content: moved 2x RGO grenades to backpack, removed 3x RHS ""30Rnd AK-74 (Plum) 7N22"" and added 4x RHS ""30Rnd AK-74 (Plum) 7T3M (tracer)"" to match TFN and US Army loadouts. " \n "- Backpack changed from vanilla ""Assaultpack green"" to RHS ""UMBTS Backpack (Engineer)"" for a more Russian/breacher look. " \n "- Backpack content: added 2x RHS ""VOG-25"" to match TFN and US Army loadouts. " \n "- Rifle mag changed from RHS ""30Rnd AK-74 (Plum) 7N10"" to RHS ""30Rnd AK-74 (Plum) 7N22"" to match the other mags in the vest. " \n "  " \n "AR: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" semi-randomly to RHS ""6B27M"" or RHS ""6B27M (ESS)"" or RHS ""6B27M (Balaclava)"". " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest changed from RHS ""6B23 (6Sh116)"" semi-randomly to RHS ""6B23 EMR-Summer (Vydra-3M)"" or RHS ""6B23 (Vydra-3M)"" " \n "- Vest content: added 1x HLC ""7.62mm 75Rnd FMJ RPK Magazine (Tracers every 3)"" " \n "- Backpack changed from vanilla ""Assaultpack (green)"" to RHS ""Sidor"" for a more Russian look. " \n "- Backpack content: added 2x HLC ""7.62mm 75Rnd FMJ RPK Magazine (Tracers every 3)"" and 1x HLC ""7.62mm 75Rnd FMJ RPK Magazine (Tracer)"" " \n "- Rifle changed from RHS ""PKP"" to HLC ""RPK"". " \n "- Rifle muzzle attachment added RHS ""Surefire SF3P-762"". " \n " " \n "AAR: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" semi-randomly to RHS ""6B27M"" or RHS ""6B27M (ESS)"" or RHS ""6B27M (Balaclava)"". " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest changed from RHS ""6B23 (6Sh116)"" semi-randomly to RHS ""6B23 EMR-Summer (6Sh92/Headset)"" or RHS ""6B23 (6Sh92/Headset)"". " \n "- Vest content: moved 2x RGO grenades to backpack, removed 3x RHS ""30Rnd AK-74 (Plum) 7N22"" and added 4x RHS ""30Rnd AK-74 (Plum) 7T3M (tracer)"" to match TFN and US Army loadouts. " \n "- Backpack content: added RHS 2x ""30Rnd AK-74 (Plum) 7N22"" and 3x HLC ""7.62mm 75Rnd FMJ RPK Magazine (Tracers every 3)"" to match TFN and US Army loadouts. " \n "- Rifle mag changed from RHS ""30Rnd AK-74 (Plum) 7N10"" to RHS ""30Rnd AK-74 (Plum) 7N22"" to match the other mags in the vest. " \n "" \n "LAT: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" semi-randomly to RHS ""6B27M"" or RHS ""6B27M (ESS)"" or RHS ""6B27M (Balaclava)"". " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest variety changed semi-randomly to RHS ""6B23 (6Sh116)"" and RHS ""6B23 EMR-Summer (6Sh116)"". " \n "- Vest content: removed 1x RHS ""30Rnd AK-74 (Plum) 7N22"" and added 2x RHS ""30Rnd AK-74 (Plum) 7T3M (tracer)"" to match TFN and US Army loadouts. " \n "- Rifle changed from RHS ""AK-74M"" to RHS ""AK-105"" for more weapon variety in the platoon. " \n "- Rifle mag changed from RHS ""30Rnd AK-74 (Plum) 7N10"" to RHS ""30Rnd AK-74 (Plum) 7N22"" to match the other mags in the vest. " \n " " \n "MMG Leader: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" to RHS ""6B27M EMR-Summer"" " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest changed from RHS ""6B23 (6Sh116/VOG)"" to RHS ""6B23 EMR-Summer (6Sh92/VOG/Radio) SpNz"".  " \n "- Vest content: moved 2x RGO grenades to backpack, removed 3x RHS ""30Rnd AK-74 (Plum) 7N22"" and added 4x RHS ""30Rnd AK-74 (Plum) 7T3M (tracer)"" to match TFN and US Army loadouts. " \n "- Backpack changed from vanilla ""Assaultpack green"" to RHS ""UMBTS Backpack"" for a more Russian look. " \n "- Backpack content: added 1x RHS ""VOG-25"" to match TFN and US Army loadouts. " \n "- Rifle mag changed from RHS ""30Rnd AK-74 (Plum) 7N10"" to RHS ""30Rnd AK-74 (Plum) 7N22"" to match the other mags in the vest. " \n "  " \n "MMG Gunner: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" to RHS ""6B27M (ESS)"". " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest changed from RHS ""6B23 (6Sh116)"" to RHS ""6B23 EMR-Summer (Rifleman)"". " \n " " \n "MMG Asst. Gunner: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" to RHS ""6B27M"". " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest content: removed 1x RHS ""30Rnd AK-74 (Plum) 7N22"" and added 2x RHS ""30Rnd AK-74 (Plum) 7T3M (tracer)"" to match TFN and US Army loadouts. " \n "- Rifle mag changed from RHS ""30Rnd AK-74 (Plum) 7N10"" to RHS ""30Rnd AK-74 (Plum) 7N22"" to match the other mags in the vest. " \n " " \n "MAT Leader: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" to RHS ""6B27M EMR-Summer"" " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest changed from RHS ""6B23 (6Sh116/VOG)"" to RHS ""6B23 EMR-Summer (6Sh92/VOG/Radio) SpNz"".  " \n "- Vest content: moved 2x RGO grenades to backpack, removed 3x RHS ""30Rnd AK-74 (Plum) 7N22"" and added 4x RHS ""30Rnd AK-74 (Plum) 7T3M (tracer)"" to match TFN and US Army loadouts. " \n "- Backpack changed from vanilla ""Assaultpack green"" to RHS ""UMBTS Backpack"" for a more Russian look. " \n "- Backpack content: added 1x RHS ""VOG-25"" to match TFN and US Army loadouts. " \n "- Rifle mag changed from RHS ""30Rnd AK-74 (Plum) 7N10"" to RHS ""30Rnd AK-74 (Plum) 7N22"" to match the other mags in the vest. " \n " " \n "MAT Gunner: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" to RHS ""6B27M (ESS)"". " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Rifle changed from RHS ""AK-74M"" to RHS ""AK-105"" for more weapon variety in the platoon. " \n "- Rifle mag changed from RHS ""30Rnd AK-74 (Plum) 7N10"" to RHS ""30Rnd AK-74 (Plum) 7N22"" to match the other mags in the vest. " \n " " \n "MAT Asst. Gunner: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" to RHS ""6B27M"". " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest changed from RHS ""6B23 (6Sh116)"" to RHS ""6B23 EMR-Summer ""(6Sh92/Headset)"". " \n "- Vest content: removed 1x RHS ""30Rnd AK-74 (Plum) 7N22"" and added 2x RHS ""30Rnd AK-74 (Plum) 7T3M (tracer)"" to match TFN and US Army loadouts. " \n "- Rifle mag changed from RHS ""30Rnd AK-74 (Plum) 7N10"" to RHS ""30Rnd AK-74 (Plum) 7N22"" to match the other mags in the vest. " \n "  " \n "DMT Marksman " \n "- Added scope RHS ""IPN34"" to the vest gear. This is a somewhat equivalent NVG scope to the US Army Faction. " \n "  " \n "ENG Leader: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" to RHS ""Altyn (visor up)"". " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest changed from RHS ""6B23 (6Sh116)"" to RHS ""6B13 EMR-Summer ""(6Sh92/Radio)"". " \n "- Rifle changed from RHS ""AK-74M"" to RHS ""AK-105"" for more weapon variety in the platoon. " \n "- Rifle mag changed from RHS ""30Rnd AK-74 (Plum) 7N10"" to RHS ""30Rnd AK-74 (Plum) 7N22"" to match the other mags in the vest. " \n "  " \n "ENG Rifleman: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" semi-randomly to RHS ""Altyn (visor down)"" or RHS ""Altyn (visor up Balaclava)"". " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest changed from RHS ""6B23 (6Sh116)"" to RHS ""6B13 EMR-Summer ""(6Sh92)"". " \n "- Rifle changed from RHS ""AK-74M"" to RHS ""AK-105"" for more weapon variety in the platoon. " \n "- Rifle mag changed from RHS ""30Rnd AK-74 (Plum) 7N10"" to RHS ""30Rnd AK-74 (Plum) 7N22"" to match the other mags in the vest. " \n "  " \n "Mortar Leader: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" to RHS ""6B27M"". " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest changed from RHS ""6B23 (6Sh116/VOG)"" to RHS ""6B23 EMR-Summer (6Sh92/Radio)"". " \n "- Rifle changed from RHS ""AK-74M (Plum)"" to RHS ""AKS-74U"" for more rifle diversity in the platoon. Slightly lower accuracy at range but lighter carry weight. " \n "- Rifle mag changed from RHS ""30Rnd AK-74 (Plum) 7N10"" to RHS ""30Rnd AK-74 (Plum) 7N22"" to match the other mags in the vest. " \n "  " \n "Mortar Gunner: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" to RHS ""6B27M (ESS)"". " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest changed from RHS ""6B23 (6Sh116/VOG)"" to RHS ""6B23 EMR-Summer (6Sh92)"". " \n "- Rifle changed from RHS ""AK-74M (Plum)"" to RHS ""AKS-74U"" for more rifle diversity in the platoon. Slightly lower accuracy at range but lighter carry weight. " \n "- Rifle mag changed from RHS ""30Rnd AK-74 (Plum) 7N10"" to RHS ""30Rnd AK-74 (Plum) 7N22"" to match the other mags in the vest. " \n "  " \n "All Units: " \n "- Disabled LAMBS AI " \n " " \n "Alpha SL: " \n "- Enabled ""is Player"". This makes it easier for Mission Makers to quickly test a mission in the editor by just hitting ""play"" instead of having to select a specific unit every time beforehand to avoid ending up in spectator mode by default. " \n " " \n "Crates: " \n "- Added an ACE3 medical crate with our usual base script. " \n "- Fireteam ammo crate: removed 4x 100Rnd PKM Box and replaced it with 4x 75Rnd RPK Mag and 1x 75Rnd RPK Tracer Mag. " \n "- Squad ammo crate: removed 13x 100Rnd PKM Tracer Box and added 12x 75Rnd RPK Mag & 4x 75Rnd RPK Tracer Mag" \n "" \n "" \n "-v1.13.6" \n "  - ALL Added persistent Call-Signs for all GM's (where not included in v1.13.4)" \n "  - ALL Added the code`this disableAI ""MOVE""; this setSpeaker ""NoVoice""; enableRadio false;` to all playable units to prevent them from running off and spamming the vanilla-radio during local testing." \n "  - ALL Changed persistent call-signs (map markers) to a consistent formula: ≤ 2 syllables = written out call-sing. ≥ 3 syllables = abbreviated call-sign." \n "  - ALL Added full changelog to all factions for quick in-game reference" \n "  - TFN Added new yellow owl insignia patches to all uniforms" \n "" \n "- v1.13.5" \n "  - ALL Added respective GM's to Standard Faction Compositions for convenience / time saving " \n "  - ALL Added base clean-up module to Standard Faction Compositions to ensure Mission Makers don't forget it in the future - radius set to 200x200 meters" \n "" \n "- v1.13.4 " \n "  - ALL Added @ Squad/Team names to leaders so that Team name appears in role select" \n "  - TFN Changed M249 to the FN MINIMI" \n "" \n "- v1.13.3" \n "  - US Added Improved Bipod/SAW Grip to AR M249" \n "  - US Removed M14 Mags" \n "  - TFN Added Bipod to M249" \n "" \n "- v1.13.2" \n "  - ALL Added 1 Extra Tourniquet to every Unit" \n "  - TFN DMT Lead Rifle Changed to D10 Version" \n "  - TFN DMT given extra pistol mag to bring in line with other units" \n "  - TFN AAR Weapon changed to HK416 D14.5" \n "  - TFN Lead Elements Given AN/PEQ-16A's" \n "  - US Alpha Fireteam 2 AAR vest changed to ALT variant to match rest of faction" \n "  - US Lead Elements Given AN/PEQ-16A's" \n "  - US DMT given extra pistol mag to bring in line with other units" \n "  - US DMT Sniper Rifle Given SU-260/P (MDO) to bring zoom level to the same as Russian and TFN factions" \n "  - US DMT Bipod Changed to Harris Bipod" \n "  - US DMT Marksman Rifle changed to black version of same rifle" \n "  - US DMT Marksman Magazines changed to SR-25 version, as RHS hotfix made M14 mags incompatible with MK11" \n "  - RUS DMT given extra pistol mag to bring in line with other units" \n "  - RUS DGR Helmets changed to TSH-4 to make distinct from US Helmets" \n "  - RUS NB Helmets changed to ZSH-7A to make distinct from US and TFN helmets" \n "  - RUS Removed RIS Rail adaptors from AK rifles" \n "  - RUS Added PG-7V rocket to MAT ammo crate. This rocket is lighter and packs less payload than the PG-7VL. This gives it an  increased effective range but is less powerful due to decreased payload" \n "" \n "- v1.12.2" \n "  - Hotfixed US Vests across the Squads to match V.12 changes. Whoops." \n "  - Added Angled Grip to TFN HK416s where possible. " \n "" \n "- v1.12" \n "  - Fixed TFN MMG Ammo preloaded into Rifle to 100RND mag from 50rnd." \n "  - Fixed TFN DMT Marksman Ammo loaded into Rifle to correct SBLR mag." \n "  - Changed TFN DMT Lead Suppressor to QDSS NT4 Black from Rotex-5 Grey" \n "  - Changed TFN Dagger Uniforms from Gorka R Green to FFCP Green Fatigues [RS]" \n "  - Changed US PLT Commander + Squad Leader Vest from SPCS Rifleman/OEF- CP to SPCS Squad Lead/OEF-CP" \n "  - Changed US Medic Vest from SPCS Rifleman/OEF-CP to SPCS Medic/OEF-CP" \n "  - Changed US PLT Rifleman Vest from SPCS OEF-CP to SPCS Rifleman Alt/OEF-CP" \n "  - Changed US FTL Vest from SPCS Rifleman/OEF-CP to SPCS Team Leader Alt/OEF-CP" \n "  - Changed US AR Vest from SPCS Rifleman/OEF-CP to SPCS SAW/OEF-CP" \n "  - Changed US AAR Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP" \n "  - Changed US Rifleman AT Vest from SPCS OEF-CP to SPCS Rifleman Alt/OEF-CP" \n "  - Changed US MAT/MMG/DMT/ENG/MTR Lead Vest from SPCS Rifleman/OEF-CP to SPCS Team Leader Alt/OEF-CP" \n "  - Changed US MMG Gunner Vest from SPCS Rifleman/OEF-CP to SPCS Machinegunner/OEF-CP" \n "  - Changed US MMG/MAT Ammo Bearer Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP" \n "  - Changed US MAT Gunner Vest from SPCS OEF-CP to SPCS Rifleman Alt/OEF-CP" \n "  - Changed US DMT Marksman vest from SPCS OEF-CP to SPCS Sniper/OEF-CP" \n "  - Fixed US DMT Marksman Rifle Loaded Mag to correct varient." \n "  - Changed US Engineer Rifleman Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP." \n "  - Changed US MTR Gunner Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP." \n "  - Changed US DGR Uniforms from FFCP ACU Fatigues to FFCP ACU Fatigues [RS]" \n "  - Changed US DGR Driver Backpack from Assault Pack Green to Assault Pack Black" \n "  - Changed US Heli Pilot/Copilot Uniforms from Heli pilot Coveralls to FFCP Nomad Fatigues [RS]" \n "  - Fixed US Heli/Jet Pilot Vest White Smoke grenade count to 2." \n "  - Changed US Heli Pilot/Copilot Helmet from Heli Pilot NATO to HGU-56/P (Black/Visor)" \n "  - Changed US Jet Pilot Uniform from Pilot Coveralls NATO to  FFCP Nomad Fatigues" \n "  - Changed RUS Vic/Heli/Jet Crew Weapons to PP-2000" \n "  - Upped RUS PP-2000 Ammo counts to 6x Mag to bring in line with ammo counts for TFN and US." \n "  - Changed RUS Heli Pilot Uniforms from Pilot Coveralls CSAT to FFCP-Fatigues EMR [RS]" \n "  - Changed RUS Heli Pilot Vest from 6B23 (6Sh116) to FFCP Tactical Vest TigerVRS" \n "  - Changed RUS Jet Pilot Uniforms from Pilot Coveralls CSAT to FFCP-Fatigues EMR [RS]" \n "  - Changed RUS Jet Pilot Vest from 6B23 (6Sh116) to FFCP Tactical Vest TigerVRS" \n "" \n "- v1.11" \n "  - changed m40 mini grenades to m67 fragmentation" \n "  - replaced mp7 weapons with mp5k-pdw" \n "  - changed ak105 to ak74m (plum) " \n "  - changed PKM to PKP" \n "  - changed RUS PKM ammo boxes. MMG now loads with 7TZ (AP rounds)" \n "  - added vert grip to us weapons" \n "  - replaced m14 with HK PSG1A1" \n "  - replaced m260e4 with mg3" \n "  - updated all ammo boxes respectively. " \n "" \n "- v1.10" \n "  - changed Medic loadouts from 6 x 1000ml blood bags to 2 x 1000ml and 8 x 500ml." \n "" \n "- v1.09" \n "  - updated Fireteam colours A1 Red A2 Yellow, B1 Green B2 Blue, C1 Red C2 Yellow." \n "" \n "- v1.08" \n "  - changed ""Reaper"" to ""Nightbird"", ""RPR"" to ""NB""" \n "  - changed ""Paladin"" to ""Falcon"", ""PAL"" to ""FC""" \n "  - changed ""DAGGER"" to ""DGR""" \n "" \n "- v1.07" \n "  - US and RU faction bumped to v1.07 to avoid confusion regarding version numbers (US and RU was 1.05, TFN was 1.06)" \n "  - overhauled the RU faction: updated helmets, uniforms, weapons to a more modern look" \n "  - overhauled the US faction: updated helmets and vests to armour rating of IV" \n "  - corrected some mistakes in all factions (grenade ammount of MMG gunner, ENG not having tourniquetes, DGR not having GPS-s)" \n "  - overhauled the medics of all factions to reflect recent cahnges to ACE medical (less QuikClots, more Elastic Bandages, etc.)" \n "" \n "- v1.05" \n "  - Added a MAT ammo box on spawn." \n "" \n "- v1.04" \n "  - All MAT Teams carrying RPG's got the ver3 scopes with ranges for all types" \n "    of ammo." \n "  - All Callsigns were changed to be uniformed throught no matter the faction." \n "" \n "- v1.03" \n "  - set crew driver/gunner and pilot/copilot/jetpilot as Engineers through the" \n "    Object: ACE Options menu in unit attributes" \n "  - overhauled the TFN faction (weapons, helmets, etc.), changes not applicable" \n "    to derived factions" \n "" \n "- v1.02" \n "  - loadout overhaul for DMT, made them lighter + gave them tools for recon" \n "  - specified preset ACRE2 radio channels for most units" \n "" \n "- v1.01" \n "  - updated team colors func to `a3ee_team_colors_fnc_setColor`, just load+save" \n "    the composition in editor, this fixes it" \n "  - changed RPG-7 using MAT teams to carry Kitbags" \n "  - removed one PKM ammo box from AAR, MMG gunner, MMG bearer (fixes overload)" \n "  - moved 1-2 AR boxes from AAR to AR, gave AR an Assaultpack" \n "  - added 1-2 more AR boxes to AR's Assaultpack (if enough space)" \n "  - changed HEDP to HE rockets for Carl Gustav (M3MAAWS)" \n "  - changed US crew uniform and helmet to match grey color scheme of US pilots" \n "  - changed backpacks of driver/copilot to use less contrasting colors compared" \n "    to their respective uniform/vest colors" \n "  - changed Carryall backpacks of TFN Engineers to use custom Flecktarn Carryall" \n "  - changed all (GP-25 and normal) AK74m rifles to be the non-NPZ variants" \n "  - removed secondary long-range (PRC148) from Engineers" \n "" \n "- v1.00 (and before)" \n "  - added a Comment object with version number (`v1.00`)" \n "  - added `respawn_west`, `respawn_east`, `respawn_guerrila` markers" \n "  - added `[this, 200] call a3ee_fnc_boxGuard` to init lines of resupply boxes" \n "  - added `Resupply` green triangle markers on the position of resupply boxes";
-		id=69;
+		id=225;
 	};
 	class Item16
 	{
@@ -15909,7 +15910,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={4.4536133,0.0014390945,-4.9321289};
+					position[]={4.4853516,0.0014390945,-4.9287109};
 				};
 				side="East";
 				flags=7;
@@ -15981,7 +15982,7 @@ class items
 						headgear="rhs_beret_mvd";
 					};
 				};
-				id=71;
+				id=227;
 				type="O_Protagonist_VR_F";
 				class CustomAttributes
 				{
@@ -16152,7 +16153,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={5.4526367,0.0014390945,-4.9311523};
+					position[]={5.484375,0.0014390945,-4.9277344};
 				};
 				side="East";
 				flags=5;
@@ -16224,7 +16225,7 @@ class items
 						headgear="rhs_beret_mvd";
 					};
 				};
-				id=72;
+				id=228;
 				type="O_Protagonist_VR_F";
 				class CustomAttributes
 				{
@@ -16394,7 +16395,7 @@ class items
 		class Attributes
 		{
 		};
-		id=70;
+		id=226;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -16424,7 +16425,7 @@ class items
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={7.574707,0,-3.6772461};
+			position[]={7.6064453,0,-3.6738281};
 		};
 		side="Empty";
 		flags=4;
@@ -16434,7 +16435,7 @@ class items
 			name="Medical_Supply_Crate";
 			description="Medical Supply Crate";
 		};
-		id=73;
+		id=229;
 		type="ACE_medicalSupplyCrate";
 		class CustomAttributes
 		{
@@ -16465,7 +16466,7 @@ class items
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={7.4658203,0.89242268,-7.6958008};
+			position[]={7.4975586,0.89242268,-7.6923828};
 		};
 		side="Empty";
 		flags=4;
@@ -16475,7 +16476,7 @@ class items
 			name="Platoon_Supply_Crate";
 			description="Platoon Supply Crate";
 		};
-		id=74;
+		id=230;
 		type="O_supplyCrate_F";
 		class CustomAttributes
 		{
@@ -16506,7 +16507,7 @@ class items
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={7.5375977,0.28405476,-5.3320313};
+			position[]={7.5693359,0.28405476,-5.3286133};
 		};
 		side="Empty";
 		flags=4;
@@ -16516,7 +16517,7 @@ class items
 			name="Fireteam_Supply_Box";
 			description="Fireteam Supply Box";
 		};
-		id=75;
+		id=231;
 		type="Box_East_Ammo_F";
 		class CustomAttributes
 		{
@@ -16547,12 +16548,12 @@ class items
 		dataType="Logic";
 		class PositionInfo
 		{
-			position[]={-0.080566406,0,0.073730469};
+			position[]={-0.048828125,0,0.077148438};
 		};
 		areaSize[]={200,-1,200};
 		areaIsRectangle=1;
 		flags=1;
-		id=76;
+		id=232;
 		type="a3aa_ee_custom_location";
 		class CustomAttributes
 		{
@@ -16621,7 +16622,7 @@ class items
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={5.3676758,0.18872452,-8.8510742};
+			position[]={5.3994141,0.18872452,-8.8476563};
 		};
 		side="Empty";
 		flags=4;
@@ -16631,7 +16632,7 @@ class items
 			name="Mortar_Supply_Box";
 			description="Mortar Supply Box";
 		};
-		id=77;
+		id=233;
 		type="Box_East_Wps_F";
 		class CustomAttributes
 		{

--- a/reference/Russian%20Army/composition.sqe
+++ b/reference/Russian%20Army/composition.sqe
@@ -1,5 +1,5 @@
 version=53;
-center[]={4145.208,5,742.66644};
+center[]={2946.8403,5,6947.4375};
 class items
 {
 	items=22;
@@ -15,7 +15,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-6.0830078,0.0014390945,8.3413086};
+					position[]={-6.0800781,0.0014390945,8.1240234};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -256,7 +256,7 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
@@ -370,7 +370,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-5.0830078,0.0014390945,8.3192139};
+					position[]={-5.0800781,0.0014390945,8.1020508};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -572,7 +572,7 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
@@ -686,7 +686,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-4.0834961,0.0014390945,8.3409424};
+					position[]={-4.0805664,0.0014390945,8.1235352};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -923,7 +923,7 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
@@ -971,7 +971,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-3.0834961,0.0014390945,8.3409424};
+					position[]={-3.0805664,0.0014390945,8.1235352};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -1133,7 +1133,7 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
@@ -1217,7 +1217,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-6.3413086,0.0014390945,5.6082764};
+					position[]={-6.3383789,0.0014390945,5.3911133};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -1459,7 +1459,7 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
@@ -1559,7 +1559,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-5.340332,0.0014390945,5.6192627};
+					position[]={-5.3374023,0.0014390945,5.4018555};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -1796,7 +1796,7 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
@@ -1844,7 +1844,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-6.3188477,0.0014390945,3.6085205};
+					position[]={-6.315918,0.0014390945,3.3911133};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -2094,7 +2094,7 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
@@ -2161,7 +2161,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-5.3188477,0.0014390945,3.6192627};
+					position[]={-5.315918,0.0014390945,3.4018555};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -2351,7 +2351,7 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
@@ -2418,7 +2418,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-4.3193359,0.0014390945,3.630249};
+					position[]={-4.3164063,0.0014390945,3.4130859};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -2657,7 +2657,7 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
@@ -2743,7 +2743,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-3.3188477,0.0014390945,3.6397705};
+					position[]={-3.315918,0.0014390945,3.4223633};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -2928,7 +2928,7 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
@@ -2995,7 +2995,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-6.2973633,0.0014390945,1.6085205};
+					position[]={-6.2944336,0.0014390945,1.3911133};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -3245,7 +3245,7 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
@@ -3312,7 +3312,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-5.2973633,0.0014390945,1.6192627};
+					position[]={-5.2944336,0.0014390945,1.4018555};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -3502,7 +3502,7 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
@@ -3569,7 +3569,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-4.2973633,0.0014390945,1.630249};
+					position[]={-4.2944336,0.0014390945,1.4130859};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -3808,7 +3808,7 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
@@ -3894,7 +3894,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-3.2973633,0.0014390945,1.6407471};
+					position[]={-3.2944336,0.0014390945,1.4233398};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -4079,7 +4079,7 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
@@ -4182,7 +4182,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-1.1313477,0.0014390945,6.03125};
+					position[]={-1.128418,0.0014390945,5.8139648};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -4424,7 +4424,7 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
@@ -4524,7 +4524,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-0.13037109,0.0014390945,6.0422363};
+					position[]={-0.12744141,0.0014390945,5.824707};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -4761,7 +4761,7 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
@@ -4847,7 +4847,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-1.1088867,0.0014390945,4.0313721};
+					position[]={-1.105957,0.0014390945,3.8139648};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -5097,7 +5097,7 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
@@ -5145,7 +5145,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-0.10888672,0.0014390945,4.0421143};
+					position[]={-0.10595703,0.0014390945,3.824707};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -5335,7 +5335,7 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
@@ -5383,7 +5383,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={0.890625,0.0014390945,4.0522461};
+					position[]={0.89355469,0.0014390945,3.8349609};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -5622,7 +5622,7 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
@@ -5708,7 +5708,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={1.8911133,0.0014390945,4.0635986};
+					position[]={1.894043,0.0014390945,3.8461914};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -5893,7 +5893,7 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
@@ -5941,7 +5941,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-1.0874023,0.0014390945,2.0313721};
+					position[]={-1.0844727,0.0014390945,1.8139648};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -6191,7 +6191,7 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
@@ -6239,7 +6239,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-0.087402344,0.0014390945,2.0421143};
+					position[]={-0.084472656,0.0014390945,1.824707};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -6429,7 +6429,7 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
@@ -6477,7 +6477,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={0.91259766,0.0014390945,2.0522461};
+					position[]={0.91552734,0.0014390945,1.8349609};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -6716,7 +6716,7 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
@@ -6802,7 +6802,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={1.9125977,0.0014390945,2.0635986};
+					position[]={1.9155273,0.0014390945,1.8461914};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -6987,7 +6987,7 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
@@ -7071,7 +7071,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={4.2768555,0.0014390945,6.5562744};
+					position[]={4.2797852,0.0014390945,6.3388672};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -7313,7 +7313,7 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
@@ -7413,7 +7413,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={5.2758789,0.0014390945,6.5672607};
+					position[]={5.2788086,0.0014390945,6.3500977};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -7650,7 +7650,7 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
@@ -7736,7 +7736,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={4.2988281,0.0014390945,4.5562744};
+					position[]={4.3017578,0.0014390945,4.3388672};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -7986,7 +7986,7 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
@@ -8072,7 +8072,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={5.2988281,0.0014390945,4.5672607};
+					position[]={5.3017578,0.0014390945,4.3500977};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -8262,7 +8262,7 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
@@ -8348,7 +8348,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={6.2988281,0.0014390945,4.5782471};
+					position[]={6.3017578,0.0014390945,4.3608398};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -8587,7 +8587,7 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
@@ -8673,7 +8673,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={7.2988281,0.0014390945,4.5892334};
+					position[]={7.3017578,0.0014390945,4.3720703};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -8858,7 +8858,7 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
@@ -8944,7 +8944,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={4.3198242,0.0014390945,2.557251};
+					position[]={4.3227539,0.0014390945,2.3398438};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -9194,7 +9194,7 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
@@ -9280,7 +9280,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={5.3198242,0.0014390945,2.5682373};
+					position[]={5.3227539,0.0014390945,2.3510742};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -9470,7 +9470,7 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
@@ -9556,7 +9556,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={6.3188477,0.0014390945,2.5782471};
+					position[]={6.3217773,0.0014390945,2.3608398};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -9795,7 +9795,7 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
@@ -9881,7 +9881,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={7.3188477,0.0014390945,2.5892334};
+					position[]={7.3217773,0.0014390945,2.3720703};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -10066,7 +10066,7 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
@@ -10188,7 +10188,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-6.6669922,0.0014390945,-1.3237305};
+					position[]={-6.6640625,0.0014390945,-1.5410156};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -10430,7 +10430,7 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
@@ -10530,7 +10530,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-5.6674805,0.0014390945,-1.3133545};
+					position[]={-5.6645508,0.0014390945,-1.5307617};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -10694,7 +10694,7 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
@@ -10742,7 +10742,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-4.6674805,0.0014390945,-1.3026123};
+					position[]={-4.6645508,0.0014390945,-1.5200195};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -10919,7 +10919,7 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
@@ -11003,7 +11003,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-1.0629883,0.0014390945,-1.5546875};
+					position[]={-1.0600586,0.0014390945,-1.7719727};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -11245,7 +11245,7 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
@@ -11345,7 +11345,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-0.063964844,0.0014390945,-1.5438232};
+					position[]={-0.061035156,0.0014390945,-1.7612305};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -11538,7 +11538,7 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
@@ -11600,7 +11600,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={0.93603516,0.0014390945,-1.5330811};
+					position[]={0.93896484,0.0014390945,-1.7504883};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -11783,7 +11783,7 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
@@ -11881,7 +11881,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-5.6811523,0.0014390945,-4.3487549};
+					position[]={-5.6782227,0.0014390945,-4.565918};
 					angles[]={-0,6.2723818,0};
 				};
 				side="East";
@@ -12080,7 +12080,7 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
@@ -12166,7 +12166,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-6.6801758,0.0014390945,-4.3597412};
+					position[]={-6.6772461,0.0014390945,-4.5771484};
 					angles[]={-0,6.2723818,0};
 				};
 				side="East";
@@ -12360,7 +12360,7 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
@@ -12496,7 +12496,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-0.92236328,0.0014390945,-4.7147217};
+					position[]={-0.91943359,0.0014390945,-4.9321289};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -12691,7 +12691,7 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
@@ -12703,7 +12703,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={0.077636719,0.0014390945,-4.7039795};
+					position[]={0.080566406,0.0014390945,-4.9213867};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -12886,7 +12886,7 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
@@ -12934,7 +12934,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={4.4487305,0.0014390945,-1.3657227};
+					position[]={4.4516602,0.0014390945,-1.5830078};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -13089,13 +13089,13 @@ class items
 								class Item0
 								{
 									name="rhs_30Rnd_545x39_7N22_plum_AK";
-									count=5;
+									count=4;
 									ammoLeft=30;
 								};
 								class Item1
 								{
 									name="rhs_30Rnd_545x39_AK_plum_green";
-									count=1;
+									count=2;
 									ammoLeft=30;
 								};
 							};
@@ -13159,7 +13159,7 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
@@ -13259,7 +13259,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={5.449707,0.0014390945,-1.3543701};
+					position[]={5.4526367,0.0014390945,-1.5717773};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -13463,7 +13463,7 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
@@ -13511,7 +13511,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={6.449707,0.0014390945,-1.3436279};
+					position[]={6.4526367,0.0014390945,-1.5610352};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -13715,7 +13715,7 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
@@ -13763,7 +13763,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={7.449707,0.0014390945,-1.3328857};
+					position[]={7.4526367,0.0014390945,-1.550293};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -13967,7 +13967,7 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
@@ -14051,7 +14051,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-6.590332,0.0014390945,-7.5217285};
+					position[]={-6.5874023,0.0014390945,-7.7387695};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -14236,7 +14236,7 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
@@ -14350,7 +14350,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-5.590332,0.0014390945,-7.5106201};
+					position[]={-5.5874023,0.0014390945,-7.7280273};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -14558,7 +14558,7 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
@@ -14570,7 +14570,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-4.590332,0.0014390945,-7.4998779};
+					position[]={-4.5874023,0.0014390945,-7.7172852};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -14764,7 +14764,7 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
@@ -14812,7 +14812,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-0.76904297,0.0014390945,-7.8677979};
+					position[]={-0.76611328,0.0014390945,-8.0849609};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -15016,7 +15016,7 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
@@ -15130,7 +15130,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={0.23095703,0.0014390945,-7.8582764};
+					position[]={0.23388672,0.0014390945,-8.0756836};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -15347,7 +15347,7 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
@@ -15478,7 +15478,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={3.0185547,0.0014390945,-7.9837646};
+					position[]={3.0214844,0.0014390945,-8.2011719};
 					angles[]={0,6.2723818,0};
 				};
 				side="East";
@@ -15686,7 +15686,7 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
@@ -15827,7 +15827,7 @@ class items
 	class Item12
 	{
 		dataType="Marker";
-		position[]={2.2553711,2.4371225e+032,-4.6639404};
+		position[]={2.2583008,2.4371225e+032,-4.8813477};
 		name="respawn_east";
 		type="respawn_unknown";
 		angle=359.38113;
@@ -15837,7 +15837,7 @@ class items
 	class Item13
 	{
 		dataType="Marker";
-		position[]={6.6928711,0,-6.383667};
+		position[]={6.6958008,0,-6.6010742};
 		name="resupply_marker_1";
 		text="Resupply";
 		type="mil_triangle";
@@ -15850,7 +15850,7 @@ class items
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={5.3046875,0.14963102,-6.7297974};
+			position[]={5.3076172,0.14963102,-6.9472656};
 			angles[]={-0,1.5418237,0};
 		};
 		side="Empty";
@@ -15891,10 +15891,10 @@ class items
 		dataType="Comment";
 		class PositionInfo
 		{
-			position[]={2.4858398,0,-3.5047607};
+			position[]={2.4887695,0,-3.7226563};
 		};
 		title="v1.14.2";
-		description="- v1.14.2" \n "PL: " \n "- Headgear changed from RHS ""Field Cap VSR"" to RHS ""6B27M (ESS)"" to give leader a helmet (issue #82). " \n "- Uniform content: moved radios 152 & 148 to backpack (issue #95). " \n " " \n "Platoon Sergeant: " \n "- Headgear changed from RHS ""6B26 (ESS)"" to RHS ""6B27M (Balaclava)"" to fit the rest of the platoon (issue #112). " \n " " \n "Platoon Medic: " \n "- Headgear changed from RHS ""6B26"" to RHS ""6B27M"" to fit the rest of the platoon (issue #112). " \n "- Rifle changed from RHS ""AKS-74U"" to RHS ""AKS-74UN"" to allow for scope attachments (issue #108). " \n "  " \n "Platoon Rifleman: " \n "- Helmet changed from RHS ""6B26 (ESS/Balaclava)"" to RHS ""6B27M (ESS/Balaclava)"" to fit the rest of the platoon (issue #112). " \n "  " \n "SL: " \n "- Helmet changed from RHS ""6B27M EMR-Summer"" to RHS ""6B27M (Balaclava)"" to fit the rest of the platoon. " \n "- Uniform content: moved radio 152 to backpack (issue #95). " \n "  " \n "Medic: " \n "- Rifle changed from RHS ""AKS-74U"" to RHS ""AKS-74UN"" to allow for scope attachments (issue #108). " \n " " \n "MMG Leader: " \n "- Helmet changed from RHS ""6B27M EMR-Summer"" to RHS ""6B27M (Balaclava)"" to fit the rest of the platoon. " \n "- Uniform content: moved radio 152 to backpack (issue #95). " \n "  " \n "MAT Leader: " \n "- Headgear changed from RHS ""6B27M EMR-Summer"" to RHS ""6B27M (Balaclava)"" to fit the rest of the platoon. " \n "- Uniform content: moved radio 152 to backpack (issue #95). " \n " " \n "ENG Leader: " \n "- Uniform content: moved radio 152 to backpack (issue #95). " \n "- Backpack content: changed ammo count to 5 regular mags and 1 tracer mag (issue #83). " \n " " \n "ENG Rifleman: " \n "- Backpack content: changed ammo count to 5 regular mags and 1 tracer mag (issue #83). " \n " " \n "DMT Leader: " \n "- Soldier class changed from ""B_spotter_F"" to ""O_soldier_M_F"" (issue #94). " \n " " \n "DMT Marksman: " \n "- Soldier class changed from ""B_spotter_F"" to ""O_spotter_F"" (issue #94). " \n " " \n "MTR Leader: " \n "- Vest content: changed ammo count to 5 regular mags and 1 tracer mag (issue #83). " \n " " \n "MTR Gunner: " \n "- Vest content: changed ammo count to 5 regular mags and 1 tracer mag (issue #83). " \n " " \n "Zeus: " \n "- Fixed missing Zeus status (issue #113). " \n " " \n "All Units: " \n "- Fixed missing standard ACRE2 radio channels (issue #110). " \n "- Uniform content: added 1x epinephrine (issue #107) and sorted all items in a more logical manner (issue #111). " \n "- Vest content: sorted all items in a more logical manner (issue #111). " \n "- Backpack content: sorted all items in a more logical manner (issue #111). " \n "- Fireteam members: fixed ST HUD colours for fireteam members of Alpha, Bravo and Charlie (issue #117). " \n " " \n "Crates: " \n "- Added a mortar supply crate (issue #77)." \n "" \n "-v1.14.1" \n " - A3EE box guard updated to A3AA." \n " - Custom location re-added." \n "" \n "-v1.14.0" \n "PL: " \n "- Headgear changed from RHS ""Field Cap EMR-Summer"" to RHS ""Field Cap VSR"". " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest changed from RHS ""6B23 (6Sh116/VOG)"" to RHS ""6B23 EMR-Summer (6Sh92/Headset/Mapcase)"" for more visual diversity in the platoon. " \n "- Vest content: moved 2x RGO grenades to backpack, removed 3x RHS ""30Rnd AK-74 (Plum) 7N22"" and added 4x RHS ""30Rnd AK-74 (Plum) 7T3M (tracer)"" to match TFN and US Army loadouts. " \n "- Backpack changed from vanilla ""Assaultpack green"" to RHS ""UMBTS Backpack"" for a more Russian look. " \n "- Backpack content: increased GL smoke white from 3x to 5x to match TFN and US Army loadouts. " \n "- Rifle mag changed from RHS ""30Rnd AK-74 (Plum) 7N10"" to RHS ""30Rnd AK-74 (Plum) 7N22"" to match the other mags in the vest. " \n " " \n " Platoon Sergeant: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" to RHS ""6B26 (ESS)"" to indicate association with platoon lead element and for more visual diversity in the platoon. " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest content: removed 3x RHS ""30Rnd AK-74 (Plum) 7N22"" and added 4x RHS ""30Rnd AK-74 (Plum) 7T3M (tracer)"" to match TFN and US Army loadouts. " \n "- Backpack added 3CB ""Radio Backpack MR3000"" and filled it with the ACRE2 ""AN/PRC-117F"" backpack radio. This gives more incentive to bring the PLT Sgt along since he is the only one who can act as a max range radio man for the platoon. " \n "- Rifle mag changed from RHS ""30Rnd AK-74 (Plum) 7N10"" to RHS ""30Rnd AK-74 (Plum) 7N22"" to match the other mags in the vest. " \n "  " \n "Platoon Medic: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" to RHS ""6B26"" to indicate association with platoon lead element and for more visual diversity in the platoon. " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest changed from RHS ""6B23 (6Sh116)"" to RHS ""6B23 EMR-Summer (Medic)"". " \n "- Vest content: removed 1x RHS ""30Rnd AK-74 (Plum) 7N22"" and added 2x RHS ""30Rnd AK-74 (Plum) 7T3M (tracer)"" to match TFN and US Army loadouts. " \n "- Backpack changed from vanilla ""Kitback (green)"" to 3CB ""Knapsack Medical (Khaki)"" to visually make the Vest medical bag look like the primary backpack. " \n "- Rifle changed from RHS ""AK-74M (Plum)"" to RHS ""AKS-74U"" for more rifle diversity in the platoon. Slightly lower accuracy at range but lighter carry weight. " \n "- Rifle mag changed from RHS ""30Rnd AK-74 (Plum) 7N10"" to RHS ""30Rnd AK-74 (Plum) 7N22"" to match the other mags in the vest. " \n " " \n "Platoon Rifleman: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" to RHS ""6B26 (ESS/Balaclava)"" to indicate association with platoon lead element and for more visual diversity in the platoon. " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest changed from RHS ""6B23 (6Sh116)"" to RHS ""6B23 EMR-Summer (6Sh116)"". " \n "- Vest content: removed 1x RHS ""30Rnd AK-74 (Plum) 7N22"" and added 2x RHS ""30Rnd AK-74 (Plum) 7T3M (tracer)"" to match TFN and US Army loadouts. " \n "- Rifle mag changed from RHS ""30Rnd AK-74 (Plum) 7N10"" to RHS ""30Rnd AK-74 (Plum) 7N22"" to match the other mags in the vest. " \n " " \n "SL: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" semi-randomly to RHS ""6B27M"" or RHS ""6B27M (ESS)"" or RHS ""6B27M (Balaclava)"". " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest changed from RHS ""6B23 (6Sh116/VOG)"" to RHS ""6B23 EMR-Summer (6Sh92/VOG/Radio) SpNz"".  " \n "- Vest content: moved 2x RGO grenades to backpack, removed 3x RHS ""30Rnd AK-74 (Plum) 7N22"" and added 4x RHS ""30Rnd AK-74 (Plum) 7T3M (tracer)"" to match TFN and US Army loadouts. " \n "- Backpack changed from vanilla ""Assaultpack green"" to RHS ""UMBTS Backpack"" for a more Russian look. " \n "- Backpack content: added 1x RHS ""VOG-25"" to match TFN and US Army loadouts. " \n "- Rifle mag changed from RHS ""30Rnd AK-74 (Plum) 7N10"" to RHS ""30Rnd AK-74 (Plum) 7N22"" to match the other mags in the vest.  " \n " " \n "SL Medic: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" semi-randomly to RHS ""6B27M"" or RHS ""6B27M (ESS)"" or RHS ""6B27M (Balaclava)"". " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest changed from RHS ""6B23 (6Sh116)"" semi-randomly to RHS ""6B23 EMR-Summer (Medic)"" or RHS ""6B23 (Medic)"". " \n "- Vest content: removed 1x RHS ""30Rnd AK-74 (Plum) 7N22"" and added 2x RHS ""30Rnd AK-74 (Plum) 7T3M (tracer)"" to match TFN and US Army loadouts. " \n "- Backpack changed from vanilla ""Kitback (green)"" to 3CB ""Knapsack Medical (Khaki)"" to visually make the Vest medical bag look like the primary backpack. " \n "- Rifle changed from RHS ""AK-74M (Plum)"" to RHS ""AKS-74U"" for more rifle diversity in the platoon. Slightly lower accuracy at range but lighter carry weight. " \n "- Rifle mag changed from RHS ""30Rnd AK-74 (Plum) 7N10"" to RHS ""30Rnd AK-74 (Plum) 7N22"" to match the other mags in the vest. " \n "  " \n "FTL: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" semi-randomly to RHS ""6B27M"" or RHS ""6B27M (ESS)"" or RHS ""6B27M (Balaclava)"". " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest changed from RHS ""6B23 (6Sh116/VOG)"" semi-randomly to RHS ""6B23 EMR-Summer (6Sh92/VOG/Headset)"" or RHS ""6B23 (6Sh92/VOG/Headset)"". " \n "- Vest content: moved 2x RGO grenades to backpack, removed 3x RHS ""30Rnd AK-74 (Plum) 7N22"" and added 4x RHS ""30Rnd AK-74 (Plum) 7T3M (tracer)"" to match TFN and US Army loadouts. " \n "- Backpack changed from vanilla ""Assaultpack green"" to RHS ""UMBTS Backpack (Engineer)"" for a more Russian/breacher look. " \n "- Backpack content: added 2x RHS ""VOG-25"" to match TFN and US Army loadouts. " \n "- Rifle mag changed from RHS ""30Rnd AK-74 (Plum) 7N10"" to RHS ""30Rnd AK-74 (Plum) 7N22"" to match the other mags in the vest. " \n "  " \n "AR: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" semi-randomly to RHS ""6B27M"" or RHS ""6B27M (ESS)"" or RHS ""6B27M (Balaclava)"". " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest changed from RHS ""6B23 (6Sh116)"" semi-randomly to RHS ""6B23 EMR-Summer (Vydra-3M)"" or RHS ""6B23 (Vydra-3M)"" " \n "- Vest content: added 1x HLC ""7.62mm 75Rnd FMJ RPK Magazine (Tracers every 3)"" " \n "- Backpack changed from vanilla ""Assaultpack (green)"" to RHS ""Sidor"" for a more Russian look. " \n "- Backpack content: added 2x HLC ""7.62mm 75Rnd FMJ RPK Magazine (Tracers every 3)"" and 1x HLC ""7.62mm 75Rnd FMJ RPK Magazine (Tracer)"" " \n "- Rifle changed from RHS ""PKP"" to HLC ""RPK"". " \n "- Rifle muzzle attachment added RHS ""Surefire SF3P-762"". " \n " " \n "AAR: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" semi-randomly to RHS ""6B27M"" or RHS ""6B27M (ESS)"" or RHS ""6B27M (Balaclava)"". " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest changed from RHS ""6B23 (6Sh116)"" semi-randomly to RHS ""6B23 EMR-Summer (6Sh92/Headset)"" or RHS ""6B23 (6Sh92/Headset)"". " \n "- Vest content: moved 2x RGO grenades to backpack, removed 3x RHS ""30Rnd AK-74 (Plum) 7N22"" and added 4x RHS ""30Rnd AK-74 (Plum) 7T3M (tracer)"" to match TFN and US Army loadouts. " \n "- Backpack content: added RHS 2x ""30Rnd AK-74 (Plum) 7N22"" and 3x HLC ""7.62mm 75Rnd FMJ RPK Magazine (Tracers every 3)"" to match TFN and US Army loadouts. " \n "- Rifle mag changed from RHS ""30Rnd AK-74 (Plum) 7N10"" to RHS ""30Rnd AK-74 (Plum) 7N22"" to match the other mags in the vest. " \n "" \n "LAT: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" semi-randomly to RHS ""6B27M"" or RHS ""6B27M (ESS)"" or RHS ""6B27M (Balaclava)"". " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest variety changed semi-randomly to RHS ""6B23 (6Sh116)"" and RHS ""6B23 EMR-Summer (6Sh116)"". " \n "- Vest content: removed 1x RHS ""30Rnd AK-74 (Plum) 7N22"" and added 2x RHS ""30Rnd AK-74 (Plum) 7T3M (tracer)"" to match TFN and US Army loadouts. " \n "- Rifle changed from RHS ""AK-74M"" to RHS ""AK-105"" for more weapon variety in the platoon. " \n "- Rifle mag changed from RHS ""30Rnd AK-74 (Plum) 7N10"" to RHS ""30Rnd AK-74 (Plum) 7N22"" to match the other mags in the vest. " \n " " \n "MMG Leader: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" to RHS ""6B27M EMR-Summer"" " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest changed from RHS ""6B23 (6Sh116/VOG)"" to RHS ""6B23 EMR-Summer (6Sh92/VOG/Radio) SpNz"".  " \n "- Vest content: moved 2x RGO grenades to backpack, removed 3x RHS ""30Rnd AK-74 (Plum) 7N22"" and added 4x RHS ""30Rnd AK-74 (Plum) 7T3M (tracer)"" to match TFN and US Army loadouts. " \n "- Backpack changed from vanilla ""Assaultpack green"" to RHS ""UMBTS Backpack"" for a more Russian look. " \n "- Backpack content: added 1x RHS ""VOG-25"" to match TFN and US Army loadouts. " \n "- Rifle mag changed from RHS ""30Rnd AK-74 (Plum) 7N10"" to RHS ""30Rnd AK-74 (Plum) 7N22"" to match the other mags in the vest. " \n "  " \n "MMG Gunner: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" to RHS ""6B27M (ESS)"". " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest changed from RHS ""6B23 (6Sh116)"" to RHS ""6B23 EMR-Summer (Rifleman)"". " \n " " \n "MMG Asst. Gunner: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" to RHS ""6B27M"". " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest content: removed 1x RHS ""30Rnd AK-74 (Plum) 7N22"" and added 2x RHS ""30Rnd AK-74 (Plum) 7T3M (tracer)"" to match TFN and US Army loadouts. " \n "- Rifle mag changed from RHS ""30Rnd AK-74 (Plum) 7N10"" to RHS ""30Rnd AK-74 (Plum) 7N22"" to match the other mags in the vest. " \n " " \n "MAT Leader: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" to RHS ""6B27M EMR-Summer"" " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest changed from RHS ""6B23 (6Sh116/VOG)"" to RHS ""6B23 EMR-Summer (6Sh92/VOG/Radio) SpNz"".  " \n "- Vest content: moved 2x RGO grenades to backpack, removed 3x RHS ""30Rnd AK-74 (Plum) 7N22"" and added 4x RHS ""30Rnd AK-74 (Plum) 7T3M (tracer)"" to match TFN and US Army loadouts. " \n "- Backpack changed from vanilla ""Assaultpack green"" to RHS ""UMBTS Backpack"" for a more Russian look. " \n "- Backpack content: added 1x RHS ""VOG-25"" to match TFN and US Army loadouts. " \n "- Rifle mag changed from RHS ""30Rnd AK-74 (Plum) 7N10"" to RHS ""30Rnd AK-74 (Plum) 7N22"" to match the other mags in the vest. " \n " " \n "MAT Gunner: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" to RHS ""6B27M (ESS)"". " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Rifle changed from RHS ""AK-74M"" to RHS ""AK-105"" for more weapon variety in the platoon. " \n "- Rifle mag changed from RHS ""30Rnd AK-74 (Plum) 7N10"" to RHS ""30Rnd AK-74 (Plum) 7N22"" to match the other mags in the vest. " \n " " \n "MAT Asst. Gunner: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" to RHS ""6B27M"". " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest changed from RHS ""6B23 (6Sh116)"" to RHS ""6B23 EMR-Summer ""(6Sh92/Headset)"". " \n "- Vest content: removed 1x RHS ""30Rnd AK-74 (Plum) 7N22"" and added 2x RHS ""30Rnd AK-74 (Plum) 7T3M (tracer)"" to match TFN and US Army loadouts. " \n "- Rifle mag changed from RHS ""30Rnd AK-74 (Plum) 7N10"" to RHS ""30Rnd AK-74 (Plum) 7N22"" to match the other mags in the vest. " \n "  " \n "DMT Marksman " \n "- Added scope RHS ""IPN34"" to the vest gear. This is a somewhat equivalent NVG scope to the US Army Faction. " \n "  " \n "ENG Leader: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" to RHS ""Altyn (visor up)"". " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest changed from RHS ""6B23 (6Sh116)"" to RHS ""6B13 EMR-Summer ""(6Sh92/Radio)"". " \n "- Rifle changed from RHS ""AK-74M"" to RHS ""AK-105"" for more weapon variety in the platoon. " \n "- Rifle mag changed from RHS ""30Rnd AK-74 (Plum) 7N10"" to RHS ""30Rnd AK-74 (Plum) 7N22"" to match the other mags in the vest. " \n "  " \n "ENG Rifleman: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" semi-randomly to RHS ""Altyn (visor down)"" or RHS ""Altyn (visor up Balaclava)"". " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest changed from RHS ""6B23 (6Sh116)"" to RHS ""6B13 EMR-Summer ""(6Sh92)"". " \n "- Rifle changed from RHS ""AK-74M"" to RHS ""AK-105"" for more weapon variety in the platoon. " \n "- Rifle mag changed from RHS ""30Rnd AK-74 (Plum) 7N10"" to RHS ""30Rnd AK-74 (Plum) 7N22"" to match the other mags in the vest. " \n "  " \n "Mortar Leader: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" to RHS ""6B27M"". " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest changed from RHS ""6B23 (6Sh116/VOG)"" to RHS ""6B23 EMR-Summer (6Sh92/Radio)"". " \n "- Rifle changed from RHS ""AK-74M (Plum)"" to RHS ""AKS-74U"" for more rifle diversity in the platoon. Slightly lower accuracy at range but lighter carry weight. " \n "- Rifle mag changed from RHS ""30Rnd AK-74 (Plum) 7N10"" to RHS ""30Rnd AK-74 (Plum) 7N22"" to match the other mags in the vest. " \n "  " \n "Mortar Gunner: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" to RHS ""6B27M (ESS)"". " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest changed from RHS ""6B23 (6Sh116/VOG)"" to RHS ""6B23 EMR-Summer (6Sh92)"". " \n "- Rifle changed from RHS ""AK-74M (Plum)"" to RHS ""AKS-74U"" for more rifle diversity in the platoon. Slightly lower accuracy at range but lighter carry weight. " \n "- Rifle mag changed from RHS ""30Rnd AK-74 (Plum) 7N10"" to RHS ""30Rnd AK-74 (Plum) 7N22"" to match the other mags in the vest. " \n "  " \n "All Units: " \n "- Disabled LAMBS AI " \n " " \n "Alpha SL: " \n "- Enabled ""is Player"". This makes it easier for Mission Makers to quickly test a mission in the editor by just hitting ""play"" instead of having to select a specific unit every time beforehand to avoid ending up in spectator mode by default. " \n " " \n "Crates: " \n "- Added an ACE3 medical crate with our usual base script. " \n "- Fireteam ammo crate: removed 4x 100Rnd PKM Box and replaced it with 4x 75Rnd RPK Mag and 1x 75Rnd RPK Tracer Mag. " \n "- Squad ammo crate: removed 13x 100Rnd PKM Tracer Box and added 12x 75Rnd RPK Mag & 4x 75Rnd RPK Tracer Mag" \n "" \n "" \n "-v1.13.6" \n "  - ALL Added persistent Call-Signs for all GM's (where not included in v1.13.4)" \n "  - ALL Added the code`this disableAI ""MOVE""; this setSpeaker ""NoVoice""; enableRadio false;` to all playable units to prevent them from running off and spamming the vanilla-radio during local testing." \n "  - ALL Changed persistent call-signs (map markers) to a consistent formula: ≤ 2 syllables = written out call-sing. ≥ 3 syllables = abbreviated call-sign." \n "  - ALL Added full changelog to all factions for quick in-game reference" \n "  - TFN Added new yellow owl insignia patches to all uniforms" \n "" \n "- v1.13.5" \n "  - ALL Added respective GM's to Standard Faction Compositions for convenience / time saving " \n "  - ALL Added base clean-up module to Standard Faction Compositions to ensure Mission Makers don't forget it in the future - radius set to 200x200 meters" \n "" \n "- v1.13.4 " \n "  - ALL Added @ Squad/Team names to leaders so that Team name appears in role select" \n "  - TFN Changed M249 to the FN MINIMI" \n "" \n "- v1.13.3" \n "  - US Added Improved Bipod/SAW Grip to AR M249" \n "  - US Removed M14 Mags" \n "  - TFN Added Bipod to M249" \n "" \n "- v1.13.2" \n "  - ALL Added 1 Extra Tourniquet to every Unit" \n "  - TFN DMT Lead Rifle Changed to D10 Version" \n "  - TFN DMT given extra pistol mag to bring in line with other units" \n "  - TFN AAR Weapon changed to HK416 D14.5" \n "  - TFN Lead Elements Given AN/PEQ-16A's" \n "  - US Alpha Fireteam 2 AAR vest changed to ALT variant to match rest of faction" \n "  - US Lead Elements Given AN/PEQ-16A's" \n "  - US DMT given extra pistol mag to bring in line with other units" \n "  - US DMT Sniper Rifle Given SU-260/P (MDO) to bring zoom level to the same as Russian and TFN factions" \n "  - US DMT Bipod Changed to Harris Bipod" \n "  - US DMT Marksman Rifle changed to black version of same rifle" \n "  - US DMT Marksman Magazines changed to SR-25 version, as RHS hotfix made M14 mags incompatible with MK11" \n "  - RUS DMT given extra pistol mag to bring in line with other units" \n "  - RUS DGR Helmets changed to TSH-4 to make distinct from US Helmets" \n "  - RUS NB Helmets changed to ZSH-7A to make distinct from US and TFN helmets" \n "  - RUS Removed RIS Rail adaptors from AK rifles" \n "  - RUS Added PG-7V rocket to MAT ammo crate. This rocket is lighter and packs less payload than the PG-7VL. This gives it an  increased effective range but is less powerful due to decreased payload" \n "" \n "- v1.12.2" \n "  - Hotfixed US Vests across the Squads to match V.12 changes. Whoops." \n "  - Added Angled Grip to TFN HK416s where possible. " \n "" \n "- v1.12" \n "  - Fixed TFN MMG Ammo preloaded into Rifle to 100RND mag from 50rnd." \n "  - Fixed TFN DMT Marksman Ammo loaded into Rifle to correct SBLR mag." \n "  - Changed TFN DMT Lead Suppressor to QDSS NT4 Black from Rotex-5 Grey" \n "  - Changed TFN Dagger Uniforms from Gorka R Green to FFCP Green Fatigues [RS]" \n "  - Changed US PLT Commander + Squad Leader Vest from SPCS Rifleman/OEF- CP to SPCS Squad Lead/OEF-CP" \n "  - Changed US Medic Vest from SPCS Rifleman/OEF-CP to SPCS Medic/OEF-CP" \n "  - Changed US PLT Rifleman Vest from SPCS OEF-CP to SPCS Rifleman Alt/OEF-CP" \n "  - Changed US FTL Vest from SPCS Rifleman/OEF-CP to SPCS Team Leader Alt/OEF-CP" \n "  - Changed US AR Vest from SPCS Rifleman/OEF-CP to SPCS SAW/OEF-CP" \n "  - Changed US AAR Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP" \n "  - Changed US Rifleman AT Vest from SPCS OEF-CP to SPCS Rifleman Alt/OEF-CP" \n "  - Changed US MAT/MMG/DMT/ENG/MTR Lead Vest from SPCS Rifleman/OEF-CP to SPCS Team Leader Alt/OEF-CP" \n "  - Changed US MMG Gunner Vest from SPCS Rifleman/OEF-CP to SPCS Machinegunner/OEF-CP" \n "  - Changed US MMG/MAT Ammo Bearer Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP" \n "  - Changed US MAT Gunner Vest from SPCS OEF-CP to SPCS Rifleman Alt/OEF-CP" \n "  - Changed US DMT Marksman vest from SPCS OEF-CP to SPCS Sniper/OEF-CP" \n "  - Fixed US DMT Marksman Rifle Loaded Mag to correct varient." \n "  - Changed US Engineer Rifleman Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP." \n "  - Changed US MTR Gunner Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP." \n "  - Changed US DGR Uniforms from FFCP ACU Fatigues to FFCP ACU Fatigues [RS]" \n "  - Changed US DGR Driver Backpack from Assault Pack Green to Assault Pack Black" \n "  - Changed US Heli Pilot/Copilot Uniforms from Heli pilot Coveralls to FFCP Nomad Fatigues [RS]" \n "  - Fixed US Heli/Jet Pilot Vest White Smoke grenade count to 2." \n "  - Changed US Heli Pilot/Copilot Helmet from Heli Pilot NATO to HGU-56/P (Black/Visor)" \n "  - Changed US Jet Pilot Uniform from Pilot Coveralls NATO to  FFCP Nomad Fatigues" \n "  - Changed RUS Vic/Heli/Jet Crew Weapons to PP-2000" \n "  - Upped RUS PP-2000 Ammo counts to 6x Mag to bring in line with ammo counts for TFN and US." \n "  - Changed RUS Heli Pilot Uniforms from Pilot Coveralls CSAT to FFCP-Fatigues EMR [RS]" \n "  - Changed RUS Heli Pilot Vest from 6B23 (6Sh116) to FFCP Tactical Vest TigerVRS" \n "  - Changed RUS Jet Pilot Uniforms from Pilot Coveralls CSAT to FFCP-Fatigues EMR [RS]" \n "  - Changed RUS Jet Pilot Vest from 6B23 (6Sh116) to FFCP Tactical Vest TigerVRS" \n "" \n "- v1.11" \n "  - changed m40 mini grenades to m67 fragmentation" \n "  - replaced mp7 weapons with mp5k-pdw" \n "  - changed ak105 to ak74m (plum) " \n "  - changed PKM to PKP" \n "  - changed RUS PKM ammo boxes. MMG now loads with 7TZ (AP rounds)" \n "  - added vert grip to us weapons" \n "  - replaced m14 with HK PSG1A1" \n "  - replaced m260e4 with mg3" \n "  - updated all ammo boxes respectively. " \n "" \n "- v1.10" \n "  - changed Medic loadouts from 6 x 1000ml blood bags to 2 x 1000ml and 8 x 500ml." \n "" \n "- v1.09" \n "  - updated Fireteam colours A1 Red A2 Yellow, B1 Green B2 Blue, C1 Red C2 Yellow." \n "" \n "- v1.08" \n "  - changed ""Reaper"" to ""Nightbird"", ""RPR"" to ""NB""" \n "  - changed ""Paladin"" to ""Falcon"", ""PAL"" to ""FC""" \n "  - changed ""DAGGER"" to ""DGR""" \n "" \n "- v1.07" \n "  - US and RU faction bumped to v1.07 to avoid confusion regarding version numbers (US and RU was 1.05, TFN was 1.06)" \n "  - overhauled the RU faction: updated helmets, uniforms, weapons to a more modern look" \n "  - overhauled the US faction: updated helmets and vests to armour rating of IV" \n "  - corrected some mistakes in all factions (grenade ammount of MMG gunner, ENG not having tourniquetes, DGR not having GPS-s)" \n "  - overhauled the medics of all factions to reflect recent cahnges to ACE medical (less QuikClots, more Elastic Bandages, etc.)" \n "" \n "- v1.05" \n "  - Added a MAT ammo box on spawn." \n "" \n "- v1.04" \n "  - All MAT Teams carrying RPG's got the ver3 scopes with ranges for all types" \n "    of ammo." \n "  - All Callsigns were changed to be uniformed throught no matter the faction." \n "" \n "- v1.03" \n "  - set crew driver/gunner and pilot/copilot/jetpilot as Engineers through the" \n "    Object: ACE Options menu in unit attributes" \n "  - overhauled the TFN faction (weapons, helmets, etc.), changes not applicable" \n "    to derived factions" \n "" \n "- v1.02" \n "  - loadout overhaul for DMT, made them lighter + gave them tools for recon" \n "  - specified preset ACRE2 radio channels for most units" \n "" \n "- v1.01" \n "  - updated team colors func to `a3ee_team_colors_fnc_setColor`, just load+save" \n "    the composition in editor, this fixes it" \n "  - changed RPG-7 using MAT teams to carry Kitbags" \n "  - removed one PKM ammo box from AAR, MMG gunner, MMG bearer (fixes overload)" \n "  - moved 1-2 AR boxes from AAR to AR, gave AR an Assaultpack" \n "  - added 1-2 more AR boxes to AR's Assaultpack (if enough space)" \n "  - changed HEDP to HE rockets for Carl Gustav (M3MAAWS)" \n "  - changed US crew uniform and helmet to match grey color scheme of US pilots" \n "  - changed backpacks of driver/copilot to use less contrasting colors compared" \n "    to their respective uniform/vest colors" \n "  - changed Carryall backpacks of TFN Engineers to use custom Flecktarn Carryall" \n "  - changed all (GP-25 and normal) AK74m rifles to be the non-NPZ variants" \n "  - removed secondary long-range (PRC148) from Engineers" \n "" \n "- v1.00 (and before)" \n "  - added a Comment object with version number (`v1.00`)" \n "  - added `respawn_west`, `respawn_east`, `respawn_guerrila` markers" \n "  - added `[this, 200] call a3ee_fnc_boxGuard` to init lines of resupply boxes" \n "  - added `Resupply` green triangle markers on the position of resupply boxes";
+		description="- v1.14.2" \n "PL: " \n "- Headgear changed from RHS ""Field Cap VSR"" to RHS ""6B27M (ESS)"" to give leader a helmet (issue #82). " \n "- Uniform content: moved radios 152 & 148 to backpack (issue #95). " \n " " \n "Platoon Sergeant: " \n "- Headgear changed from RHS ""6B26 (ESS)"" to RHS ""6B27M (Balaclava)"" to fit the rest of the platoon (issue #112). " \n " " \n "Platoon Medic: " \n "- Headgear changed from RHS ""6B26"" to RHS ""6B27M"" to fit the rest of the platoon (issue #112). " \n "- Rifle changed from RHS ""AKS-74U"" to RHS ""AKS-74UN"" to allow for scope attachments (issue #108). " \n "  " \n "Platoon Rifleman: " \n "- Helmet changed from RHS ""6B26 (ESS/Balaclava)"" to RHS ""6B27M (ESS/Balaclava)"" to fit the rest of the platoon (issue #112). " \n "  " \n "SL: " \n "- Helmet changed from RHS ""6B27M EMR-Summer"" to RHS ""6B27M (Balaclava)"" to fit the rest of the platoon. " \n "- Uniform content: moved radio 152 to backpack (issue #95). " \n "  " \n "Medic: " \n "- Rifle changed from RHS ""AKS-74U"" to RHS ""AKS-74UN"" to allow for scope attachments (issue #108). " \n " " \n "MMG Leader: " \n "- Helmet changed from RHS ""6B27M EMR-Summer"" to RHS ""6B27M (Balaclava)"" to fit the rest of the platoon. " \n "- Uniform content: moved radio 152 to backpack (issue #95). " \n "  " \n "MAT Leader: " \n "- Headgear changed from RHS ""6B27M EMR-Summer"" to RHS ""6B27M (Balaclava)"" to fit the rest of the platoon. " \n "- Uniform content: moved radio 152 to backpack (issue #95). " \n " " \n "ENG Leader: " \n "- Uniform content: moved radio 152 to backpack (issue #95). " \n "- Backpack content: changed ammo count to 4 regular mags and 2 tracer mag (issue #83). " \n " " \n "ENG Rifleman: " \n "- Backpack content: changed ammo count to 5 regular mags and 1 tracer mag (issue #83). " \n " " \n "DMT Leader: " \n "- Soldier class changed from ""B_spotter_F"" to ""O_soldier_M_F"" (issue #94). " \n " " \n "DMT Marksman: " \n "- Soldier class changed from ""B_spotter_F"" to ""O_spotter_F"" (issue #94). " \n " " \n "MTR Leader: " \n "- Vest content: changed ammo count to 5 regular mags and 1 tracer mag (issue #83). " \n " " \n "MTR Gunner: " \n "- Vest content: changed ammo count to 5 regular mags and 1 tracer mag (issue #83). " \n " " \n "Zeus: " \n "- Fixed missing Zeus status (issue #113). " \n " " \n "All Units: " \n "- Fixed missing standard ACRE2 radio channels (issue #110). " \n "- Uniform content: added 1x epinephrine (issue #107) and sorted all items in a more logical manner (issue #111). " \n "- Vest content: sorted all items in a more logical manner (issue #111). " \n "- Backpack content: sorted all items in a more logical manner (issue #111). " \n "- Fireteam members: fixed ST HUD colours for fireteam members of Alpha, Bravo and Charlie (issue #117). " \n " " \n "Crates: " \n "- Added a mortar supply crate (issue #77)." \n "" \n "-v1.14.1" \n " - A3EE box guard updated to A3AA." \n " - Custom location re-added." \n "" \n "-v1.14.0" \n "PL: " \n "- Headgear changed from RHS ""Field Cap EMR-Summer"" to RHS ""Field Cap VSR"". " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest changed from RHS ""6B23 (6Sh116/VOG)"" to RHS ""6B23 EMR-Summer (6Sh92/Headset/Mapcase)"" for more visual diversity in the platoon. " \n "- Vest content: moved 2x RGO grenades to backpack, removed 3x RHS ""30Rnd AK-74 (Plum) 7N22"" and added 4x RHS ""30Rnd AK-74 (Plum) 7T3M (tracer)"" to match TFN and US Army loadouts. " \n "- Backpack changed from vanilla ""Assaultpack green"" to RHS ""UMBTS Backpack"" for a more Russian look. " \n "- Backpack content: increased GL smoke white from 3x to 5x to match TFN and US Army loadouts. " \n "- Rifle mag changed from RHS ""30Rnd AK-74 (Plum) 7N10"" to RHS ""30Rnd AK-74 (Plum) 7N22"" to match the other mags in the vest. " \n " " \n " Platoon Sergeant: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" to RHS ""6B26 (ESS)"" to indicate association with platoon lead element and for more visual diversity in the platoon. " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest content: removed 3x RHS ""30Rnd AK-74 (Plum) 7N22"" and added 4x RHS ""30Rnd AK-74 (Plum) 7T3M (tracer)"" to match TFN and US Army loadouts. " \n "- Backpack added 3CB ""Radio Backpack MR3000"" and filled it with the ACRE2 ""AN/PRC-117F"" backpack radio. This gives more incentive to bring the PLT Sgt along since he is the only one who can act as a max range radio man for the platoon. " \n "- Rifle mag changed from RHS ""30Rnd AK-74 (Plum) 7N10"" to RHS ""30Rnd AK-74 (Plum) 7N22"" to match the other mags in the vest. " \n "  " \n "Platoon Medic: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" to RHS ""6B26"" to indicate association with platoon lead element and for more visual diversity in the platoon. " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest changed from RHS ""6B23 (6Sh116)"" to RHS ""6B23 EMR-Summer (Medic)"". " \n "- Vest content: removed 1x RHS ""30Rnd AK-74 (Plum) 7N22"" and added 2x RHS ""30Rnd AK-74 (Plum) 7T3M (tracer)"" to match TFN and US Army loadouts. " \n "- Backpack changed from vanilla ""Kitback (green)"" to 3CB ""Knapsack Medical (Khaki)"" to visually make the Vest medical bag look like the primary backpack. " \n "- Rifle changed from RHS ""AK-74M (Plum)"" to RHS ""AKS-74U"" for more rifle diversity in the platoon. Slightly lower accuracy at range but lighter carry weight. " \n "- Rifle mag changed from RHS ""30Rnd AK-74 (Plum) 7N10"" to RHS ""30Rnd AK-74 (Plum) 7N22"" to match the other mags in the vest. " \n " " \n "Platoon Rifleman: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" to RHS ""6B26 (ESS/Balaclava)"" to indicate association with platoon lead element and for more visual diversity in the platoon. " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest changed from RHS ""6B23 (6Sh116)"" to RHS ""6B23 EMR-Summer (6Sh116)"". " \n "- Vest content: removed 1x RHS ""30Rnd AK-74 (Plum) 7N22"" and added 2x RHS ""30Rnd AK-74 (Plum) 7T3M (tracer)"" to match TFN and US Army loadouts. " \n "- Rifle mag changed from RHS ""30Rnd AK-74 (Plum) 7N10"" to RHS ""30Rnd AK-74 (Plum) 7N22"" to match the other mags in the vest. " \n " " \n "SL: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" semi-randomly to RHS ""6B27M"" or RHS ""6B27M (ESS)"" or RHS ""6B27M (Balaclava)"". " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest changed from RHS ""6B23 (6Sh116/VOG)"" to RHS ""6B23 EMR-Summer (6Sh92/VOG/Radio) SpNz"".  " \n "- Vest content: moved 2x RGO grenades to backpack, removed 3x RHS ""30Rnd AK-74 (Plum) 7N22"" and added 4x RHS ""30Rnd AK-74 (Plum) 7T3M (tracer)"" to match TFN and US Army loadouts. " \n "- Backpack changed from vanilla ""Assaultpack green"" to RHS ""UMBTS Backpack"" for a more Russian look. " \n "- Backpack content: added 1x RHS ""VOG-25"" to match TFN and US Army loadouts. " \n "- Rifle mag changed from RHS ""30Rnd AK-74 (Plum) 7N10"" to RHS ""30Rnd AK-74 (Plum) 7N22"" to match the other mags in the vest.  " \n " " \n "SL Medic: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" semi-randomly to RHS ""6B27M"" or RHS ""6B27M (ESS)"" or RHS ""6B27M (Balaclava)"". " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest changed from RHS ""6B23 (6Sh116)"" semi-randomly to RHS ""6B23 EMR-Summer (Medic)"" or RHS ""6B23 (Medic)"". " \n "- Vest content: removed 1x RHS ""30Rnd AK-74 (Plum) 7N22"" and added 2x RHS ""30Rnd AK-74 (Plum) 7T3M (tracer)"" to match TFN and US Army loadouts. " \n "- Backpack changed from vanilla ""Kitback (green)"" to 3CB ""Knapsack Medical (Khaki)"" to visually make the Vest medical bag look like the primary backpack. " \n "- Rifle changed from RHS ""AK-74M (Plum)"" to RHS ""AKS-74U"" for more rifle diversity in the platoon. Slightly lower accuracy at range but lighter carry weight. " \n "- Rifle mag changed from RHS ""30Rnd AK-74 (Plum) 7N10"" to RHS ""30Rnd AK-74 (Plum) 7N22"" to match the other mags in the vest. " \n "  " \n "FTL: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" semi-randomly to RHS ""6B27M"" or RHS ""6B27M (ESS)"" or RHS ""6B27M (Balaclava)"". " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest changed from RHS ""6B23 (6Sh116/VOG)"" semi-randomly to RHS ""6B23 EMR-Summer (6Sh92/VOG/Headset)"" or RHS ""6B23 (6Sh92/VOG/Headset)"". " \n "- Vest content: moved 2x RGO grenades to backpack, removed 3x RHS ""30Rnd AK-74 (Plum) 7N22"" and added 4x RHS ""30Rnd AK-74 (Plum) 7T3M (tracer)"" to match TFN and US Army loadouts. " \n "- Backpack changed from vanilla ""Assaultpack green"" to RHS ""UMBTS Backpack (Engineer)"" for a more Russian/breacher look. " \n "- Backpack content: added 2x RHS ""VOG-25"" to match TFN and US Army loadouts. " \n "- Rifle mag changed from RHS ""30Rnd AK-74 (Plum) 7N10"" to RHS ""30Rnd AK-74 (Plum) 7N22"" to match the other mags in the vest. " \n "  " \n "AR: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" semi-randomly to RHS ""6B27M"" or RHS ""6B27M (ESS)"" or RHS ""6B27M (Balaclava)"". " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest changed from RHS ""6B23 (6Sh116)"" semi-randomly to RHS ""6B23 EMR-Summer (Vydra-3M)"" or RHS ""6B23 (Vydra-3M)"" " \n "- Vest content: added 1x HLC ""7.62mm 75Rnd FMJ RPK Magazine (Tracers every 3)"" " \n "- Backpack changed from vanilla ""Assaultpack (green)"" to RHS ""Sidor"" for a more Russian look. " \n "- Backpack content: added 2x HLC ""7.62mm 75Rnd FMJ RPK Magazine (Tracers every 3)"" and 1x HLC ""7.62mm 75Rnd FMJ RPK Magazine (Tracer)"" " \n "- Rifle changed from RHS ""PKP"" to HLC ""RPK"". " \n "- Rifle muzzle attachment added RHS ""Surefire SF3P-762"". " \n " " \n "AAR: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" semi-randomly to RHS ""6B27M"" or RHS ""6B27M (ESS)"" or RHS ""6B27M (Balaclava)"". " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest changed from RHS ""6B23 (6Sh116)"" semi-randomly to RHS ""6B23 EMR-Summer (6Sh92/Headset)"" or RHS ""6B23 (6Sh92/Headset)"". " \n "- Vest content: moved 2x RGO grenades to backpack, removed 3x RHS ""30Rnd AK-74 (Plum) 7N22"" and added 4x RHS ""30Rnd AK-74 (Plum) 7T3M (tracer)"" to match TFN and US Army loadouts. " \n "- Backpack content: added RHS 2x ""30Rnd AK-74 (Plum) 7N22"" and 3x HLC ""7.62mm 75Rnd FMJ RPK Magazine (Tracers every 3)"" to match TFN and US Army loadouts. " \n "- Rifle mag changed from RHS ""30Rnd AK-74 (Plum) 7N10"" to RHS ""30Rnd AK-74 (Plum) 7N22"" to match the other mags in the vest. " \n "" \n "LAT: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" semi-randomly to RHS ""6B27M"" or RHS ""6B27M (ESS)"" or RHS ""6B27M (Balaclava)"". " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest variety changed semi-randomly to RHS ""6B23 (6Sh116)"" and RHS ""6B23 EMR-Summer (6Sh116)"". " \n "- Vest content: removed 1x RHS ""30Rnd AK-74 (Plum) 7N22"" and added 2x RHS ""30Rnd AK-74 (Plum) 7T3M (tracer)"" to match TFN and US Army loadouts. " \n "- Rifle changed from RHS ""AK-74M"" to RHS ""AK-105"" for more weapon variety in the platoon. " \n "- Rifle mag changed from RHS ""30Rnd AK-74 (Plum) 7N10"" to RHS ""30Rnd AK-74 (Plum) 7N22"" to match the other mags in the vest. " \n " " \n "MMG Leader: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" to RHS ""6B27M EMR-Summer"" " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest changed from RHS ""6B23 (6Sh116/VOG)"" to RHS ""6B23 EMR-Summer (6Sh92/VOG/Radio) SpNz"".  " \n "- Vest content: moved 2x RGO grenades to backpack, removed 3x RHS ""30Rnd AK-74 (Plum) 7N22"" and added 4x RHS ""30Rnd AK-74 (Plum) 7T3M (tracer)"" to match TFN and US Army loadouts. " \n "- Backpack changed from vanilla ""Assaultpack green"" to RHS ""UMBTS Backpack"" for a more Russian look. " \n "- Backpack content: added 1x RHS ""VOG-25"" to match TFN and US Army loadouts. " \n "- Rifle mag changed from RHS ""30Rnd AK-74 (Plum) 7N10"" to RHS ""30Rnd AK-74 (Plum) 7N22"" to match the other mags in the vest. " \n "  " \n "MMG Gunner: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" to RHS ""6B27M (ESS)"". " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest changed from RHS ""6B23 (6Sh116)"" to RHS ""6B23 EMR-Summer (Rifleman)"". " \n " " \n "MMG Asst. Gunner: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" to RHS ""6B27M"". " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest content: removed 1x RHS ""30Rnd AK-74 (Plum) 7N22"" and added 2x RHS ""30Rnd AK-74 (Plum) 7T3M (tracer)"" to match TFN and US Army loadouts. " \n "- Rifle mag changed from RHS ""30Rnd AK-74 (Plum) 7N10"" to RHS ""30Rnd AK-74 (Plum) 7N22"" to match the other mags in the vest. " \n " " \n "MAT Leader: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" to RHS ""6B27M EMR-Summer"" " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest changed from RHS ""6B23 (6Sh116/VOG)"" to RHS ""6B23 EMR-Summer (6Sh92/VOG/Radio) SpNz"".  " \n "- Vest content: moved 2x RGO grenades to backpack, removed 3x RHS ""30Rnd AK-74 (Plum) 7N22"" and added 4x RHS ""30Rnd AK-74 (Plum) 7T3M (tracer)"" to match TFN and US Army loadouts. " \n "- Backpack changed from vanilla ""Assaultpack green"" to RHS ""UMBTS Backpack"" for a more Russian look. " \n "- Backpack content: added 1x RHS ""VOG-25"" to match TFN and US Army loadouts. " \n "- Rifle mag changed from RHS ""30Rnd AK-74 (Plum) 7N10"" to RHS ""30Rnd AK-74 (Plum) 7N22"" to match the other mags in the vest. " \n " " \n "MAT Gunner: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" to RHS ""6B27M (ESS)"". " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Rifle changed from RHS ""AK-74M"" to RHS ""AK-105"" for more weapon variety in the platoon. " \n "- Rifle mag changed from RHS ""30Rnd AK-74 (Plum) 7N10"" to RHS ""30Rnd AK-74 (Plum) 7N22"" to match the other mags in the vest. " \n " " \n "MAT Asst. Gunner: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" to RHS ""6B27M"". " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest changed from RHS ""6B23 (6Sh116)"" to RHS ""6B23 EMR-Summer ""(6Sh92/Headset)"". " \n "- Vest content: removed 1x RHS ""30Rnd AK-74 (Plum) 7N22"" and added 2x RHS ""30Rnd AK-74 (Plum) 7T3M (tracer)"" to match TFN and US Army loadouts. " \n "- Rifle mag changed from RHS ""30Rnd AK-74 (Plum) 7N10"" to RHS ""30Rnd AK-74 (Plum) 7N22"" to match the other mags in the vest. " \n "  " \n "DMT Marksman " \n "- Added scope RHS ""IPN34"" to the vest gear. This is a somewhat equivalent NVG scope to the US Army Faction. " \n "  " \n "ENG Leader: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" to RHS ""Altyn (visor up)"". " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest changed from RHS ""6B23 (6Sh116)"" to RHS ""6B13 EMR-Summer ""(6Sh92/Radio)"". " \n "- Rifle changed from RHS ""AK-74M"" to RHS ""AK-105"" for more weapon variety in the platoon. " \n "- Rifle mag changed from RHS ""30Rnd AK-74 (Plum) 7N10"" to RHS ""30Rnd AK-74 (Plum) 7N22"" to match the other mags in the vest. " \n "  " \n "ENG Rifleman: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" semi-randomly to RHS ""Altyn (visor down)"" or RHS ""Altyn (visor up Balaclava)"". " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest changed from RHS ""6B23 (6Sh116)"" to RHS ""6B13 EMR-Summer ""(6Sh92)"". " \n "- Rifle changed from RHS ""AK-74M"" to RHS ""AK-105"" for more weapon variety in the platoon. " \n "- Rifle mag changed from RHS ""30Rnd AK-74 (Plum) 7N10"" to RHS ""30Rnd AK-74 (Plum) 7N22"" to match the other mags in the vest. " \n "  " \n "Mortar Leader: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" to RHS ""6B27M"". " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest changed from RHS ""6B23 (6Sh116/VOG)"" to RHS ""6B23 EMR-Summer (6Sh92/Radio)"". " \n "- Rifle changed from RHS ""AK-74M (Plum)"" to RHS ""AKS-74U"" for more rifle diversity in the platoon. Slightly lower accuracy at range but lighter carry weight. " \n "- Rifle mag changed from RHS ""30Rnd AK-74 (Plum) 7N10"" to RHS ""30Rnd AK-74 (Plum) 7N22"" to match the other mags in the vest. " \n "  " \n "Mortar Gunner: " \n "- Helmet changed from FFCP ""Combat SF Helmet Green"" to RHS ""6B27M (ESS)"". " \n "- Uniform changed from RHS ""EMR-Summer"" to RHS ""Flora"" for a kit-bash look. " \n "- Uniform content: moved 1x tourniquet from to vest to avoid potentially overloading the uniform with radios. " \n "- Vest changed from RHS ""6B23 (6Sh116/VOG)"" to RHS ""6B23 EMR-Summer (6Sh92)"". " \n "- Rifle changed from RHS ""AK-74M (Plum)"" to RHS ""AKS-74U"" for more rifle diversity in the platoon. Slightly lower accuracy at range but lighter carry weight. " \n "- Rifle mag changed from RHS ""30Rnd AK-74 (Plum) 7N10"" to RHS ""30Rnd AK-74 (Plum) 7N22"" to match the other mags in the vest. " \n "  " \n "All Units: " \n "- Disabled LAMBS AI " \n " " \n "Alpha SL: " \n "- Enabled ""is Player"". This makes it easier for Mission Makers to quickly test a mission in the editor by just hitting ""play"" instead of having to select a specific unit every time beforehand to avoid ending up in spectator mode by default. " \n " " \n "Crates: " \n "- Added an ACE3 medical crate with our usual base script. " \n "- Fireteam ammo crate: removed 4x 100Rnd PKM Box and replaced it with 4x 75Rnd RPK Mag and 1x 75Rnd RPK Tracer Mag. " \n "- Squad ammo crate: removed 13x 100Rnd PKM Tracer Box and added 12x 75Rnd RPK Mag & 4x 75Rnd RPK Tracer Mag" \n "" \n "" \n "-v1.13.6" \n "  - ALL Added persistent Call-Signs for all GM's (where not included in v1.13.4)" \n "  - ALL Added the code`this disableAI ""MOVE""; this setSpeaker ""NoVoice""; enableRadio false;` to all playable units to prevent them from running off and spamming the vanilla-radio during local testing." \n "  - ALL Changed persistent call-signs (map markers) to a consistent formula: ≤ 2 syllables = written out call-sing. ≥ 3 syllables = abbreviated call-sign." \n "  - ALL Added full changelog to all factions for quick in-game reference" \n "  - TFN Added new yellow owl insignia patches to all uniforms" \n "" \n "- v1.13.5" \n "  - ALL Added respective GM's to Standard Faction Compositions for convenience / time saving " \n "  - ALL Added base clean-up module to Standard Faction Compositions to ensure Mission Makers don't forget it in the future - radius set to 200x200 meters" \n "" \n "- v1.13.4 " \n "  - ALL Added @ Squad/Team names to leaders so that Team name appears in role select" \n "  - TFN Changed M249 to the FN MINIMI" \n "" \n "- v1.13.3" \n "  - US Added Improved Bipod/SAW Grip to AR M249" \n "  - US Removed M14 Mags" \n "  - TFN Added Bipod to M249" \n "" \n "- v1.13.2" \n "  - ALL Added 1 Extra Tourniquet to every Unit" \n "  - TFN DMT Lead Rifle Changed to D10 Version" \n "  - TFN DMT given extra pistol mag to bring in line with other units" \n "  - TFN AAR Weapon changed to HK416 D14.5" \n "  - TFN Lead Elements Given AN/PEQ-16A's" \n "  - US Alpha Fireteam 2 AAR vest changed to ALT variant to match rest of faction" \n "  - US Lead Elements Given AN/PEQ-16A's" \n "  - US DMT given extra pistol mag to bring in line with other units" \n "  - US DMT Sniper Rifle Given SU-260/P (MDO) to bring zoom level to the same as Russian and TFN factions" \n "  - US DMT Bipod Changed to Harris Bipod" \n "  - US DMT Marksman Rifle changed to black version of same rifle" \n "  - US DMT Marksman Magazines changed to SR-25 version, as RHS hotfix made M14 mags incompatible with MK11" \n "  - RUS DMT given extra pistol mag to bring in line with other units" \n "  - RUS DGR Helmets changed to TSH-4 to make distinct from US Helmets" \n "  - RUS NB Helmets changed to ZSH-7A to make distinct from US and TFN helmets" \n "  - RUS Removed RIS Rail adaptors from AK rifles" \n "  - RUS Added PG-7V rocket to MAT ammo crate. This rocket is lighter and packs less payload than the PG-7VL. This gives it an  increased effective range but is less powerful due to decreased payload" \n "" \n "- v1.12.2" \n "  - Hotfixed US Vests across the Squads to match V.12 changes. Whoops." \n "  - Added Angled Grip to TFN HK416s where possible. " \n "" \n "- v1.12" \n "  - Fixed TFN MMG Ammo preloaded into Rifle to 100RND mag from 50rnd." \n "  - Fixed TFN DMT Marksman Ammo loaded into Rifle to correct SBLR mag." \n "  - Changed TFN DMT Lead Suppressor to QDSS NT4 Black from Rotex-5 Grey" \n "  - Changed TFN Dagger Uniforms from Gorka R Green to FFCP Green Fatigues [RS]" \n "  - Changed US PLT Commander + Squad Leader Vest from SPCS Rifleman/OEF- CP to SPCS Squad Lead/OEF-CP" \n "  - Changed US Medic Vest from SPCS Rifleman/OEF-CP to SPCS Medic/OEF-CP" \n "  - Changed US PLT Rifleman Vest from SPCS OEF-CP to SPCS Rifleman Alt/OEF-CP" \n "  - Changed US FTL Vest from SPCS Rifleman/OEF-CP to SPCS Team Leader Alt/OEF-CP" \n "  - Changed US AR Vest from SPCS Rifleman/OEF-CP to SPCS SAW/OEF-CP" \n "  - Changed US AAR Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP" \n "  - Changed US Rifleman AT Vest from SPCS OEF-CP to SPCS Rifleman Alt/OEF-CP" \n "  - Changed US MAT/MMG/DMT/ENG/MTR Lead Vest from SPCS Rifleman/OEF-CP to SPCS Team Leader Alt/OEF-CP" \n "  - Changed US MMG Gunner Vest from SPCS Rifleman/OEF-CP to SPCS Machinegunner/OEF-CP" \n "  - Changed US MMG/MAT Ammo Bearer Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP" \n "  - Changed US MAT Gunner Vest from SPCS OEF-CP to SPCS Rifleman Alt/OEF-CP" \n "  - Changed US DMT Marksman vest from SPCS OEF-CP to SPCS Sniper/OEF-CP" \n "  - Fixed US DMT Marksman Rifle Loaded Mag to correct varient." \n "  - Changed US Engineer Rifleman Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP." \n "  - Changed US MTR Gunner Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP." \n "  - Changed US DGR Uniforms from FFCP ACU Fatigues to FFCP ACU Fatigues [RS]" \n "  - Changed US DGR Driver Backpack from Assault Pack Green to Assault Pack Black" \n "  - Changed US Heli Pilot/Copilot Uniforms from Heli pilot Coveralls to FFCP Nomad Fatigues [RS]" \n "  - Fixed US Heli/Jet Pilot Vest White Smoke grenade count to 2." \n "  - Changed US Heli Pilot/Copilot Helmet from Heli Pilot NATO to HGU-56/P (Black/Visor)" \n "  - Changed US Jet Pilot Uniform from Pilot Coveralls NATO to  FFCP Nomad Fatigues" \n "  - Changed RUS Vic/Heli/Jet Crew Weapons to PP-2000" \n "  - Upped RUS PP-2000 Ammo counts to 6x Mag to bring in line with ammo counts for TFN and US." \n "  - Changed RUS Heli Pilot Uniforms from Pilot Coveralls CSAT to FFCP-Fatigues EMR [RS]" \n "  - Changed RUS Heli Pilot Vest from 6B23 (6Sh116) to FFCP Tactical Vest TigerVRS" \n "  - Changed RUS Jet Pilot Uniforms from Pilot Coveralls CSAT to FFCP-Fatigues EMR [RS]" \n "  - Changed RUS Jet Pilot Vest from 6B23 (6Sh116) to FFCP Tactical Vest TigerVRS" \n "" \n "- v1.11" \n "  - changed m40 mini grenades to m67 fragmentation" \n "  - replaced mp7 weapons with mp5k-pdw" \n "  - changed ak105 to ak74m (plum) " \n "  - changed PKM to PKP" \n "  - changed RUS PKM ammo boxes. MMG now loads with 7TZ (AP rounds)" \n "  - added vert grip to us weapons" \n "  - replaced m14 with HK PSG1A1" \n "  - replaced m260e4 with mg3" \n "  - updated all ammo boxes respectively. " \n "" \n "- v1.10" \n "  - changed Medic loadouts from 6 x 1000ml blood bags to 2 x 1000ml and 8 x 500ml." \n "" \n "- v1.09" \n "  - updated Fireteam colours A1 Red A2 Yellow, B1 Green B2 Blue, C1 Red C2 Yellow." \n "" \n "- v1.08" \n "  - changed ""Reaper"" to ""Nightbird"", ""RPR"" to ""NB""" \n "  - changed ""Paladin"" to ""Falcon"", ""PAL"" to ""FC""" \n "  - changed ""DAGGER"" to ""DGR""" \n "" \n "- v1.07" \n "  - US and RU faction bumped to v1.07 to avoid confusion regarding version numbers (US and RU was 1.05, TFN was 1.06)" \n "  - overhauled the RU faction: updated helmets, uniforms, weapons to a more modern look" \n "  - overhauled the US faction: updated helmets and vests to armour rating of IV" \n "  - corrected some mistakes in all factions (grenade ammount of MMG gunner, ENG not having tourniquetes, DGR not having GPS-s)" \n "  - overhauled the medics of all factions to reflect recent cahnges to ACE medical (less QuikClots, more Elastic Bandages, etc.)" \n "" \n "- v1.05" \n "  - Added a MAT ammo box on spawn." \n "" \n "- v1.04" \n "  - All MAT Teams carrying RPG's got the ver3 scopes with ranges for all types" \n "    of ammo." \n "  - All Callsigns were changed to be uniformed throught no matter the faction." \n "" \n "- v1.03" \n "  - set crew driver/gunner and pilot/copilot/jetpilot as Engineers through the" \n "    Object: ACE Options menu in unit attributes" \n "  - overhauled the TFN faction (weapons, helmets, etc.), changes not applicable" \n "    to derived factions" \n "" \n "- v1.02" \n "  - loadout overhaul for DMT, made them lighter + gave them tools for recon" \n "  - specified preset ACRE2 radio channels for most units" \n "" \n "- v1.01" \n "  - updated team colors func to `a3ee_team_colors_fnc_setColor`, just load+save" \n "    the composition in editor, this fixes it" \n "  - changed RPG-7 using MAT teams to carry Kitbags" \n "  - removed one PKM ammo box from AAR, MMG gunner, MMG bearer (fixes overload)" \n "  - moved 1-2 AR boxes from AAR to AR, gave AR an Assaultpack" \n "  - added 1-2 more AR boxes to AR's Assaultpack (if enough space)" \n "  - changed HEDP to HE rockets for Carl Gustav (M3MAAWS)" \n "  - changed US crew uniform and helmet to match grey color scheme of US pilots" \n "  - changed backpacks of driver/copilot to use less contrasting colors compared" \n "    to their respective uniform/vest colors" \n "  - changed Carryall backpacks of TFN Engineers to use custom Flecktarn Carryall" \n "  - changed all (GP-25 and normal) AK74m rifles to be the non-NPZ variants" \n "  - removed secondary long-range (PRC148) from Engineers" \n "" \n "- v1.00 (and before)" \n "  - added a Comment object with version number (`v1.00`)" \n "  - added `respawn_west`, `respawn_east`, `respawn_guerrila` markers" \n "  - added `[this, 200] call a3ee_fnc_boxGuard` to init lines of resupply boxes" \n "  - added `Resupply` green triangle markers on the position of resupply boxes";
 		id=69;
 	};
 	class Item16
@@ -15909,7 +15909,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={4.4506836,0.0014390945,-4.7147217};
+					position[]={4.4536133,0.0014390945,-4.9321289};
 				};
 				side="East";
 				flags=7;
@@ -16057,7 +16057,7 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="Curator";
 							};
 						};
 					};
@@ -16152,7 +16152,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={5.449707,0.0014390945,-4.7137451};
+					position[]={5.4526367,0.0014390945,-4.9311523};
 				};
 				side="East";
 				flags=5;
@@ -16262,7 +16262,7 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="Curator";
 							};
 						};
 					};
@@ -16424,7 +16424,7 @@ class items
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={7.5717773,0,-3.4597778};
+			position[]={7.574707,0,-3.6772461};
 		};
 		side="Empty";
 		flags=4;
@@ -16465,7 +16465,7 @@ class items
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={7.4628906,0.89242268,-7.4787598};
+			position[]={7.4658203,0.89242268,-7.6958008};
 		};
 		side="Empty";
 		flags=4;
@@ -16506,7 +16506,7 @@ class items
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={7.534668,0.28405476,-5.1148071};
+			position[]={7.5375977,0.28405476,-5.3320313};
 		};
 		side="Empty";
 		flags=4;
@@ -16547,7 +16547,7 @@ class items
 		dataType="Logic";
 		class PositionInfo
 		{
-			position[]={-0.083496094,0,0.2911377};
+			position[]={-0.080566406,0,0.073730469};
 		};
 		areaSize[]={200,-1,200};
 		areaIsRectangle=1;
@@ -16621,7 +16621,7 @@ class items
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={5.3647461,0.18872452,-8.6337891};
+			position[]={5.3676758,0.18872452,-8.8510742};
 		};
 		side="Empty";
 		flags=4;


### PR DESCRIPTION
PL:
- Headgear changed from RHS "Field Cap VSR" to RHS "6B27M (ESS)" to give leader a helmet (fixes #82).
- Uniform content: moved radios 152 & 148 to backpack (fixes #95).


Platoon Sergeant:
- Headgear changed from RHS "6B26 (ESS)" to RHS "6B27M (Balaclava)" to fit the rest of the platoon (fixes #112).


Platoon Medic:
- Headgear changed from RHS "6B26" to RHS "6B27M" to fit the rest of the platoon (fixes #112).
- Rifle changed from RHS "AKS-74U" to RHS "AKS-74UN" to allow for scope attachments (fixes #108).


Platoon Rifleman:
- Helmet changed from RHS "6B26 (ESS/Balaclava)" to RHS "6B27M (ESS/Balaclava)" to fit the rest of the platoon (fixes #112).


SL:
- Helmet changed from RHS "6B27M EMR-Summer" to RHS "6B27M (Balaclava)" to fit the rest of the platoon.
- Uniform content: moved radio 152 to backpack (fixes #95).


Medic:
- Rifle changed from RHS "AKS-74U" to RHS "AKS-74UN" to allow for scope attachments (fixes #108).


MMG Leader:
- Helmet changed from RHS "6B27M EMR-Summer" to RHS "6B27M (Balaclava)" to fit the rest of the platoon.
- Uniform content: moved radio 152 to backpack (fixes #95).


MAT Leader:
- Headgear changed from RHS "6B27M EMR-Summer" to RHS "6B27M (Balaclava)" to fit the rest of the platoon.
- Uniform content: moved radio 152 to backpack (fixes #95).


ENG Leader:
- Uniform content: moved radio 152 to backpack (fixes #95).
- Backpack content: changed ammo count to 4 regular mags and 2 tracer mag (fixes #83).


ENG Rifleman:
- Backpack content: changed ammo count to 5 regular mags and 1 tracer mag (fixes #83).


DMT Leader:
- Soldier class changed from "B_spotter_F" to "O_spotter_F" (fixes #94).


DMT Marksman:
- Soldier class changed from "B_spotter_F" to "O_soldier_M_F" (fixes #94).


MTR Leader:
- Vest content: changed ammo count to 5 regular mags and 1 tracer mag (fixes #83).


MTR Gunner:
- Vest content: changed ammo count to 5 regular mags and 1 tracer mag (fixes #83).


Zeus:
- Fixed missing Zeus status (fixes #113).


Alpha Squad Leader:
- set to player via attributes (fixes #122).


All Units:
- Fixed missing standard ACRE2 radio channels (fixes #110).
- Uniform content: added 1x epinephrine (fixes #107) and sorted all items in a more logical manner (fixes #111).
- Vest content: sorted all items in a more logical manner (fixes #111).
- Backpack content: sorted all items in a more logical manner (fixes #111).
- Fireteam members: fixed ST HUD colours for fireteam members of Alpha, Bravo and Charlie (fixes #117).

Detailed overview for #111 item sorting: https://docs.google.com/spreadsheets/d/138Ri_0QcqhK5CMb84NIovQBv1RXs-MBtom6YtQrMtGs/edit#gid=728566920


Crates:
- Added a mortar supply crate (fixes #77).