### PR TITLE
Standard factions 1.14.2

### DIFF
--- a/reference/PMC%20Faction/composition.sqe
+++ b/reference/PMC%20Faction/composition.sqe
@@ -1,12 +1,12 @@
 version=53;
-center[]={3000.5588,5,3837.3384};
+center[]={4143.9121,5,5008.2334};
 class items
 {
-	items=69;
+	items=68;
 	class Item0
 	{
 		dataType="Marker";
-		position[]={0.54541016,1.3349106e+013,-1.2211914};
+		position[]={0.49804688,1.3349106e+013,-1.2407227};
 		name="respawn_guerrila";
 		type="respawn_unknown";
 		id=0;
@@ -15,7 +15,7 @@ class items
 	class Item1
 	{
 		dataType="Marker";
-		position[]={-22.454102,0.29708433,15.778809};
+		position[]={-22.501465,0.29708433,15.759277};
 		name="Rifles_6";
 		text="Rifles";
 		type="mil_triangle";
@@ -35,7 +35,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-22.453857,0.0014390945,5.8286133};
+					position[]={-22.500977,0.0014390945,5.809082};
 				};
 				side="Independent";
 				flags=7;
@@ -387,7 +387,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-20.455078,0.0014390945,5.8295898};
+					position[]={-20.502441,0.0014390945,5.8100586};
 				};
 				side="Independent";
 				flags=5;
@@ -663,7 +663,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-19.455078,0.0014390945,5.8295898};
+					position[]={-19.502441,0.0014390945,5.8100586};
 				};
 				side="Independent";
 				flags=5;
@@ -863,7 +863,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-21.453857,0.0014390945,5.8286133};
+					position[]={-21.500977,0.0014390945,5.809082};
 				};
 				side="Independent";
 				flags=4;
@@ -1185,7 +1185,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-22.513184,0.0014390945,3.534668};
+					position[]={-22.560547,0.0014390945,3.5151367};
 				};
 				side="Independent";
 				flags=7;
@@ -1516,7 +1516,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-21.512695,0.0014390945,3.5356445};
+					position[]={-21.560059,0.0014390945,3.5161133};
 				};
 				side="Independent";
 				flags=5;
@@ -1792,7 +1792,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-22.512695,0.0014390945,1.5356445};
+					position[]={-22.560059,0.0014390945,1.5161133};
 				};
 				side="Independent";
 				flags=5;
@@ -2073,7 +2073,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-21.512695,0.0014390945,1.5356445};
+					position[]={-21.560059,0.0014390945,1.5161133};
 				};
 				side="Independent";
 				flags=5;
@@ -2288,7 +2288,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-20.512695,0.0014390945,1.5356445};
+					position[]={-20.560059,0.0014390945,1.5161133};
 				};
 				side="Independent";
 				flags=5;
@@ -2552,7 +2552,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-19.512695,0.0014390945,1.5356445};
+					position[]={-19.560059,0.0014390945,1.5161133};
 				};
 				side="Independent";
 				flags=5;
@@ -2756,7 +2756,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-22.512695,0.0014390945,-0.46435547};
+					position[]={-22.560059,0.0014390945,-0.48388672};
 				};
 				side="Independent";
 				flags=5;
@@ -3037,7 +3037,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-21.512695,0.0014390945,-0.46435547};
+					position[]={-21.560059,0.0014390945,-0.48388672};
 				};
 				side="Independent";
 				flags=5;
@@ -3252,7 +3252,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-20.512695,0.0014390945,-0.46435547};
+					position[]={-20.560059,0.0014390945,-0.48388672};
 				};
 				side="Independent";
 				flags=5;
@@ -3516,7 +3516,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-19.512695,0.0014390945,-0.46435547};
+					position[]={-19.560059,0.0014390945,-0.48388672};
 				};
 				side="Independent";
 				flags=5;
@@ -3756,7 +3756,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-16.950195,0.0014390945,3.4233398};
+					position[]={-16.997559,0.0014390945,3.4038086};
 				};
 				side="Independent";
 				flags=7;
@@ -4068,7 +4068,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-15.951172,0.0014390945,3.4233398};
+					position[]={-15.998535,0.0014390945,3.4038086};
 				};
 				side="Independent";
 				flags=5;
@@ -4344,7 +4344,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-16.951172,0.0014390945,1.4233398};
+					position[]={-16.998535,0.0014390945,1.4038086};
 				};
 				side="Independent";
 				flags=5;
@@ -4625,7 +4625,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-15.951172,0.0014390945,1.4233398};
+					position[]={-15.998535,0.0014390945,1.4038086};
 				};
 				side="Independent";
 				flags=5;
@@ -4840,7 +4840,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-14.950684,0.0014390945,1.4233398};
+					position[]={-14.998047,0.0014390945,1.4038086};
 				};
 				side="Independent";
 				flags=5;
@@ -5104,7 +5104,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-13.951172,0.0014390945,1.4233398};
+					position[]={-13.998535,0.0014390945,1.4038086};
 				};
 				side="Independent";
 				flags=5;
@@ -5308,7 +5308,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-16.951172,0.0014390945,-0.57666016};
+					position[]={-16.998535,0.0014390945,-0.59619141};
 				};
 				side="Independent";
 				flags=5;
@@ -5589,7 +5589,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-15.951172,0.0014390945,-0.57666016};
+					position[]={-15.998535,0.0014390945,-0.59619141};
 				};
 				side="Independent";
 				flags=5;
@@ -5804,7 +5804,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-14.951172,0.0014390945,-0.57666016};
+					position[]={-14.998535,0.0014390945,-0.59619141};
 				};
 				side="Independent";
 				flags=5;
@@ -6068,7 +6068,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-13.951172,0.0014390945,-0.57666016};
+					position[]={-13.998535,0.0014390945,-0.59619141};
 				};
 				side="Independent";
 				flags=5;
@@ -6308,7 +6308,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-11.902832,0.0014390945,3.315918};
+					position[]={-11.950195,0.0014390945,3.2963867};
 				};
 				side="Independent";
 				flags=7;
@@ -6620,7 +6620,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-10.902832,0.0014390945,3.3149414};
+					position[]={-10.950195,0.0014390945,3.2954102};
 				};
 				side="Independent";
 				flags=5;
@@ -6896,7 +6896,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-11.902832,0.0014390945,1.3149414};
+					position[]={-11.950195,0.0014390945,1.2954102};
 				};
 				side="Independent";
 				flags=5;
@@ -7177,7 +7177,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-10.902832,0.0014390945,1.3149414};
+					position[]={-10.950195,0.0014390945,1.2954102};
 				};
 				side="Independent";
 				flags=5;
@@ -7392,7 +7392,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-9.902832,0.0014390945,1.3149414};
+					position[]={-9.9501953,0.0014390945,1.2954102};
 				};
 				side="Independent";
 				flags=5;
@@ -7656,7 +7656,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-8.902832,0.0014390945,1.3149414};
+					position[]={-8.9501953,0.0014390945,1.2954102};
 				};
 				side="Independent";
 				flags=5;
@@ -7860,7 +7860,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-11.902832,0.0014390945,-0.68505859};
+					position[]={-11.950195,0.0014390945,-0.70458984};
 				};
 				side="Independent";
 				flags=5;
@@ -8141,7 +8141,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-10.902832,0.0014390945,-0.68505859};
+					position[]={-10.950195,0.0014390945,-0.70458984};
 				};
 				side="Independent";
 				flags=5;
@@ -8356,7 +8356,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-9.902832,0.0014390945,-0.68505859};
+					position[]={-9.9501953,0.0014390945,-0.70458984};
 				};
 				side="Independent";
 				flags=5;
@@ -8620,7 +8620,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-8.902832,0.0014390945,-0.68505859};
+					position[]={-8.9501953,0.0014390945,-0.70458984};
 				};
 				side="Independent";
 				flags=5;
@@ -8851,7 +8851,7 @@ class items
 	class Item6
 	{
 		dataType="Marker";
-		position[]={-9.4541016,0.035955906,-9.2211914};
+		position[]={-9.5014648,0.036262512,-9.2407227};
 		name="resupply_marker_2";
 		text="Resupply";
 		type="mil_triangle";
@@ -8864,7 +8864,7 @@ class items
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={-22.454102,0.79142618,16.778809};
+			position[]={-22.501465,0.79142618,16.759277};
 		};
 		side="Empty";
 		flags=4;
@@ -8880,7 +8880,7 @@ class items
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={-15.454102,0.79142618,16.778809};
+			position[]={-15.501465,0.79142618,16.759277};
 		};
 		side="Empty";
 		flags=4;
@@ -8896,7 +8896,7 @@ class items
 		dataType="Comment";
 		class PositionInfo
 		{
-			position[]={-22.454102,0,17.778809};
+			position[]={-22.501465,0,17.759277};
 		};
 		title="Standard Rifles";
 		id=43;
@@ -8906,7 +8906,7 @@ class items
 		dataType="Comment";
 		class PositionInfo
 		{
-			position[]={-15.454102,0,17.778809};
+			position[]={-15.501465,0,17.759277};
 		};
 		title="SL & FTLS";
 		id=44;
@@ -8916,7 +8916,7 @@ class items
 		dataType="Comment";
 		class PositionInfo
 		{
-			position[]={-8.4541016,0,17.778809};
+			position[]={-8.5014648,0,17.759277};
 		};
 		title="DMT";
 		id=45;
@@ -8926,7 +8926,7 @@ class items
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={-8.4541016,0.79142618,16.778809};
+			position[]={-8.5014648,0.79142618,16.759277};
 		};
 		side="Empty";
 		flags=4;
@@ -8940,7 +8940,7 @@ class items
 	class Item13
 	{
 		dataType="Marker";
-		position[]={-15.454102,0.29708433,15.778809};
+		position[]={-15.501465,0.29708433,15.759277};
 		name="Rifles_7";
 		text="SL & FTLS";
 		type="mil_triangle";
@@ -8951,7 +8951,7 @@ class items
 	class Item14
 	{
 		dataType="Marker";
-		position[]={-8.4541016,0.29708433,15.778809};
+		position[]={-8.5014648,0.29708433,15.759277};
 		name="Rifles_8";
 		text="DMT";
 		type="mil_triangle";
@@ -8971,7 +8971,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-22.512695,0.0014390945,-4.4643555};
+					position[]={-22.560059,0.0014390945,-4.4838867};
 				};
 				side="Independent";
 				flags=7;
@@ -9296,7 +9296,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-21.512695,0.0014390945,-4.465332};
+					position[]={-21.560059,0.0014390945,-4.4848633};
 				};
 				side="Independent";
 				flags=5;
@@ -9517,7 +9517,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-20.512695,0.0014390945,-4.465332};
+					position[]={-20.560059,0.0014390945,-4.4848633};
 				};
 				side="Independent";
 				flags=5;
@@ -9793,7 +9793,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-16.269531,0.0014390945,-4.4995117};
+					position[]={-16.316895,0.0014390945,-4.519043};
 				};
 				side="Independent";
 				flags=7;
@@ -10118,7 +10118,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-15.270996,0.0014390945,-4.4975586};
+					position[]={-15.318359,0.0014390945,-4.5170898};
 				};
 				side="Independent";
 				flags=5;
@@ -10367,7 +10367,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-14.270996,0.0014390945,-4.4975586};
+					position[]={-14.318359,0.0014390945,-4.5170898};
 				};
 				side="Independent";
 				flags=5;
@@ -10643,7 +10643,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-22.773438,0.0014390945,-7.1333008};
+					position[]={-22.820801,0.0014390945,-7.152832};
 				};
 				side="Independent";
 				flags=7;
@@ -10929,7 +10929,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-21.773926,0.0014390945,-7.1342773};
+					position[]={-21.821289,0.0014390945,-7.1538086};
 				};
 				side="Independent";
 				flags=4;
@@ -11213,7 +11213,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-16.642578,0.0014390945,-7.1948242};
+					position[]={-16.689941,0.0014390945,-7.2143555};
 				};
 				side="Independent";
 				flags=7;
@@ -11434,7 +11434,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-15.641602,0.0014390945,-7.1948242};
+					position[]={-15.688965,0.0014390945,-7.2143555};
 				};
 				side="Independent";
 				flags=5;
@@ -11668,7 +11668,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-11.374512,0.0014390945,-4.4604492};
+					position[]={-11.421875,0.0014390945,-4.4799805};
 				};
 				side="Independent";
 				flags=7;
@@ -11956,7 +11956,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-10.374512,0.0014390945,-4.4604492};
+					position[]={-10.421875,0.0014390945,-4.4799805};
 				};
 				side="Independent";
 				flags=5;
@@ -12209,7 +12209,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-9.3745117,0.0014390945,-4.4604492};
+					position[]={-9.421875,0.0014390945,-4.4799805};
 				};
 				side="Independent";
 				flags=5;
@@ -12472,7 +12472,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-8.3745117,0.0014390945,-4.4604492};
+					position[]={-8.421875,0.0014390945,-4.4799805};
 				};
 				side="Independent";
 				flags=5;
@@ -12765,7 +12765,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-23.04248,0.0014390945,-9.8120117};
+					position[]={-23.089844,0.0014390945,-9.831543};
 				};
 				side="Independent";
 				flags=7;
@@ -13031,7 +13031,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-22.04248,0.0014390945,-9.8120117};
+					position[]={-22.089844,0.0014390945,-9.831543};
 				};
 				side="Independent";
 				flags=5;
@@ -13256,7 +13256,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-21.04248,0.0014390945,-9.8120117};
+					position[]={-21.089844,0.0014390945,-9.831543};
 				};
 				side="Independent";
 				flags=5;
@@ -13503,7 +13503,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-16.762695,0.0014390945,-10.000488};
+					position[]={-16.810059,0.0014390945,-10.02002};
 				};
 				side="Independent";
 				flags=7;
@@ -13788,7 +13788,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-15.762695,0.0014390945,-9.9995117};
+					position[]={-15.810059,0.0014390945,-10.019043};
 				};
 				side="Independent";
 				flags=5;
@@ -14132,7 +14132,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-13.026367,0.0014390945,-10.129395};
+					position[]={-13.07373,0.0014390945,-10.148926};
 				};
 				side="Independent";
 				flags=7;
@@ -14443,7 +14443,7 @@ class items
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={-8.8950195,0.28405476,-8.550293};
+			position[]={-8.9423828,0.28405476,-8.5698242};
 		};
 		side="Empty";
 		flags=4;
@@ -14482,7 +14482,7 @@ class items
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={-8.8422852,0.89242268,-10.932129};
+			position[]={-8.8896484,0.89242268,-10.95166};
 		};
 		side="Empty";
 		flags=4;
@@ -14521,7 +14521,7 @@ class items
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={-11.013184,0.14963102,-9.8608398};
+			position[]={-11.060547,0.14963102,-9.8803711};
 			angles[]={-0,4.7330365,0};
 		};
 		side="Empty";
@@ -14567,7 +14567,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-11.374512,0.0014390945,-7.1948242};
+					position[]={-11.421875,0.0014390945,-7.2143555};
 				};
 				side="Independent";
 				flags=7;
@@ -14645,7 +14645,7 @@ class items
 						headgear="H_ShemagOpen_khk";
 					};
 				};
-				id=82;
+				id=81;
 				type="I_Protagonist_VR_F";
 				class CustomAttributes
 				{
@@ -14778,7 +14778,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-10.374512,0.0014390945,-7.1948242};
+					position[]={-10.421875,0.0014390945,-7.2143555};
 				};
 				side="Independent";
 				flags=5;
@@ -14851,7 +14851,7 @@ class items
 						headgear="rhsusf_bowman_cap";
 					};
 				};
-				id=83;
+				id=82;
 				type="I_Protagonist_VR_F";
 				class CustomAttributes
 				{
@@ -14983,7 +14983,7 @@ class items
 		class Attributes
 		{
 		};
-		id=81;
+		id=80;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -15013,7 +15013,7 @@ class items
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={-8.4624023,0,-6.8754883};
+			position[]={-8.5097656,0,-6.8950195};
 		};
 		side="Empty";
 		flags=4;
@@ -15021,7 +15021,7 @@ class items
 		{
 			init="call{[this, 200] call a3aa_fnc_boxGuard}";
 		};
-		id=84;
+		id=83;
 		type="ACE_medicalSupplyCrate";
 		class CustomAttributes
 		{
@@ -15059,7 +15059,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={9.5458984,0.0014390945,5.8286133};
+					position[]={9.4985352,0.0014390945,5.809082};
 				};
 				side="Independent";
 				flags=7;
@@ -15278,7 +15278,7 @@ class items
 						headgear="cnto_flecktarn_h_beret";
 					};
 				};
-				id=86;
+				id=85;
 				type="I_officer_F";
 				class CustomAttributes
 				{
@@ -15309,7 +15309,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={11.544922,0.0014390945,5.8295898};
+					position[]={11.497559,0.0014390945,5.8100586};
 				};
 				side="Independent";
 				flags=5;
@@ -15523,7 +15523,7 @@ class items
 						headgear="LOP_H_Cowboy_hat";
 					};
 				};
-				id=87;
+				id=86;
 				type="I_medic_F";
 				class CustomAttributes
 				{
@@ -15554,7 +15554,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={12.545898,0.0014390945,5.8286133};
+					position[]={12.498535,0.0014390945,5.809082};
 				};
 				side="Independent";
 				flags=5;
@@ -15687,7 +15687,7 @@ class items
 						headgear="cnto_flecktarn_h_boo_desert";
 					};
 				};
-				id=88;
+				id=87;
 				type="I_soldier_F";
 				class CustomAttributes
 				{
@@ -15718,7 +15718,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={10.545898,0.0014390945,5.8286133};
+					position[]={10.498535,0.0014390945,5.809082};
 				};
 				side="Independent";
 				flags=4;
@@ -15871,7 +15871,7 @@ class items
 						headgear="cnto_flecktarn_h_s_mediterranean";
 					};
 				};
-				id=89;
+				id=88;
 				type="I_soldier_F";
 				class CustomAttributes
 				{
@@ -15901,7 +15901,7 @@ class items
 		class Attributes
 		{
 		};
-		id=85;
+		id=84;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -15938,7 +15938,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={9.4868164,0.0014390945,3.5356445};
+					position[]={9.4394531,0.0014390945,3.5161133};
 				};
 				side="Independent";
 				flags=7;
@@ -16169,7 +16169,7 @@ class items
 						headgear="H_Cap_headphones";
 					};
 				};
-				id=91;
+				id=90;
 				type="I_Soldier_SL_F";
 				class CustomAttributes
 				{
@@ -16269,7 +16269,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={10.487305,0.0014390945,3.5356445};
+					position[]={10.439941,0.0014390945,3.5161133};
 				};
 				side="Independent";
 				flags=5;
@@ -16478,7 +16478,7 @@ class items
 						headgear="LOP_H_Cowboy_hat";
 					};
 				};
-				id=92;
+				id=91;
 				type="I_medic_F";
 				class CustomAttributes
 				{
@@ -16545,7 +16545,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={9.4873047,0.0014390945,1.5356445};
+					position[]={9.4399414,0.0014390945,1.5161133};
 				};
 				side="Independent";
 				flags=5;
@@ -16759,7 +16759,7 @@ class items
 						headgear="rhsusf_bowman_cap";
 					};
 				};
-				id=93;
+				id=92;
 				type="I_Soldier_TL_F";
 				class CustomAttributes
 				{
@@ -16826,7 +16826,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={10.487305,0.0014390945,1.5356445};
+					position[]={10.439941,0.0014390945,1.5161133};
 				};
 				side="Independent";
 				flags=5;
@@ -16974,7 +16974,7 @@ class items
 						headgear="H_ShemagOpen_khk";
 					};
 				};
-				id=94;
+				id=93;
 				type="I_Soldier_AR_F";
 				class CustomAttributes
 				{
@@ -17041,7 +17041,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={11.487305,0.0014390945,1.5356445};
+					position[]={11.439941,0.0014390945,1.5161133};
 				};
 				side="Independent";
 				flags=5;
@@ -17244,7 +17244,7 @@ class items
 						headgear="H_Booniehat_khk_hs";
 					};
 				};
-				id=95;
+				id=94;
 				type="I_Soldier_AAR_F";
 				class CustomAttributes
 				{
@@ -17311,7 +17311,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={12.487305,0.0014390945,1.5356445};
+					position[]={12.439941,0.0014390945,1.5161133};
 				};
 				side="Independent";
 				flags=5;
@@ -17448,7 +17448,7 @@ class items
 						headgear="LOP_H_Beanie_dpmw";
 					};
 				};
-				id=96;
+				id=95;
 				type="I_Soldier_LAT_F";
 				class CustomAttributes
 				{
@@ -17515,7 +17515,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={9.4868164,0.0014390945,-0.46435547};
+					position[]={9.4394531,0.0014390945,-0.48388672};
 				};
 				side="Independent";
 				flags=5;
@@ -17729,7 +17729,7 @@ class items
 						headgear="rhsusf_bowman_cap";
 					};
 				};
-				id=97;
+				id=96;
 				type="I_Soldier_TL_F";
 				class CustomAttributes
 				{
@@ -17796,7 +17796,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={10.487305,0.0014390945,-0.46435547};
+					position[]={10.439941,0.0014390945,-0.48388672};
 				};
 				side="Independent";
 				flags=5;
@@ -17944,7 +17944,7 @@ class items
 						headgear="H_ShemagOpen_khk";
 					};
 				};
-				id=98;
+				id=97;
 				type="I_Soldier_AR_F";
 				class CustomAttributes
 				{
@@ -18011,7 +18011,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={11.487305,0.0014390945,-0.46435547};
+					position[]={11.439941,0.0014390945,-0.48388672};
 				};
 				side="Independent";
 				flags=5;
@@ -18214,7 +18214,7 @@ class items
 						headgear="H_Booniehat_khk_hs";
 					};
 				};
-				id=99;
+				id=98;
 				type="I_Soldier_AAR_F";
 				class CustomAttributes
 				{
@@ -18281,7 +18281,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={12.487305,0.0014390945,-0.46435547};
+					position[]={12.439941,0.0014390945,-0.48388672};
 				};
 				side="Independent";
 				flags=5;
@@ -18418,7 +18418,7 @@ class items
 						headgear="LOP_H_Beanie_dpmw";
 					};
 				};
-				id=100;
+				id=99;
 				type="I_Soldier_LAT_F";
 				class CustomAttributes
 				{
@@ -18484,7 +18484,7 @@ class items
 		class Attributes
 		{
 		};
-		id=90;
+		id=89;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -18521,7 +18521,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={15.049805,0.0014390945,3.4243164};
+					position[]={15.002441,0.0014390945,3.4047852};
 				};
 				side="Independent";
 				flags=7;
@@ -18752,7 +18752,7 @@ class items
 						headgear="H_Cap_headphones";
 					};
 				};
-				id=102;
+				id=101;
 				type="I_Soldier_SL_F";
 				class CustomAttributes
 				{
@@ -18833,7 +18833,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={16.048828,0.0014390945,3.4243164};
+					position[]={16.001465,0.0014390945,3.4047852};
 				};
 				side="Independent";
 				flags=5;
@@ -19042,7 +19042,7 @@ class items
 						headgear="LOP_H_Cowboy_hat";
 					};
 				};
-				id=103;
+				id=102;
 				type="I_medic_F";
 				class CustomAttributes
 				{
@@ -19109,7 +19109,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={15.048828,0.0014390945,1.4243164};
+					position[]={15.001465,0.0014390945,1.4047852};
 				};
 				side="Independent";
 				flags=5;
@@ -19323,7 +19323,7 @@ class items
 						headgear="rhsusf_bowman_cap";
 					};
 				};
-				id=104;
+				id=103;
 				type="I_Soldier_TL_F";
 				class CustomAttributes
 				{
@@ -19390,7 +19390,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={16.048828,0.0014390945,1.4243164};
+					position[]={16.001465,0.0014390945,1.4047852};
 				};
 				side="Independent";
 				flags=5;
@@ -19538,7 +19538,7 @@ class items
 						headgear="H_ShemagOpen_khk";
 					};
 				};
-				id=105;
+				id=104;
 				type="I_Soldier_AR_F";
 				class CustomAttributes
 				{
@@ -19605,7 +19605,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={17.049316,0.0014390945,1.4243164};
+					position[]={17.001953,0.0014390945,1.4047852};
 				};
 				side="Independent";
 				flags=5;
@@ -19808,7 +19808,7 @@ class items
 						headgear="H_Booniehat_khk_hs";
 					};
 				};
-				id=106;
+				id=105;
 				type="I_Soldier_AAR_F";
 				class CustomAttributes
 				{
@@ -19875,7 +19875,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={18.048828,0.0014390945,1.4243164};
+					position[]={18.001465,0.0014390945,1.4047852};
 				};
 				side="Independent";
 				flags=5;
@@ -20012,7 +20012,7 @@ class items
 						headgear="LOP_H_Beanie_dpmw";
 					};
 				};
-				id=107;
+				id=106;
 				type="I_Soldier_LAT_F";
 				class CustomAttributes
 				{
@@ -20079,7 +20079,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={15.048828,0.0014390945,-0.57568359};
+					position[]={15.001465,0.0014390945,-0.59521484};
 				};
 				side="Independent";
 				flags=5;
@@ -20293,7 +20293,7 @@ class items
 						headgear="rhsusf_bowman_cap";
 					};
 				};
-				id=108;
+				id=107;
 				type="I_Soldier_TL_F";
 				class CustomAttributes
 				{
@@ -20360,7 +20360,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={16.048828,0.0014390945,-0.57568359};
+					position[]={16.001465,0.0014390945,-0.59521484};
 				};
 				side="Independent";
 				flags=5;
@@ -20508,7 +20508,7 @@ class items
 						headgear="H_ShemagOpen_khk";
 					};
 				};
-				id=109;
+				id=108;
 				type="I_Soldier_AR_F";
 				class CustomAttributes
 				{
@@ -20575,7 +20575,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={17.048828,0.0014390945,-0.57568359};
+					position[]={17.001465,0.0014390945,-0.59521484};
 				};
 				side="Independent";
 				flags=5;
@@ -20778,7 +20778,7 @@ class items
 						headgear="H_Booniehat_khk_hs";
 					};
 				};
-				id=110;
+				id=109;
 				type="I_Soldier_AAR_F";
 				class CustomAttributes
 				{
@@ -20845,7 +20845,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={18.048828,0.0014390945,-0.57568359};
+					position[]={18.001465,0.0014390945,-0.59521484};
 				};
 				side="Independent";
 				flags=5;
@@ -20982,7 +20982,7 @@ class items
 						headgear="LOP_H_Beanie_dpmw";
 					};
 				};
-				id=111;
+				id=110;
 				type="I_Soldier_LAT_F";
 				class CustomAttributes
 				{
@@ -21048,7 +21048,7 @@ class items
 		class Attributes
 		{
 		};
-		id=101;
+		id=100;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -21085,7 +21085,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={20.097168,0.0014390945,3.315918};
+					position[]={20.049805,0.0014390945,3.2963867};
 				};
 				side="Independent";
 				flags=7;
@@ -21316,7 +21316,7 @@ class items
 						headgear="H_Cap_headphones";
 					};
 				};
-				id=113;
+				id=112;
 				type="I_Soldier_SL_F";
 				class CustomAttributes
 				{
@@ -21397,7 +21397,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={21.097168,0.0014390945,3.3149414};
+					position[]={21.049805,0.0014390945,3.2954102};
 				};
 				side="Independent";
 				flags=5;
@@ -21606,7 +21606,7 @@ class items
 						headgear="LOP_H_Cowboy_hat";
 					};
 				};
-				id=114;
+				id=113;
 				type="I_medic_F";
 				class CustomAttributes
 				{
@@ -21673,7 +21673,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={20.097168,0.0014390945,1.3149414};
+					position[]={20.049805,0.0014390945,1.2954102};
 				};
 				side="Independent";
 				flags=5;
@@ -21887,7 +21887,7 @@ class items
 						headgear="rhsusf_bowman_cap";
 					};
 				};
-				id=115;
+				id=114;
 				type="I_Soldier_TL_F";
 				class CustomAttributes
 				{
@@ -21954,7 +21954,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={21.097168,0.0014390945,1.3149414};
+					position[]={21.049805,0.0014390945,1.2954102};
 				};
 				side="Independent";
 				flags=5;
@@ -22102,7 +22102,7 @@ class items
 						headgear="H_ShemagOpen_khk";
 					};
 				};
-				id=116;
+				id=115;
 				type="I_Soldier_AR_F";
 				class CustomAttributes
 				{
@@ -22169,7 +22169,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={22.097168,0.0014390945,1.3149414};
+					position[]={22.049805,0.0014390945,1.2954102};
 				};
 				side="Independent";
 				flags=5;
@@ -22372,7 +22372,7 @@ class items
 						headgear="H_Booniehat_khk_hs";
 					};
 				};
-				id=117;
+				id=116;
 				type="I_Soldier_AAR_F";
 				class CustomAttributes
 				{
@@ -22439,7 +22439,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={23.097168,0.0014390945,1.3149414};
+					position[]={23.049805,0.0014390945,1.2954102};
 				};
 				side="Independent";
 				flags=5;
@@ -22576,7 +22576,7 @@ class items
 						headgear="LOP_H_Beanie_dpmw";
 					};
 				};
-				id=118;
+				id=117;
 				type="I_Soldier_LAT_F";
 				class CustomAttributes
 				{
@@ -22643,7 +22643,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={20.097168,0.0014390945,-0.68505859};
+					position[]={20.049805,0.0014390945,-0.70458984};
 				};
 				side="Independent";
 				flags=5;
@@ -22857,7 +22857,7 @@ class items
 						headgear="rhsusf_bowman_cap";
 					};
 				};
-				id=119;
+				id=118;
 				type="I_Soldier_TL_F";
 				class CustomAttributes
 				{
@@ -22924,7 +22924,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={21.097168,0.0014390945,-0.68505859};
+					position[]={21.049805,0.0014390945,-0.70458984};
 				};
 				side="Independent";
 				flags=5;
@@ -23072,7 +23072,7 @@ class items
 						headgear="H_ShemagOpen_khk";
 					};
 				};
-				id=120;
+				id=119;
 				type="I_Soldier_AR_F";
 				class CustomAttributes
 				{
@@ -23139,7 +23139,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={22.097168,0.0014390945,-0.68505859};
+					position[]={22.049805,0.0014390945,-0.70458984};
 				};
 				side="Independent";
 				flags=5;
@@ -23342,7 +23342,7 @@ class items
 						headgear="H_Booniehat_khk_hs";
 					};
 				};
-				id=121;
+				id=120;
 				type="I_Soldier_AAR_F";
 				class CustomAttributes
 				{
@@ -23409,7 +23409,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={23.097168,0.0014390945,-0.68505859};
+					position[]={23.049805,0.0014390945,-0.70458984};
 				};
 				side="Independent";
 				flags=5;
@@ -23546,7 +23546,7 @@ class items
 						headgear="LOP_H_Beanie_dpmw";
 					};
 				};
-				id=122;
+				id=121;
 				type="I_Soldier_LAT_F";
 				class CustomAttributes
 				{
@@ -23612,7 +23612,7 @@ class items
 		class Attributes
 		{
 		};
-		id=112;
+		id=111;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -23649,7 +23649,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={9.4873047,0.0014390945,-4.4643555};
+					position[]={9.4399414,0.0014390945,-4.4838867};
 				};
 				side="Independent";
 				flags=7;
@@ -23874,7 +23874,7 @@ class items
 						headgear="LOP_H_Beanie_dpmw";
 					};
 				};
-				id=124;
+				id=123;
 				type="I_Soldier_TL_F";
 				class CustomAttributes
 				{
@@ -23974,7 +23974,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={10.487305,0.0014390945,-4.465332};
+					position[]={10.439941,0.0014390945,-4.4848633};
 				};
 				side="Independent";
 				flags=5;
@@ -24115,7 +24115,7 @@ class items
 						headgear="LOP_H_Cowboy_hat";
 					};
 				};
-				id=125;
+				id=124;
 				type="I_Soldier_AR_F";
 				class CustomAttributes
 				{
@@ -24201,7 +24201,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={11.487305,0.0014390945,-4.465332};
+					position[]={11.439941,0.0014390945,-4.4848633};
 				};
 				side="Independent";
 				flags=5;
@@ -24361,7 +24361,7 @@ class items
 						headgear="LOP_H_Beanie_dpmw";
 					};
 				};
-				id=126;
+				id=125;
 				type="I_Soldier_AAR_F";
 				class CustomAttributes
 				{
@@ -24446,7 +24446,7 @@ class items
 		class Attributes
 		{
 		};
-		id=123;
+		id=122;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -24483,7 +24483,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={15.730469,0.0014390945,-4.4995117};
+					position[]={15.683105,0.0014390945,-4.519043};
 				};
 				side="Independent";
 				flags=7;
@@ -24708,7 +24708,7 @@ class items
 						headgear="H_ShemagOpen_khk";
 					};
 				};
-				id=128;
+				id=127;
 				type="I_Soldier_TL_F";
 				class CustomAttributes
 				{
@@ -24808,7 +24808,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={16.729004,0.0014390945,-4.4975586};
+					position[]={16.681641,0.0014390945,-4.5170898};
 				};
 				side="Independent";
 				flags=5;
@@ -24966,7 +24966,7 @@ class items
 						headgear="LOP_H_Cowboy_hat";
 					};
 				};
-				id=129;
+				id=128;
 				type="I_Soldier_AT_F";
 				class CustomAttributes
 				{
@@ -25052,7 +25052,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={17.729004,0.0014390945,-4.4975586};
+					position[]={17.681641,0.0014390945,-4.5170898};
 				};
 				side="Independent";
 				flags=5;
@@ -25200,7 +25200,7 @@ class items
 						headgear="LOP_H_Beanie_dpmw";
 					};
 				};
-				id=130;
+				id=129;
 				type="I_Soldier_AAT_F";
 				class CustomAttributes
 				{
@@ -25285,7 +25285,7 @@ class items
 		class Attributes
 		{
 		};
-		id=127;
+		id=126;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -25322,7 +25322,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={9.2265625,0.0014390945,-7.1333008};
+					position[]={9.1791992,0.0014390945,-7.152832};
 				};
 				side="Independent";
 				flags=7;
@@ -25508,7 +25508,7 @@ class items
 						headgear="H_Booniehat_khk_hs";
 					};
 				};
-				id=132;
+				id=131;
 				type="I_Spotter_F";
 				class CustomAttributes
 				{
@@ -25608,7 +25608,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={10.226074,0.0014390945,-7.1342773};
+					position[]={10.178711,0.0014390945,-7.1538086};
 				};
 				side="Independent";
 				flags=4;
@@ -25774,7 +25774,7 @@ class items
 						headgear="LOP_H_Beanie_dpmw";
 					};
 				};
-				id=133;
+				id=132;
 				type="I_Sniper_F";
 				class CustomAttributes
 				{
@@ -25859,7 +25859,7 @@ class items
 		class Attributes
 		{
 		};
-		id=131;
+		id=130;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -25896,7 +25896,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={15.357422,0.0014390945,-7.1948242};
+					position[]={15.310059,0.0014390945,-7.2143555};
 				};
 				side="Independent";
 				flags=7;
@@ -26067,7 +26067,7 @@ class items
 						headgear="H_ShemagOpen_khk";
 					};
 				};
-				id=135;
+				id=134;
 				type="I_support_AMort_F";
 				class CustomAttributes
 				{
@@ -26117,7 +26117,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={16.358398,0.0014390945,-7.1948242};
+					position[]={16.311035,0.0014390945,-7.2143555};
 				};
 				side="Independent";
 				flags=5;
@@ -26265,7 +26265,7 @@ class items
 						headgear="H_Booniehat_khk_hs";
 					};
 				};
-				id=136;
+				id=135;
 				type="I_support_Mort_F";
 				class CustomAttributes
 				{
@@ -26314,7 +26314,7 @@ class items
 		class Attributes
 		{
 		};
-		id=134;
+		id=133;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -26351,7 +26351,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={20.625488,0.0014390945,-4.4604492};
+					position[]={20.578125,0.0014390945,-4.4799805};
 				};
 				side="Independent";
 				flags=7;
@@ -26524,7 +26524,7 @@ class items
 						headgear="LOP_H_Beanie_dpmw";
 					};
 				};
-				id=138;
+				id=137;
 				type="I_engineer_F";
 				class CustomAttributes
 				{
@@ -26624,7 +26624,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={21.625488,0.0014390945,-4.4604492};
+					position[]={21.578125,0.0014390945,-4.4799805};
 				};
 				side="Independent";
 				flags=5;
@@ -26791,7 +26791,7 @@ class items
 						headgear="H_ShemagOpen_khk";
 					};
 				};
-				id=139;
+				id=138;
 				type="I_engineer_F";
 				class CustomAttributes
 				{
@@ -26877,7 +26877,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={22.625488,0.0014390945,-4.4604492};
+					position[]={22.578125,0.0014390945,-4.4799805};
 				};
 				side="Independent";
 				flags=5;
@@ -27044,7 +27044,7 @@ class items
 						headgear="H_Booniehat_khk_hs";
 					};
 				};
-				id=140;
+				id=139;
 				type="I_engineer_F";
 				class CustomAttributes
 				{
@@ -27130,7 +27130,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={23.625488,0.0014390945,-4.4604492};
+					position[]={23.578125,0.0014390945,-4.4799805};
 				};
 				side="Independent";
 				flags=5;
@@ -27301,7 +27301,7 @@ class items
 						headgear="LOP_H_Cowboy_hat";
 					};
 				};
-				id=141;
+				id=140;
 				type="I_engineer_F";
 				class CustomAttributes
 				{
@@ -27386,7 +27386,7 @@ class items
 		class Attributes
 		{
 		};
-		id=137;
+		id=136;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -27423,7 +27423,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={8.9575195,0.0014390945,-9.8120117};
+					position[]={8.9101563,0.0014390945,-9.831543};
 				};
 				side="Independent";
 				flags=7;
@@ -27575,7 +27575,7 @@ class items
 						headgear="H_Booniehat_khk_hs";
 					};
 				};
-				id=143;
+				id=142;
 				type="I_crew_F";
 				class CustomAttributes
 				{
@@ -27689,7 +27689,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={9.9575195,0.0014390945,-9.8120117};
+					position[]={9.9101563,0.0014390945,-9.831543};
 				};
 				side="Independent";
 				flags=5;
@@ -27845,7 +27845,7 @@ class items
 						headgear="rhsusf_bowman_cap";
 					};
 				};
-				id=144;
+				id=143;
 				type="I_crew_F";
 				class CustomAttributes
 				{
@@ -27914,7 +27914,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={10.95752,0.0014390945,-9.8120117};
+					position[]={10.910156,0.0014390945,-9.831543};
 				};
 				side="Independent";
 				flags=5;
@@ -28056,7 +28056,7 @@ class items
 						headgear="LOP_H_Beanie_dpmw";
 					};
 				};
-				id=145;
+				id=144;
 				type="I_crew_F";
 				class CustomAttributes
 				{
@@ -28124,7 +28124,7 @@ class items
 		class Attributes
 		{
 		};
-		id=142;
+		id=141;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -28161,7 +28161,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={15.237305,0.0014390945,-10.000488};
+					position[]={15.189941,0.0014390945,-10.02002};
 				};
 				side="Independent";
 				flags=7;
@@ -28313,7 +28313,7 @@ class items
 						headgear="H_ShemagOpen_khk";
 					};
 				};
-				id=147;
+				id=146;
 				type="I_pilot_F";
 				class CustomAttributes
 				{
@@ -28446,7 +28446,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={16.237305,0.0014390945,-9.9995117};
+					position[]={16.189941,0.0014390945,-10.019043};
 				};
 				side="Independent";
 				flags=5;
@@ -28631,7 +28631,7 @@ class items
 						headgear="LOP_H_Cowboy_hat";
 					};
 				};
-				id=148;
+				id=147;
 				type="I_pilot_F";
 				class CustomAttributes
 				{
@@ -28763,7 +28763,7 @@ class items
 		class Attributes
 		{
 		};
-		id=146;
+		id=145;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -28800,7 +28800,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={18.973633,0.0014390945,-10.129395};
+					position[]={18.92627,0.0014390945,-10.148926};
 				};
 				side="Independent";
 				flags=7;
@@ -28949,7 +28949,7 @@ class items
 						headgear="H_PilotHelmetFighter_I";
 					};
 				};
-				id=150;
+				id=149;
 				type="I_pilot_F";
 				class CustomAttributes
 				{
@@ -29081,7 +29081,7 @@ class items
 		class Attributes
 		{
 		};
-		id=149;
+		id=148;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -29111,7 +29111,7 @@ class items
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={23.10498,0.28405476,-8.550293};
+			position[]={23.057617,0.28405476,-8.5698242};
 		};
 		side="Empty";
 		flags=4;
@@ -29119,7 +29119,7 @@ class items
 		{
 			init="call{[this, 200] call a3aa_fnc_boxGuard}";
 		};
-		id=151;
+		id=150;
 		type="Box_IND_Ammo_F";
 		class CustomAttributes
 		{
@@ -29150,7 +29150,7 @@ class items
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={23.157715,0.89242268,-10.932129};
+			position[]={23.110352,0.89242268,-10.95166};
 		};
 		side="Empty";
 		flags=4;
@@ -29158,7 +29158,7 @@ class items
 		{
 			init="call{[this, 200] call a3aa_fnc_boxGuard}";
 		};
-		id=152;
+		id=151;
 		type="I_supplyCrate_F";
 		class CustomAttributes
 		{
@@ -29186,17 +29186,6 @@ class items
 	};
 	class Item42
 	{
-		dataType="Comment";
-		class PositionInfo
-		{
-			position[]={18.900146,0,-7.9494629};
-		};
-		title="v1.14.2";
-		description="-v1.14.2 " \n "-GM: Fixed ""assign zeus to this unit"" not being present " \n "-All Groups: Fixed radio channel presets " \n "-Gave every unit 1 epi in Uniform, or Vest if uniform was full (medic not included) " \n "-Moved element lead LR radio to backpack " \n "-Added mortar supply crate " \n "-DMT: Removed NVG scope, and replaced main scope with one that can be used with goggles. " \n "-Gave engineers more ammo (1 tracer + 1 for members, 2 tracer for leader)" \n "" \n "-v1.14.1" \n " - A3EE box guard updated to A3AA." \n " - Custom location re-added." \n "" \n "- v1.14.0 " \n "PL: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Boonie Hat"" for more visual diversity in the platoon and to bring PL headgear in line with RU and US Standard Factions. " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n "  - Removed CNTO ""Beret"" from Backpack gear due to old logo texture. " \n " " \n "Platoon Sergeant: " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n "  - Backpack added 3CB ""Radio Backpack MR3000"" and filled it with the ACRE2 ""AN/PRC-117F"" backpack radio. This gives more incentive to bring the PLT Sgt along since he is the only one who can act as a max range radio man for the platoon. " \n " " \n "Platoon Medic: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n " " \n "Platoon Rifleman: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n " " \n "Squad Medic: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n " " \n "FTL: " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n " " \n "AR: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n "  - Added muzzle attachment RHS ""SF3P-556 1/2-28"". " \n " " \n "AAR: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n " " \n "LAT: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n " " \n "MMG Teamleader: " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n " " \n "MMG Gunner: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n "  - Unfortunately no muzzle attachments available for the MG-3! " \n " " \n "MMG Asst. Gunner: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n " " \n "MAT Teamleader: " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n " " \n "MAT Gunner: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n " " \n "MAT Asst. Gunner: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n " " \n "ENG Leader: " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Heavy"" to differentiate ENG from the rest of the platoon. " \n " " \n "ENG Rifleman: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Heavy"" to differentiate ENG from the rest of the platoon. " \n " " \n "Mortar Leader: " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Special"" to visually differentiate the Mortar Team from the rest of the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n "  - Reduced STANAG mags from 10 to 5 to match the ENG ammo count. " \n " " \n "Mortar Gunner: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Special"" to visually differentiate the Mortar Team from the rest of the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n "  - Reduced STANAG mags from 10 to 5 to match the ENG ammo count. " \n " " \n "DMT Leader " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n " " \n "DMT Marksman " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n "  - Added NVG scope RHS ""AN/PVS-27"" to the vest gear. " \n " " \n "Zeus & Co-Zeus " \n "  - Uniform changed from vanilla ""VR Suit Indie"" to CNTO ""Flecktarn Recon"" to make Zeus look a bit more like an HQ commander than a Tron character. " \n "  - Facewear changed from vanilla ""VR Goggles"" to vanilla ""Aviator Glasses"". " \n "  - Insignia added ""Zeus"". " \n " " \n "All Units: " \n "  - Disabled LAMBS AI " \n " " \n "Alpha SL: " \n "  - Enabled ""is Player"". This makes it easier for Mission Makers to quickly test a mission in the editor by just hitting ""play"" instead of having to select a specific unit every time beforehand to avoid ending up in spectator mode by default. " \n " " \n "Crates: " \n "  - Added an ACE3 medical crate with our usual base script. " \n " " \n " " \n "- v1.13.6 " \n "  - ALL Added persistent Call-Signs for all GM's (where not included in v1.13.4) " \n "  - ALL Added the code `this disableAI ""MOVE""; this setSpeaker ""NoVoice""; enableRadio false;` to all playable units to prevent them from running off and spamming the vanilla-radio during local testing. " \n "  - ALL Changed persistent call-signs (map markers) to a consistent formula: ≤ 2 syllables = written out call-sing. ≥ 3 syllables = abbreviated call-sign. " \n "  - ALL Added full changelog to all factions for quick in-game reference " \n "  - TFN Added new yellow owl insignia patches to all uniforms " \n " " \n " " \n "- v1.13.5 " \n "  - ALL Added respective GM's to Standard Faction Compositions for convenience / time saving  " \n "  - ALL Added base clean-up module to Standard Faction Compositions to ensure Mission Makers don't forget it in the future - radius set to 200x200 meters " \n " " \n " " \n "- v1.13.4  " \n "  - ALL Added @ Squad/Team names to leaders so that Team name appears in role select " \n "  - TFN Changed M249 to the FN MINIMI " \n " " \n " " \n "- v1.13.3 " \n "  - US Added Improved Bipod/SAW Grip to AR M249 " \n "  - US Removed M14 Mags " \n "  - TFN Added Bipod to M249 " \n " " \n " " \n "- v1.13.2 " \n "  - ALL Added 1 Extra Tourniquet to every Unit " \n "  - TFN DMT Lead Rifle Changed to D10 Version " \n "  - TFN DMT given extra pistol mag to bring in line with other units " \n "  - TFN AAR Weapon changed to HK416 D14.5 " \n "  - TFN Lead Elements Given AN/PEQ-16A's " \n "  - US Alpha Fireteam 2 AAR vest changed to ALT variant to match rest of faction " \n "  - US Lead Elements Given AN/PEQ-16A's " \n "  - US DMT given extra pistol mag to bring in line with other units " \n "  - US DMT Sniper Rifle Given SU-260/P (MDO) to bring zoom level to the same as Russian and TFN factions " \n "  - US DMT Bipod Changed to Harris Bipod " \n "  - US DMT Marksman Rifle changed to black version of same rifle " \n "  - US DMT Marksman Magazines changed to SR-25 version, as RHS hotfix made M14 mags incompatible with MK11 " \n "  - RUS DMT given extra pistol mag to bring in line with other units " \n "  - RUS DGR Helmets changed to TSH-4 to make distinct from US Helmets " \n "  - RUS NB Helmets changed to ZSH-7A to make distinct from US and TFN helmets " \n "  - RUS Removed RIS Rail adaptors from AK rifles " \n "  - RUS Added PG-7V rocket to MAT ammo crate. This rocket is lighter and packs less payload than the PG-7VL. This gives it an  increased effective range but is less powerful due to decreased payload " \n " " \n " " \n "- v1.12.2 " \n "  - Hotfixed US Vests across the Squads to match V.12 changes. Whoops. " \n "  - Added Angled Grip to TFN HK416s where possible.  " \n " " \n " " \n "- v1.12 " \n "  - Fixed TFN MMG Ammo preloaded into Rifle to 100RND mag from 50rnd. " \n "  - Fixed TFN DMT Marksman Ammo loaded into Rifle to correct SBLR mag. " \n "  - Changed TFN DMT Lead Suppressor to QDSS NT4 Black from Rotex-5 Grey " \n "  - Changed TFN Dagger Uniforms from Gorka R Green to FFCP Green Fatigues [RS] " \n "  - Changed US PLT Commander + Squad Leader Vest from SPCS Rifleman/OEF- CP to SPCS Squad Lead/OEF-CP " \n "  - Changed US Medic Vest from SPCS Rifleman/OEF-CP to SPCS Medic/OEF-CP " \n "  - Changed US PLT Rifleman Vest from SPCS OEF-CP to SPCS Rifleman Alt/OEF-CP " \n "  - Changed US FTL Vest from SPCS Rifleman/OEF-CP to SPCS Team Leader Alt/OEF-CP " \n "  - Changed US AR Vest from SPCS Rifleman/OEF-CP to SPCS SAW/OEF-CP " \n "  - Changed US AAR Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP " \n "  - Changed US Rifleman AT Vest from SPCS OEF-CP to SPCS Rifleman Alt/OEF-CP " \n "  - Changed US MAT/MMG/DMT/ENG/MTR Lead Vest from SPCS Rifleman/OEF-CP to SPCS Team Leader Alt/OEF-CP " \n "  - Changed US MMG Gunner Vest from SPCS Rifleman/OEF-CP to SPCS Machinegunner/OEF-CP " \n "  - Changed US MMG/MAT Ammo Bearer Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP " \n "  - Changed US MAT Gunner Vest from SPCS OEF-CP to SPCS Rifleman Alt/OEF-CP " \n "  - Changed US DMT Marksman vest from SPCS OEF-CP to SPCS Sniper/OEF-CP " \n "  - Fixed US DMT Marksman Rifle Loaded Mag to correct varient. " \n "  - Changed US Engineer Rifleman Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP. " \n "  - Changed US MTR Gunner Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP. " \n "  - Changed US DGR Uniforms from FFCP ACU Fatigues to FFCP ACU Fatigues [RS] " \n "  - Changed US DGR Driver Backpack from Assault Pack Green to Assault Pack Black " \n "  - Changed US Heli Pilot/Copilot Uniforms from Heli pilot Coveralls to FFCP Nomad Fatigues [RS] " \n "  - Fixed US Heli/Jet Pilot Vest White Smoke grenade count to 2. " \n "  - Changed US Heli Pilot/Copilot Helmet from Heli Pilot NATO to HGU-56/P (Black/Visor) " \n "  - Changed US Jet Pilot Uniform from Pilot Coveralls NATO to  FFCP Nomad Fatigues " \n "  - Changed RUS Vic/Heli/Jet Crew Weapons to PP-2000 " \n "  - Upped RUS PP-2000 Ammo counts to 6x Mag to bring in line with ammo counts for TFN and US. " \n "  - Changed RUS Heli Pilot Uniforms from Pilot Coveralls CSAT to FFCP-Fatigues EMR [RS] " \n "  - Changed RUS Heli Pilot Vest from 6B23 (6Sh116) to FFCP Tactical Vest TigerVRS " \n "  - Changed RUS Jet Pilot Uniforms from Pilot Coveralls CSAT to FFCP-Fatigues EMR [RS] " \n "  - Changed RUS Jet Pilot Vest from 6B23 (6Sh116) to FFCP Tactical Vest TigerVRS " \n " " \n " " \n "- v1.11 " \n "  - changed m40 mini grenades to m67 fragmentation " \n "  - replaced mp7 weapons with mp5k-pdw " \n "  - changed ak105 to ak74m (plum)  " \n "  - changed PKM to PKP " \n "  - changed RUS PKM ammo boxes. MMG now loads with 7TZ (AP rounds) " \n "  - added vert grip to us weapons " \n "  - replaced m14 with HK PSG1A1 " \n "  - replaced m260e4 with mg3 " \n "  - updated all ammo boxes respectively.  " \n " " \n " " \n "- v1.10 " \n "  - changed Medic loadouts from 6 x 1000ml blood bags to 2 x 1000ml and 8 x 500ml. " \n " " \n " " \n "- v1.09 " \n "  - updated Fireteam colours A1 Red A2 Yellow, B1 Green B2 Blue, C1 Red C2 Yellow. " \n " " \n " " \n "- v1.08 " \n "  - changed ""Reaper"" to ""Nightbird"", ""RPR"" to ""NB"" " \n "  - changed ""Paladin"" to ""Falcon"", ""PAL"" to ""FC"" " \n "  - changed ""DAGGER"" to ""DGR"" " \n " " \n " " \n "- v1.07 " \n "  - US and RU faction bumped to v1.07 to avoid confusion regarding version numbers (US and RU was 1.05, TFN was 1.06) " \n "  - overhauled the RU faction: updated helmets, uniforms, weapons to a more modern look " \n "  - overhauled the US faction: updated helmets and vests to armour rating of IV " \n "  - corrected some mistakes in all factions (grenade ammount of MMG gunner, ENG not having tourniquetes, DGR not having GPS-s) " \n "  - overhauled the medics of all factions to reflect recent cahnges to ACE medical (less QuikClots, more Elastic Bandages, etc.) " \n " " \n " " \n "- v1.05 " \n "  - Added a MAT ammo box on spawn. " \n " " \n " " \n "- v1.04 " \n "  - All MAT Teams carrying RPG's got the ver3 scopes with ranges for all types " \n "    of ammo. " \n "  - All Callsigns were changed to be uniformed throught no matter the faction. " \n " " \n " " \n "- v1.03 " \n "  - set crew driver/gunner and pilot/copilot/jetpilot as Engineers through the " \n "    Object: ACE Options menu in unit attributes " \n "  - overhauled the TFN faction (weapons, helmets, etc.), changes not applicable " \n "    to derived factions " \n " " \n " " \n "- v1.02 " \n "  - loadout overhaul for DMT, made them lighter + gave them tools for recon " \n "  - specified preset ACRE2 radio channels for most units " \n " " \n " " \n "- v1.01 " \n "  - updated team colors func to `a3ee_team_colors_fnc_setColor`, just load+save " \n "    the composition in editor, this fixes it " \n "  - changed RPG-7 using MAT teams to carry Kitbags " \n "  - removed one PKM ammo box from AAR, MMG gunner, MMG bearer (fixes overload) " \n "  - moved 1-2 AR boxes from AAR to AR, gave AR an Assaultpack " \n "  - added 1-2 more AR boxes to AR's Assaultpack (if enough space) " \n "  - changed HEDP to HE rockets for Carl Gustav (M3MAAWS) " \n "  - changed US crew uniform and helmet to match grey color scheme of US pilots " \n "  - changed backpacks of driver/copilot to use less contrasting colors compared " \n "    to their respective uniform/vest colors " \n "  - changed Carryall backpacks of TFN Engineers to use custom Flecktarn Carryall " \n "  - changed all (GP-25 and normal) AK74m rifles to be the non-NPZ variants " \n "  - removed secondary long-range (PRC148) from Engineers " \n " " \n " " \n "- v1.00 (and before) " \n "  - added a Comment object with version number (`v1.00`) " \n "  - added `respawn_west`, `respawn_east`, `respawn_guerrila` markers " \n "  - added `[this, 200] call a3ee_fnc_boxGuard` to init lines of resupply boxes " \n "  - added `Resupply` green triangle markers on the position of resupply boxes";
-		id=153;
-	};
-	class Item43
-	{
 		dataType="Group";
 		side="Independent";
 		class Entities
@@ -29207,7 +29196,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={20.625488,0.0014390945,-7.1948242};
+					position[]={20.578125,0.0014390945,-7.2143555};
 				};
 				side="Independent";
 				flags=7;
@@ -29280,7 +29269,7 @@ class items
 						headgear="H_ShemagOpen_khk";
 					};
 				};
-				id=155;
+				id=154;
 				type="I_Protagonist_VR_F";
 				class CustomAttributes
 				{
@@ -29413,7 +29402,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={21.625488,0.0014390945,-7.1948242};
+					position[]={21.578125,0.0014390945,-7.2143555};
 				};
 				side="Independent";
 				flags=5;
@@ -29486,7 +29475,7 @@ class items
 						headgear="rhsusf_bowman_cap";
 					};
 				};
-				id=156;
+				id=155;
 				type="I_Protagonist_VR_F";
 				class CustomAttributes
 				{
@@ -29618,7 +29607,7 @@ class items
 		class Attributes
 		{
 		};
-		id=154;
+		id=153;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -29643,12 +29632,12 @@ class items
 			nAttributes=1;
 		};
 	};
-	class Item44
+	class Item43
 	{
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={23.536621,0,-6.8754883};
+			position[]={23.489258,0,-6.8950195};
 		};
 		side="Empty";
 		flags=4;
@@ -29656,7 +29645,7 @@ class items
 		{
 			init="call{[this, 200] call a3aa_fnc_boxGuard}";
 		};
-		id=157;
+		id=156;
 		type="ACE_medicalSupplyCrate";
 		class CustomAttributes
 		{
@@ -29682,32 +29671,48 @@ class items
 			nAttributes=1;
 		};
 	};
+	class Item44
+	{
+		dataType="Comment";
+		class PositionInfo
+		{
+			position[]={-15.501465,0,6.7587891};
+		};
+		title="WESTERN PMC";
+		id=157;
+	};
 	class Item45
 	{
 		dataType="Comment";
 		class PositionInfo
 		{
-			position[]={-15.454102,0,6.7783203};
+			position[]={16.498535,0,6.7587891};
 		};
-		title="WESTERN PMC";
+		title="EASTERN PMC";
 		id=158;
 	};
 	class Item46
 	{
-		dataType="Comment";
+		dataType="Object";
 		class PositionInfo
 		{
-			position[]={16.545898,0,6.7783203};
+			position[]={9.4985352,0.79142618,16.759277};
 		};
-		title="EASTERN PMC";
+		side="Empty";
+		flags=4;
+		class Attributes
+		{
+			disableSimulation=1;
+		};
 		id=159;
+		type="Land_Noticeboard_F";
 	};
 	class Item47
 	{
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={9.5458984,0.79142618,16.778809};
+			position[]={16.498535,0.79142618,16.759277};
 		};
 		side="Empty";
 		flags=4;
@@ -29720,28 +29725,22 @@ class items
 	};
 	class Item48
 	{
-		dataType="Object";
+		dataType="Comment";
 		class PositionInfo
 		{
-			position[]={16.545898,0.79142618,16.778809};
+			position[]={9.4985352,0,17.759277};
 		};
-		side="Empty";
-		flags=4;
-		class Attributes
-		{
-			disableSimulation=1;
-		};
+		title="Standard Rifles";
 		id=161;
-		type="Land_Noticeboard_F";
 	};
 	class Item49
 	{
 		dataType="Comment";
 		class PositionInfo
 		{
-			position[]={9.5458984,0,17.778809};
+			position[]={16.498535,0,17.759277};
 		};
-		title="Standard Rifles";
+		title="SL & FTLS";
 		id=162;
 	};
 	class Item50
@@ -29749,27 +29748,17 @@ class items
 		dataType="Comment";
 		class PositionInfo
 		{
-			position[]={16.545898,0,17.778809};
+			position[]={23.498047,0,17.759277};
 		};
-		title="SL & FTLS";
+		title="DMT";
 		id=163;
 	};
 	class Item51
 	{
-		dataType="Comment";
-		class PositionInfo
-		{
-			position[]={23.54541,0,17.778809};
-		};
-		title="DMT";
-		id=164;
-	};
-	class Item52
-	{
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={23.54541,0.79142618,16.778809};
+			position[]={23.498047,0.79142618,16.759277};
 		};
 		side="Empty";
 		flags=4;
@@ -29777,15 +29766,26 @@ class items
 		{
 			disableSimulation=1;
 		};
-		id=165;
+		id=164;
 		type="Land_Noticeboard_F";
+	};
+	class Item52
+	{
+		dataType="Marker";
+		position[]={9.4985352,0.29708433,15.759277};
+		name="Rifles_9";
+		text="Rifles";
+		type="mil_triangle";
+		colorName="ColorGreen";
+		angle=2.177;
+		id=165;
 	};
 	class Item53
 	{
 		dataType="Marker";
-		position[]={9.5458984,0.29708433,15.778809};
-		name="Rifles_9";
-		text="Rifles";
+		position[]={16.498535,0.29708433,15.759277};
+		name="Rifles_10";
+		text="SL & FTLS";
 		type="mil_triangle";
 		colorName="ColorGreen";
 		angle=2.177;
@@ -29794,9 +29794,9 @@ class items
 	class Item54
 	{
 		dataType="Marker";
-		position[]={16.545898,0.29708433,15.778809};
-		name="Rifles_10";
-		text="SL & FTLS";
+		position[]={23.498047,0.29708433,15.759277};
+		name="Rifles_11";
+		text="DMT";
 		type="mil_triangle";
 		colorName="ColorGreen";
 		angle=2.177;
@@ -29804,21 +29804,10 @@ class items
 	};
 	class Item55
 	{
-		dataType="Marker";
-		position[]={23.54541,0.29708433,15.778809};
-		name="Rifles_11";
-		text="DMT";
-		type="mil_triangle";
-		colorName="ColorGreen";
-		angle=2.177;
-		id=168;
-	};
-	class Item56
-	{
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={21.545898,0.14963102,-9.2211914};
+			position[]={21.498535,0.14963102,-9.2407227};
 			angles[]={-0,1.5418237,0};
 		};
 		side="Empty";
@@ -29826,7 +29815,7 @@ class items
 		class Attributes
 		{
 		};
-		id=169;
+		id=168;
 		type="Box_East_WpsLaunch_F";
 		class CustomAttributes
 		{
@@ -29852,23 +29841,23 @@ class items
 			nAttributes=1;
 		};
 	};
-	class Item57
+	class Item56
 	{
 		dataType="Marker";
-		position[]={22.54541,0.035955906,-9.2211914};
+		position[]={22.498047,0.036262512,-9.2407227};
 		name="resupply_marker_3";
 		text="Resupply";
 		type="mil_triangle";
 		colorName="ColorGreen";
-		id=170;
+		id=169;
 		atlOffset=0.00015306473;
 	};
-	class Item58
+	class Item57
 	{
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={-8.4545898,0.1566577,15.778809};
+			position[]={-8.5019531,0.1566577,15.759277};
 			angles[]={-0,4.7261076,0};
 		};
 		side="Empty";
@@ -29876,6 +29865,47 @@ class items
 		class Attributes
 		{
 			init="call{{    " \n "    _x params [""_classname"", ""_text""];    " \n "    this addAction [    " \n "        _text,    " \n "  {if (count ((player weaponAccessories primaryWeapon player)-[""""]) != 0) then {hint ""Remove weapon attachments before changing weapon""} else {player addWeapon (_this select 3), player addItemToVest ""20Rnd_762x51_Mag""}; " \n "  },    " \n "  _classname, 0.1, true, true, """", ""typeOf _this in ['I_Sniper_F']"",3   " \n "    ];    " \n "} forEach [    " \n "   " \n "[""srifle_EBR_F"",""<t color='#e6e600'>M18 ABR</t>""],   " \n "[""arifle_SPAR_03_blk_F"",""<t color='#ff0000'>SPAR 7.62 DMR Black</t>""],     " \n "[""arifle_SPAR_03_khk_F"",""<t color='#009933'>SPAR 7.62 DMR Woodland</t>""],    " \n "[""arifle_SPAR_03_snd_F"",""<t color='e6e600'>SPAR 7.62 DMR Sand</t>""],    " \n "[""srifle_DMR_06_olive_F"",""<t color='#e6e600'>Mk14 DMR Woodland</t>""],    " \n "[""srifle_DMR_06_camo_F"",""<t color='#e6e600'>Mk14 DMR Sand</t>""],    " \n "[""srifle_DMR_03_tan_F"",""<t color='#e6e600'>Mk1 EMR Sand""],    " \n "[""srifle_DMR_03_khaki_F"",""<t color='#009933'>Mk1 EMR Woodland</t>""],    " \n "[""srifle_DMR_03_multicam_F"",""<t color='#ff0000'>Mk1 EMR Camo 1</t>""],   " \n "[""srifle_DMR_03_multicam_F"",""<t color='#ff0000'>Mk1 EMR Camo 2</t>""],   " \n "[""hlc_rifle_M14dmr_Rail"",""<t color='#ff0000'>M14 DMR Black</t>""]   " \n "   " \n "];}";
+			disableSimulation=1;
+		};
+		id=170;
+		type="Land_PlasticCase_01_small_F";
+		class CustomAttributes
+		{
+			class Attribute0
+			{
+				property="ammoBox";
+				expression="[_this,_value] call bis_fnc_initAmmoBox;";
+				class Value
+				{
+					class data
+					{
+						class type
+						{
+							type[]=
+							{
+								"STRING"
+							};
+						};
+						value="[[[[],[]],[[],[]],[[],[]],[[],[]]],false]";
+					};
+				};
+			};
+			nAttributes=1;
+		};
+	};
+	class Item58
+	{
+		dataType="Object";
+		class PositionInfo
+		{
+			position[]={9.4980469,0.1566577,15.759277};
+			angles[]={-0,4.7261076,0};
+		};
+		side="Empty";
+		flags=4;
+		class Attributes
+		{
+			init="call{{   " \n "    _x params [""_classname"", ""_text""];   " \n "    this addAction [   " \n "        _text,   " \n "  {player addWeapon (_this select 3), player addItemToVest ""rhs_30Rnd_545x39_7N22_AK"", player addPrimaryWeaponItem ""rhs_acc_dtk""},   " \n "  _classname, 0.1, true, true, """", ""typeOf _this in ['I_medic_F', 'I_soldier_F', 'I_Soldier_AAR_F', 'I_Soldier_LAT_F', 'I_Soldier_AT_F', 'I_Soldier_AAT_F', 'I_engineer_F', 'I_crew_F', 'I_support_MORT_F', 'I_support_AMORT_F']"",3    " \n "    ];   " \n "} forEach [   " \n "  " \n "[""rhs_weap_ak105"",""<t color='#ff0000'>AK 105</t>""],     " \n "[""rhs_weap_ak105_npz"",""<t color='#009933'>AK 105 - Rail mod</t>""],    " \n "[""rhs_weap_ak105_zenitco01"",""<t color='#009933'>AK 105 Zentico</t>""],    " \n "[""rhs_weap_ak105_zenitco01_b33"",""<t color='#e6e600'>AK 105 Zentico - Rail mod</t>""],    " \n "[""rhs_weap_ak74"",""<t color='#e6e600'>AK 74</t>""],    " \n "[""rhs_weap_ak74m_camo"",""<t color='#e6e600'>AK74M Camo</t>""],    " \n "[""rhs_weap_ak74m_desert_npz"",""<t color='#009933'>AK74M Desert - Rail mod</t>""],    " \n "[""rhs_weap_ak74mr"",""<t color='#e6e600'>AK74MR</t>""],    " \n "[""hlc_rifle_ak12"",""<t color='#009933'>AK12</t>""],    " \n "[""hlc_rifle_aku12"",""<t color='#ff0000'>AK12U</t>""],    " \n "[""hlc_rifle_ak74m"",""<t color='#ff0000'>AK74M</t>""],    " \n "[""hlc_rifle_aks74"",""<t color='#ff0000'>AKS74</t>""],      " \n "[""hlc_rifle_aek971_mtk"",""<t color='#e6e600'>AEK971</t>""]  " \n "  " \n "]; " \n "}";
 			disableSimulation=1;
 		};
 		id=171;
@@ -29909,14 +29939,14 @@ class items
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={9.5454102,0.1566577,15.778809};
+			position[]={16.498047,0.1566577,15.759277};
 			angles[]={-0,4.7261076,0};
 		};
 		side="Empty";
 		flags=4;
 		class Attributes
 		{
-			init="call{{   " \n "    _x params [""_classname"", ""_text""];   " \n "    this addAction [   " \n "        _text,   " \n "  {player addWeapon (_this select 3), player addItemToVest ""rhs_30Rnd_545x39_7N22_AK"", player addPrimaryWeaponItem ""rhs_acc_dtk""},   " \n "  _classname, 0.1, true, true, """", ""typeOf _this in ['I_medic_F', 'I_soldier_F', 'I_Soldier_AAR_F', 'I_Soldier_LAT_F', 'I_Soldier_AT_F', 'I_Soldier_AAT_F', 'I_engineer_F', 'I_crew_F', 'I_support_MORT_F', 'I_support_AMORT_F']"",3    " \n "    ];   " \n "} forEach [   " \n "  " \n "[""rhs_weap_ak105"",""<t color='#ff0000'>AK 105</t>""],     " \n "[""rhs_weap_ak105_npz"",""<t color='#009933'>AK 105 - Rail mod</t>""],    " \n "[""rhs_weap_ak105_zenitco01"",""<t color='#009933'>AK 105 Zentico</t>""],    " \n "[""rhs_weap_ak105_zenitco01_b33"",""<t color='#e6e600'>AK 105 Zentico - Rail mod</t>""],    " \n "[""rhs_weap_ak74"",""<t color='#e6e600'>AK 74</t>""],    " \n "[""rhs_weap_ak74m_camo"",""<t color='#e6e600'>AK74M Camo</t>""],    " \n "[""rhs_weap_ak74m_desert_npz"",""<t color='#009933'>AK74M Desert - Rail mod</t>""],    " \n "[""rhs_weap_ak74mr"",""<t color='#e6e600'>AK74MR</t>""],    " \n "[""hlc_rifle_ak12"",""<t color='#009933'>AK12</t>""],    " \n "[""hlc_rifle_aku12"",""<t color='#ff0000'>AK12U</t>""],    " \n "[""hlc_rifle_ak74m"",""<t color='#ff0000'>AK74M</t>""],    " \n "[""hlc_rifle_aks74"",""<t color='#ff0000'>AKS74</t>""],      " \n "[""hlc_rifle_aek971_mtk"",""<t color='#e6e600'>AEK971</t>""]  " \n "  " \n "]; " \n "}";
+			init="call{{   " \n "    _x params [""_classname"", ""_text""];   " \n "    this addAction [   " \n "        _text,   " \n "  {player addWeapon (_this select 3), player addItemToVest ""rhs_30Rnd_545x39_7N22_AK"", player addItemToBackpack ""rhs_VOG25"", player addPrimaryWeaponItem ""rhs_acc_dtk""},  " \n "  _classname, 0.1, true, true, """", ""typeOf _this in ['I_officer_F', 'I_Soldier_SL_F', 'I_Soldier_TL_F', 'I_Spotter_F']"",3 " \n "    ];   " \n "} forEach [   " \n "  " \n "[""rhs_weap_ak74_gp25"",""<t color='#ff0000'>AK74 GL</t>""],    " \n "[""rhs_weap_ak74mr_gp25"",""<t color='#009933'>AK74MR 21 GL</t>""],   " \n "[""hlc_rifle_ak12GL"",""<t color='#009933'>AK12 GL</t>""],   " \n "[""hlc_rifle_ak74m_gl"",""<t color='#e6e600'>AK74M GL</t>""],  " \n "[""hlc_rifle_aks74_GL"",""<t color='#e6e600'>AKS74 GL</t>""]  " \n "  " \n "];}";
 			disableSimulation=1;
 		};
 		id=172;
@@ -29950,14 +29980,14 @@ class items
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={16.54541,0.1566577,15.778809};
+			position[]={-22.501953,0.1566577,15.758789};
 			angles[]={-0,4.7261076,0};
 		};
 		side="Empty";
 		flags=4;
 		class Attributes
 		{
-			init="call{{   " \n "    _x params [""_classname"", ""_text""];   " \n "    this addAction [   " \n "        _text,   " \n "  {player addWeapon (_this select 3), player addItemToVest ""rhs_30Rnd_545x39_7N22_AK"", player addItemToBackpack ""rhs_VOG25"", player addPrimaryWeaponItem ""rhs_acc_dtk""},  " \n "  _classname, 0.1, true, true, """", ""typeOf _this in ['I_officer_F', 'I_Soldier_SL_F', 'I_Soldier_TL_F', 'I_Spotter_F']"",3 " \n "    ];   " \n "} forEach [   " \n "  " \n "[""rhs_weap_ak74_gp25"",""<t color='#ff0000'>AK74 GL</t>""],    " \n "[""rhs_weap_ak74mr_gp25"",""<t color='#009933'>AK74MR 21 GL</t>""],   " \n "[""hlc_rifle_ak12GL"",""<t color='#009933'>AK12 GL</t>""],   " \n "[""hlc_rifle_ak74m_gl"",""<t color='#e6e600'>AK74M GL</t>""],  " \n "[""hlc_rifle_aks74_GL"",""<t color='#e6e600'>AKS74 GL</t>""]  " \n "  " \n "];}";
+			init="call{{  " \n "    _x params [""_classname"", ""_text""];    " \n "    this addAction [    " \n "        _text,    " \n "  {player addWeapon (_this select 3), player addItemToVest ""rhs_mag_30Rnd_556x45_M855A1_Stanag"", player addPrimaryWeaponItem ""rhsusf_acc_M952V""},    " \n "  _classname, 0.1, true, true, """", ""typeOf _this in ['I_medic_F', 'I_soldier_F', 'I_Soldier_AAR_F', 'I_Soldier_LAT_F', 'I_Soldier_AT_F', 'I_Soldier_AAT_F', 'I_engineer_F', 'I_crew_F', 'I_support_MORT_F', 'I_support_AMORT_F']"",3  " \n "    ];    " \n "} forEach [    " \n "   " \n "[""arifle_Mk20C_plain_F"",""<t color='#ff0000'>Mk20 Carbine</t>""],      " \n "[""arifle_TRG21_F"",""<t color='#009933'>TRG 21</t>""],     " \n "[""arifle_SPAR_01_khk_F"",""<t color='#009933'>SPAR Woodland</t>""],     " \n "[""arifle_SPAR_01_snd_F"",""<t color='#e6e600'>SPAR Sand</t>""],     " \n "[""rhs_weap_hk416d145_d"",""<t color='#e6e600'>HK416 Sand</t>""],     " \n "[""rhs_weap_m4a1_blockII_d"",""<t color='#e6e600'>M4A1 Sand</t>""],     " \n "[""rhs_weap_m4a1_blockII_wd"",""<t color='#009933'>M4A1 Woodland</t>""],     " \n "[""rhs_weap_mk18_KAC_d"",""<t color='#e6e600'>Mk18 Sand</t>""],     " \n "[""rhs_weap_mk18_KAC_wd"",""<t color='#009933'>Mk18 Woodland</t>""],     " \n "[""hlc_rifle_RU5562"",""<t color='#ff0000'>Sanitiser</t>""],     " \n "[""hlc_rifle_RU556"",""<t color='#ff0000'>Liquidator</t>""],     " \n "[""hlc_rifle_bcmjack"",""<t color='#ff0000'>Jack</t>""],     " \n "[""hlc_rifle_ACR_SBR_green"",""<t color='#009933'>ACR Woodland</t>""],     " \n "[""hlc_rifle_ACR_SBR_tan"",""<t color='#e6e600'>ACR Sand</t>""]   " \n "   " \n "];}";
 			disableSimulation=1;
 		};
 		id=173;
@@ -29991,14 +30021,14 @@ class items
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={-22.454834,0.1566577,15.778564};
+			position[]={23.498047,0.1566577,15.759277};
 			angles[]={-0,4.7261076,0};
 		};
 		side="Empty";
 		flags=4;
 		class Attributes
 		{
-			init="call{{  " \n "    _x params [""_classname"", ""_text""];    " \n "    this addAction [    " \n "        _text,    " \n "  {player addWeapon (_this select 3), player addItemToVest ""rhs_mag_30Rnd_556x45_M855A1_Stanag"", player addPrimaryWeaponItem ""rhsusf_acc_M952V""},    " \n "  _classname, 0.1, true, true, """", ""typeOf _this in ['I_medic_F', 'I_soldier_F', 'I_Soldier_AAR_F', 'I_Soldier_LAT_F', 'I_Soldier_AT_F', 'I_Soldier_AAT_F', 'I_engineer_F', 'I_crew_F', 'I_support_MORT_F', 'I_support_AMORT_F']"",3  " \n "    ];    " \n "} forEach [    " \n "   " \n "[""arifle_Mk20C_plain_F"",""<t color='#ff0000'>Mk20 Carbine</t>""],      " \n "[""arifle_TRG21_F"",""<t color='#009933'>TRG 21</t>""],     " \n "[""arifle_SPAR_01_khk_F"",""<t color='#009933'>SPAR Woodland</t>""],     " \n "[""arifle_SPAR_01_snd_F"",""<t color='#e6e600'>SPAR Sand</t>""],     " \n "[""rhs_weap_hk416d145_d"",""<t color='#e6e600'>HK416 Sand</t>""],     " \n "[""rhs_weap_m4a1_blockII_d"",""<t color='#e6e600'>M4A1 Sand</t>""],     " \n "[""rhs_weap_m4a1_blockII_wd"",""<t color='#009933'>M4A1 Woodland</t>""],     " \n "[""rhs_weap_mk18_KAC_d"",""<t color='#e6e600'>Mk18 Sand</t>""],     " \n "[""rhs_weap_mk18_KAC_wd"",""<t color='#009933'>Mk18 Woodland</t>""],     " \n "[""hlc_rifle_RU5562"",""<t color='#ff0000'>Sanitiser</t>""],     " \n "[""hlc_rifle_RU556"",""<t color='#ff0000'>Liquidator</t>""],     " \n "[""hlc_rifle_bcmjack"",""<t color='#ff0000'>Jack</t>""],     " \n "[""hlc_rifle_ACR_SBR_green"",""<t color='#009933'>ACR Woodland</t>""],     " \n "[""hlc_rifle_ACR_SBR_tan"",""<t color='#e6e600'>ACR Sand</t>""]   " \n "   " \n "];}";
+			init="call{{   " \n "    _x params [""_classname"", ""_text""];   " \n "    this addAction [   " \n "        _text,   " \n "  {if (count ((player weaponAccessories primaryWeapon player)-[""""]) != 0) then {hint ""Remove weapon attachments before changing weapon""} else {player addWeapon (_this select 3), player addItemToVest ""10Rnd_762x54_Mag""}; " \n "  },   " \n "  _classname, 0.1, true, true, """", ""typeOf _this in ['I_Sniper_F']"",3 " \n "    ];   " \n "} forEach [   " \n "  " \n "[""rhs_weap_svdp_wd"",""<t color='#e6e600'>SVD Camo</t>""],  " \n "[""rhs_weap_svds_npz"",""<t color='#ff0000'>SVD Blk - Rail mod</t>""],  " \n "[""UK3CB_SVD_OLD"",""<t color='#ff0000'>Dragunov</t>""]  " \n "  " \n "];}";
 			disableSimulation=1;
 		};
 		id=174;
@@ -30032,14 +30062,14 @@ class items
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={23.54541,0.1566577,15.778809};
+			position[]={-15.501953,0.1566577,15.759277};
 			angles[]={-0,4.7261076,0};
 		};
 		side="Empty";
 		flags=4;
 		class Attributes
 		{
-			init="call{{   " \n "    _x params [""_classname"", ""_text""];   " \n "    this addAction [   " \n "        _text,   " \n "  {if (count ((player weaponAccessories primaryWeapon player)-[""""]) != 0) then {hint ""Remove weapon attachments before changing weapon""} else {player addWeapon (_this select 3), player addItemToVest ""10Rnd_762x54_Mag""}; " \n "  },   " \n "  _classname, 0.1, true, true, """", ""typeOf _this in ['I_Sniper_F']"",3 " \n "    ];   " \n "} forEach [   " \n "  " \n "[""rhs_weap_svdp_wd"",""<t color='#e6e600'>SVD Camo</t>""],  " \n "[""rhs_weap_svds_npz"",""<t color='#ff0000'>SVD Blk - Rail mod</t>""],  " \n "[""UK3CB_SVD_OLD"",""<t color='#ff0000'>Dragunov</t>""]  " \n "  " \n "];}";
+			init="call{{    " \n "    _x params [""_classname"", ""_text""];    " \n "    this addAction [    " \n "    _text,    " \n "     {player addWeapon (_this select 3), player addItemToVest ""rhs_mag_30Rnd_556x45_M855A1_Stanag"", player addItemToBackpack ""1Rnd_HE_Grenade_shell"", player addPrimaryWeaponItem ""rhsusf_acc_M952V""},    " \n "     _classname, 0.1, true, true, """", ""typeOf _this in ['I_officer_F', 'I_Soldier_SL_F', 'I_Soldier_TL_F', 'I_Spotter_F']"",  3  " \n "  ];    " \n "} forEach [    " \n "   " \n "[""arifle_Mk20_GL_plain_F"",""<t color='#ff0000'>Mk20 Carbine GL</t>""],     " \n "[""arifle_TRG21_GL_F"",""<t color='#009933'>TRG 21 GL</t>""],    " \n "[""arifle_SPAR_01_GL_khk_F"",""<t color='#009933'>SPAR Woodland GL</t>""],    " \n "[""arifle_SPAR_01_GL_snd_F"",""<t color='#e6e600'>SPAR Sand GL</t>""],    " \n "[""rhs_weap_m4a1_blockII_M203_d"",""<t color='#e6e600'>M4A1 Sand GL</t>""],    " \n "[""rhs_weap_m4a1_blockII_M203_wd"",""<t color='#009933'>M4A1 Woodland GL""],    " \n "[""hlc_rifle_ACR_GL_SBR_green"",""<t color='#009933'>ACR Woodland GL</t>""],    " \n "[""hlc_rifle_ACR_GL_SBR_tan"",""<t color='#e6e600'>ACR Sand GL</t>""]   " \n "   " \n "];  " \n "}";
 			disableSimulation=1;
 		};
 		id=175;
@@ -30070,27 +30100,41 @@ class items
 	};
 	class Item63
 	{
-		dataType="Object";
+		dataType="Logic";
 		class PositionInfo
 		{
-			position[]={-15.45459,0.1566577,15.778809};
-			angles[]={-0,4.7261076,0};
+			position[]={16.499023,0,-2.2412109};
 		};
-		side="Empty";
-		flags=4;
-		class Attributes
-		{
-			init="call{{    " \n "    _x params [""_classname"", ""_text""];    " \n "    this addAction [    " \n "    _text,    " \n "     {player addWeapon (_this select 3), player addItemToVest ""rhs_mag_30Rnd_556x45_M855A1_Stanag"", player addItemToBackpack ""1Rnd_HE_Grenade_shell"", player addPrimaryWeaponItem ""rhsusf_acc_M952V""},    " \n "     _classname, 0.1, true, true, """", ""typeOf _this in ['I_officer_F', 'I_Soldier_SL_F', 'I_Soldier_TL_F', 'I_Spotter_F']"",  3  " \n "  ];    " \n "} forEach [    " \n "   " \n "[""arifle_Mk20_GL_plain_F"",""<t color='#ff0000'>Mk20 Carbine GL</t>""],     " \n "[""arifle_TRG21_GL_F"",""<t color='#009933'>TRG 21 GL</t>""],    " \n "[""arifle_SPAR_01_GL_khk_F"",""<t color='#009933'>SPAR Woodland GL</t>""],    " \n "[""arifle_SPAR_01_GL_snd_F"",""<t color='#e6e600'>SPAR Sand GL</t>""],    " \n "[""rhs_weap_m4a1_blockII_M203_d"",""<t color='#e6e600'>M4A1 Sand GL</t>""],    " \n "[""rhs_weap_m4a1_blockII_M203_wd"",""<t color='#009933'>M4A1 Woodland GL""],    " \n "[""hlc_rifle_ACR_GL_SBR_green"",""<t color='#009933'>ACR Woodland GL</t>""],    " \n "[""hlc_rifle_ACR_GL_SBR_tan"",""<t color='#e6e600'>ACR Sand GL</t>""]   " \n "   " \n "];  " \n "}";
-			disableSimulation=1;
-		};
+		areaSize[]={200,0,200};
+		areaIsRectangle=1;
+		flags=1;
 		id=176;
-		type="Land_PlasticCase_01_small_F";
+		type="a3aa_ee_custom_location";
 		class CustomAttributes
 		{
 			class Attribute0
 			{
-				property="ammoBox";
-				expression="[_this,_value] call bis_fnc_initAmmoBox;";
+				property="a3aa_ee_custom_location_delcorpse";
+				expression="_this setVariable [""a3aa_ee_custom_location_delcorpse"",_value]";
+				class Value
+				{
+					class data
+					{
+						class type
+						{
+							type[]=
+							{
+								"BOOL"
+							};
+						};
+						value=1;
+					};
+				};
+			};
+			class Attribute1
+			{
+				property="a3aa_ee_custom_location_locname";
+				expression="_this setVariable [""a3aa_ee_custom_location_locname"",_value]";
 				class Value
 				{
 					class data
@@ -30102,11 +30146,30 @@ class items
 								"STRING"
 							};
 						};
-						value="[[[[],[]],[[],[]],[[],[]],[[],[]]],false]";
+						value="";
 					};
 				};
 			};
-			nAttributes=1;
+			class Attribute2
+			{
+				property="a3aa_ee_custom_location_loctype";
+				expression="_this setVariable [""a3aa_ee_custom_location_loctype"",_value]";
+				class Value
+				{
+					class data
+					{
+						class type
+						{
+							type[]=
+							{
+								"STRING"
+							};
+						};
+						value="NameVillage";
+					};
+				};
+			};
+			nAttributes=3;
 		};
 	};
 	class Item64
@@ -30114,9 +30177,9 @@ class items
 		dataType="Logic";
 		class PositionInfo
 		{
-			position[]={16.546143,0,-2.2214355};
+			position[]={-15.501465,0,-2.2407227};
 		};
-		areaSize[]={200,0,200};
+		areaSize[]={200,-1,200};
 		areaIsRectangle=1;
 		flags=1;
 		id=177;
@@ -30185,41 +30248,24 @@ class items
 	};
 	class Item65
 	{
-		dataType="Logic";
+		dataType="Object";
 		class PositionInfo
 		{
-			position[]={-15.454102,0,-2.2211914};
+			position[]={23.371094,0.18872452,-13.023926};
 		};
-		areaSize[]={200,-1,200};
-		areaIsRectangle=1;
-		flags=1;
+		side="Empty";
+		flags=4;
+		class Attributes
+		{
+		};
 		id=178;
-		type="a3aa_ee_custom_location";
+		type="Box_IND_Wps_F";
 		class CustomAttributes
 		{
 			class Attribute0
 			{
-				property="a3aa_ee_custom_location_delcorpse";
-				expression="_this setVariable [""a3aa_ee_custom_location_delcorpse"",_value]";
-				class Value
-				{
-					class data
-					{
-						class type
-						{
-							type[]=
-							{
-								"BOOL"
-							};
-						};
-						value=1;
-					};
-				};
-			};
-			class Attribute1
-			{
-				property="a3aa_ee_custom_location_locname";
-				expression="_this setVariable [""a3aa_ee_custom_location_locname"",_value]";
+				property="ammoBox";
+				expression="[_this,_value] call bis_fnc_initAmmoBox;";
 				class Value
 				{
 					class data
@@ -30231,30 +30277,11 @@ class items
 								"STRING"
 							};
 						};
-						value="";
+						value="[[[[""arifle_Mk20C_F"",""arifle_Mk20_F"",""arifle_Mk20_GL_F"",""LMG_Mk200_F"",""hgun_PDW2000_F"",""hgun_ACPC2_F""],[2,4,2,2,1,1]],[[""30Rnd_556x45_Stanag"",""9Rnd_45ACP_Mag"",""30Rnd_9x21_Mag"",""200Rnd_65x39_cased_Box"",""ACE_30Rnd_556x45_Stanag_M995_AP_mag"",""ACE_30Rnd_556x45_Stanag_Mk262_mag"",""ACE_30Rnd_556x45_Stanag_Mk318_mag""],[8,1,1,2,4,4,4]],[[""ACE_MapTools"",""ACE_RangeTable_82mm""],[2,2]],[[""I_Mortar_01_support_F"",""I_Mortar_01_weapon_F""],[2,2]]],false]";
 					};
 				};
 			};
-			class Attribute2
-			{
-				property="a3aa_ee_custom_location_loctype";
-				expression="_this setVariable [""a3aa_ee_custom_location_loctype"",_value]";
-				class Value
-				{
-					class data
-					{
-						class type
-						{
-							type[]=
-							{
-								"STRING"
-							};
-						};
-						value="NameVillage";
-					};
-				};
-			};
-			nAttributes=3;
+			nAttributes=1;
 		};
 	};
 	class Item66
@@ -30262,14 +30289,14 @@ class items
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={23.418213,0.18872452,-13.004395};
+			position[]={-8.6953125,0.18872452,-13.076172};
 		};
 		side="Empty";
 		flags=4;
 		class Attributes
 		{
 		};
-		id=257;
+		id=179;
 		type="Box_IND_Wps_F";
 		class CustomAttributes
 		{
@@ -30297,51 +30324,13 @@ class items
 	};
 	class Item67
 	{
-		dataType="Object";
-		class PositionInfo
-		{
-			position[]={-8.6479492,0.18872452,-13.056885};
-		};
-		side="Empty";
-		flags=4;
-		class Attributes
-		{
-		};
-		id=258;
-		type="Box_IND_Wps_F";
-		class CustomAttributes
-		{
-			class Attribute0
-			{
-				property="ammoBox";
-				expression="[_this,_value] call bis_fnc_initAmmoBox;";
-				class Value
-				{
-					class data
-					{
-						class type
-						{
-							type[]=
-							{
-								"STRING"
-							};
-						};
-						value="[[[[""arifle_Mk20C_F"",""arifle_Mk20_F"",""arifle_Mk20_GL_F"",""LMG_Mk200_F"",""hgun_PDW2000_F"",""hgun_ACPC2_F""],[2,4,2,2,1,1]],[[""30Rnd_556x45_Stanag"",""9Rnd_45ACP_Mag"",""30Rnd_9x21_Mag"",""200Rnd_65x39_cased_Box"",""ACE_30Rnd_556x45_Stanag_M995_AP_mag"",""ACE_30Rnd_556x45_Stanag_Mk262_mag"",""ACE_30Rnd_556x45_Stanag_Mk318_mag""],[8,1,1,2,4,4,4]],[[""ACE_MapTools"",""ACE_RangeTable_82mm""],[2,2]],[[""I_Mortar_01_support_F"",""I_Mortar_01_weapon_F""],[2,2]]],false]";
-					};
-				};
-			};
-			nAttributes=1;
-		};
-	};
-	class Item68
-	{
 		dataType="Comment";
 		class PositionInfo
 		{
-			position[]={-12.731689,0,-8.1850586};
+			position[]={0.23144531,0,-14.811035};
 		};
 		title="v1.14.2";
-		description="-v1.14.2 " \n "-GM: Fixed ""assign zeus to this unit"" not being present " \n "-All Groups: Fixed radio channel presets " \n "-Gave every unit 1 epi in Uniform, or Vest if uniform was full (medic not included) " \n "-Moved element lead LR radio to backpack " \n "-Added mortar supply crate " \n "-DMT: Removed NVG scope, and replaced main scope with one that can be used with goggles. " \n "-Gave engineers more ammo (1 tracer + 1 for members, 2 tracer for leader)" \n "" \n "-v1.14.1" \n " - A3EE box guard updated to A3AA." \n " - Custom location re-added." \n "" \n "- v1.14.0 " \n "PL: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Boonie Hat"" for more visual diversity in the platoon and to bring PL headgear in line with RU and US Standard Factions. " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n "  - Removed CNTO ""Beret"" from Backpack gear due to old logo texture. " \n " " \n "Platoon Sergeant: " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n "  - Backpack added 3CB ""Radio Backpack MR3000"" and filled it with the ACRE2 ""AN/PRC-117F"" backpack radio. This gives more incentive to bring the PLT Sgt along since he is the only one who can act as a max range radio man for the platoon. " \n " " \n "Platoon Medic: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n " " \n "Platoon Rifleman: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n " " \n "Squad Medic: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n " " \n "FTL: " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n " " \n "AR: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n "  - Added muzzle attachment RHS ""SF3P-556 1/2-28"". " \n " " \n "AAR: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n " " \n "LAT: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n " " \n "MMG Teamleader: " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n " " \n "MMG Gunner: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n "  - Unfortunately no muzzle attachments available for the MG-3! " \n " " \n "MMG Asst. Gunner: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n " " \n "MAT Teamleader: " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n " " \n "MAT Gunner: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n " " \n "MAT Asst. Gunner: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n " " \n "ENG Leader: " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Heavy"" to differentiate ENG from the rest of the platoon. " \n " " \n "ENG Rifleman: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Heavy"" to differentiate ENG from the rest of the platoon. " \n " " \n "Mortar Leader: " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Special"" to visually differentiate the Mortar Team from the rest of the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n "  - Reduced STANAG mags from 10 to 5 to match the ENG ammo count. " \n " " \n "Mortar Gunner: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Special"" to visually differentiate the Mortar Team from the rest of the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n "  - Reduced STANAG mags from 10 to 5 to match the ENG ammo count. " \n " " \n "DMT Leader " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n " " \n "DMT Marksman " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n "  - Added NVG scope RHS ""AN/PVS-27"" to the vest gear. " \n " " \n "Zeus & Co-Zeus " \n "  - Uniform changed from vanilla ""VR Suit Indie"" to CNTO ""Flecktarn Recon"" to make Zeus look a bit more like an HQ commander than a Tron character. " \n "  - Facewear changed from vanilla ""VR Goggles"" to vanilla ""Aviator Glasses"". " \n "  - Insignia added ""Zeus"". " \n " " \n "All Units: " \n "  - Disabled LAMBS AI " \n " " \n "Alpha SL: " \n "  - Enabled ""is Player"". This makes it easier for Mission Makers to quickly test a mission in the editor by just hitting ""play"" instead of having to select a specific unit every time beforehand to avoid ending up in spectator mode by default. " \n " " \n "Crates: " \n "  - Added an ACE3 medical crate with our usual base script. " \n " " \n " " \n "- v1.13.6 " \n "  - ALL Added persistent Call-Signs for all GM's (where not included in v1.13.4) " \n "  - ALL Added the code `this disableAI ""MOVE""; this setSpeaker ""NoVoice""; enableRadio false;` to all playable units to prevent them from running off and spamming the vanilla-radio during local testing. " \n "  - ALL Changed persistent call-signs (map markers) to a consistent formula: ≤ 2 syllables = written out call-sing. ≥ 3 syllables = abbreviated call-sign. " \n "  - ALL Added full changelog to all factions for quick in-game reference " \n "  - TFN Added new yellow owl insignia patches to all uniforms " \n " " \n " " \n "- v1.13.5 " \n "  - ALL Added respective GM's to Standard Faction Compositions for convenience / time saving  " \n "  - ALL Added base clean-up module to Standard Faction Compositions to ensure Mission Makers don't forget it in the future - radius set to 200x200 meters " \n " " \n " " \n "- v1.13.4  " \n "  - ALL Added @ Squad/Team names to leaders so that Team name appears in role select " \n "  - TFN Changed M249 to the FN MINIMI " \n " " \n " " \n "- v1.13.3 " \n "  - US Added Improved Bipod/SAW Grip to AR M249 " \n "  - US Removed M14 Mags " \n "  - TFN Added Bipod to M249 " \n " " \n " " \n "- v1.13.2 " \n "  - ALL Added 1 Extra Tourniquet to every Unit " \n "  - TFN DMT Lead Rifle Changed to D10 Version " \n "  - TFN DMT given extra pistol mag to bring in line with other units " \n "  - TFN AAR Weapon changed to HK416 D14.5 " \n "  - TFN Lead Elements Given AN/PEQ-16A's " \n "  - US Alpha Fireteam 2 AAR vest changed to ALT variant to match rest of faction " \n "  - US Lead Elements Given AN/PEQ-16A's " \n "  - US DMT given extra pistol mag to bring in line with other units " \n "  - US DMT Sniper Rifle Given SU-260/P (MDO) to bring zoom level to the same as Russian and TFN factions " \n "  - US DMT Bipod Changed to Harris Bipod " \n "  - US DMT Marksman Rifle changed to black version of same rifle " \n "  - US DMT Marksman Magazines changed to SR-25 version, as RHS hotfix made M14 mags incompatible with MK11 " \n "  - RUS DMT given extra pistol mag to bring in line with other units " \n "  - RUS DGR Helmets changed to TSH-4 to make distinct from US Helmets " \n "  - RUS NB Helmets changed to ZSH-7A to make distinct from US and TFN helmets " \n "  - RUS Removed RIS Rail adaptors from AK rifles " \n "  - RUS Added PG-7V rocket to MAT ammo crate. This rocket is lighter and packs less payload than the PG-7VL. This gives it an  increased effective range but is less powerful due to decreased payload " \n " " \n " " \n "- v1.12.2 " \n "  - Hotfixed US Vests across the Squads to match V.12 changes. Whoops. " \n "  - Added Angled Grip to TFN HK416s where possible.  " \n " " \n " " \n "- v1.12 " \n "  - Fixed TFN MMG Ammo preloaded into Rifle to 100RND mag from 50rnd. " \n "  - Fixed TFN DMT Marksman Ammo loaded into Rifle to correct SBLR mag. " \n "  - Changed TFN DMT Lead Suppressor to QDSS NT4 Black from Rotex-5 Grey " \n "  - Changed TFN Dagger Uniforms from Gorka R Green to FFCP Green Fatigues [RS] " \n "  - Changed US PLT Commander + Squad Leader Vest from SPCS Rifleman/OEF- CP to SPCS Squad Lead/OEF-CP " \n "  - Changed US Medic Vest from SPCS Rifleman/OEF-CP to SPCS Medic/OEF-CP " \n "  - Changed US PLT Rifleman Vest from SPCS OEF-CP to SPCS Rifleman Alt/OEF-CP " \n "  - Changed US FTL Vest from SPCS Rifleman/OEF-CP to SPCS Team Leader Alt/OEF-CP " \n "  - Changed US AR Vest from SPCS Rifleman/OEF-CP to SPCS SAW/OEF-CP " \n "  - Changed US AAR Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP " \n "  - Changed US Rifleman AT Vest from SPCS OEF-CP to SPCS Rifleman Alt/OEF-CP " \n "  - Changed US MAT/MMG/DMT/ENG/MTR Lead Vest from SPCS Rifleman/OEF-CP to SPCS Team Leader Alt/OEF-CP " \n "  - Changed US MMG Gunner Vest from SPCS Rifleman/OEF-CP to SPCS Machinegunner/OEF-CP " \n "  - Changed US MMG/MAT Ammo Bearer Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP " \n "  - Changed US MAT Gunner Vest from SPCS OEF-CP to SPCS Rifleman Alt/OEF-CP " \n "  - Changed US DMT Marksman vest from SPCS OEF-CP to SPCS Sniper/OEF-CP " \n "  - Fixed US DMT Marksman Rifle Loaded Mag to correct varient. " \n "  - Changed US Engineer Rifleman Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP. " \n "  - Changed US MTR Gunner Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP. " \n "  - Changed US DGR Uniforms from FFCP ACU Fatigues to FFCP ACU Fatigues [RS] " \n "  - Changed US DGR Driver Backpack from Assault Pack Green to Assault Pack Black " \n "  - Changed US Heli Pilot/Copilot Uniforms from Heli pilot Coveralls to FFCP Nomad Fatigues [RS] " \n "  - Fixed US Heli/Jet Pilot Vest White Smoke grenade count to 2. " \n "  - Changed US Heli Pilot/Copilot Helmet from Heli Pilot NATO to HGU-56/P (Black/Visor) " \n "  - Changed US Jet Pilot Uniform from Pilot Coveralls NATO to  FFCP Nomad Fatigues " \n "  - Changed RUS Vic/Heli/Jet Crew Weapons to PP-2000 " \n "  - Upped RUS PP-2000 Ammo counts to 6x Mag to bring in line with ammo counts for TFN and US. " \n "  - Changed RUS Heli Pilot Uniforms from Pilot Coveralls CSAT to FFCP-Fatigues EMR [RS] " \n "  - Changed RUS Heli Pilot Vest from 6B23 (6Sh116) to FFCP Tactical Vest TigerVRS " \n "  - Changed RUS Jet Pilot Uniforms from Pilot Coveralls CSAT to FFCP-Fatigues EMR [RS] " \n "  - Changed RUS Jet Pilot Vest from 6B23 (6Sh116) to FFCP Tactical Vest TigerVRS " \n " " \n " " \n "- v1.11 " \n "  - changed m40 mini grenades to m67 fragmentation " \n "  - replaced mp7 weapons with mp5k-pdw " \n "  - changed ak105 to ak74m (plum)  " \n "  - changed PKM to PKP " \n "  - changed RUS PKM ammo boxes. MMG now loads with 7TZ (AP rounds) " \n "  - added vert grip to us weapons " \n "  - replaced m14 with HK PSG1A1 " \n "  - replaced m260e4 with mg3 " \n "  - updated all ammo boxes respectively.  " \n " " \n " " \n "- v1.10 " \n "  - changed Medic loadouts from 6 x 1000ml blood bags to 2 x 1000ml and 8 x 500ml. " \n " " \n " " \n "- v1.09 " \n "  - updated Fireteam colours A1 Red A2 Yellow, B1 Green B2 Blue, C1 Red C2 Yellow. " \n " " \n " " \n "- v1.08 " \n "  - changed ""Reaper"" to ""Nightbird"", ""RPR"" to ""NB"" " \n "  - changed ""Paladin"" to ""Falcon"", ""PAL"" to ""FC"" " \n "  - changed ""DAGGER"" to ""DGR"" " \n " " \n " " \n "- v1.07 " \n "  - US and RU faction bumped to v1.07 to avoid confusion regarding version numbers (US and RU was 1.05, TFN was 1.06) " \n "  - overhauled the RU faction: updated helmets, uniforms, weapons to a more modern look " \n "  - overhauled the US faction: updated helmets and vests to armour rating of IV " \n "  - corrected some mistakes in all factions (grenade ammount of MMG gunner, ENG not having tourniquetes, DGR not having GPS-s) " \n "  - overhauled the medics of all factions to reflect recent cahnges to ACE medical (less QuikClots, more Elastic Bandages, etc.) " \n " " \n " " \n "- v1.05 " \n "  - Added a MAT ammo box on spawn. " \n " " \n " " \n "- v1.04 " \n "  - All MAT Teams carrying RPG's got the ver3 scopes with ranges for all types " \n "    of ammo. " \n "  - All Callsigns were changed to be uniformed throught no matter the faction. " \n " " \n " " \n "- v1.03 " \n "  - set crew driver/gunner and pilot/copilot/jetpilot as Engineers through the " \n "    Object: ACE Options menu in unit attributes " \n "  - overhauled the TFN faction (weapons, helmets, etc.), changes not applicable " \n "    to derived factions " \n " " \n " " \n "- v1.02 " \n "  - loadout overhaul for DMT, made them lighter + gave them tools for recon " \n "  - specified preset ACRE2 radio channels for most units " \n " " \n " " \n "- v1.01 " \n "  - updated team colors func to `a3ee_team_colors_fnc_setColor`, just load+save " \n "    the composition in editor, this fixes it " \n "  - changed RPG-7 using MAT teams to carry Kitbags " \n "  - removed one PKM ammo box from AAR, MMG gunner, MMG bearer (fixes overload) " \n "  - moved 1-2 AR boxes from AAR to AR, gave AR an Assaultpack " \n "  - added 1-2 more AR boxes to AR's Assaultpack (if enough space) " \n "  - changed HEDP to HE rockets for Carl Gustav (M3MAAWS) " \n "  - changed US crew uniform and helmet to match grey color scheme of US pilots " \n "  - changed backpacks of driver/copilot to use less contrasting colors compared " \n "    to their respective uniform/vest colors " \n "  - changed Carryall backpacks of TFN Engineers to use custom Flecktarn Carryall " \n "  - changed all (GP-25 and normal) AK74m rifles to be the non-NPZ variants " \n "  - removed secondary long-range (PRC148) from Engineers " \n " " \n " " \n "- v1.00 (and before) " \n "  - added a Comment object with version number (`v1.00`) " \n "  - added `respawn_west`, `respawn_east`, `respawn_guerrila` markers " \n "  - added `[this, 200] call a3ee_fnc_boxGuard` to init lines of resupply boxes " \n "  - added `Resupply` green triangle markers on the position of resupply boxes";
-		id=259;
+		description="-v1.14.2" \n "-Replaced NIArms MG3 with BWMod MG3 " \n "-GM: Fixed ""assign zeus to this unit"" not being present " \n "-All Groups: Fixed radio channel presets " \n "-Gave every unit 1 epi in Uniform, or Vest if uniform was full (medic not included) " \n "-Moved element lead LR radio to backpack " \n "-Added mortar supply crate " \n "-DMT: Removed NVG scope, and replaced main scope with one that can be used with goggles. " \n "-Gave engineers more ammo (1 tracer + 1 for members, 2 tracer for leader)" \n "" \n "-v1.14.1" \n " - A3EE box guard updated to A3AA." \n " - Custom location re-added." \n "" \n "- v1.14.0 " \n "PL: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Boonie Hat"" for more visual diversity in the platoon and to bring PL headgear in line with RU and US Standard Factions. " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n "  - Removed CNTO ""Beret"" from Backpack gear due to old logo texture. " \n " " \n "Platoon Sergeant: " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n "  - Backpack added 3CB ""Radio Backpack MR3000"" and filled it with the ACRE2 ""AN/PRC-117F"" backpack radio. This gives more incentive to bring the PLT Sgt along since he is the only one who can act as a max range radio man for the platoon. " \n " " \n "Platoon Medic: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n " " \n "Platoon Rifleman: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n " " \n "Squad Medic: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n " " \n "FTL: " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n " " \n "AR: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n "  - Added muzzle attachment RHS ""SF3P-556 1/2-28"". " \n " " \n "AAR: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n " " \n "LAT: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n " " \n "MMG Teamleader: " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n " " \n "MMG Gunner: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n "  - Unfortunately no muzzle attachments available for the MG-3! " \n " " \n "MMG Asst. Gunner: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n " " \n "MAT Teamleader: " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n " " \n "MAT Gunner: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n " " \n "MAT Asst. Gunner: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n " " \n "ENG Leader: " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Heavy"" to differentiate ENG from the rest of the platoon. " \n " " \n "ENG Rifleman: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Heavy"" to differentiate ENG from the rest of the platoon. " \n " " \n "Mortar Leader: " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Special"" to visually differentiate the Mortar Team from the rest of the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n "  - Reduced STANAG mags from 10 to 5 to match the ENG ammo count. " \n " " \n "Mortar Gunner: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Special"" to visually differentiate the Mortar Team from the rest of the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n "  - Reduced STANAG mags from 10 to 5 to match the ENG ammo count. " \n " " \n "DMT Leader " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n " " \n "DMT Marksman " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n "  - Added NVG scope RHS ""AN/PVS-27"" to the vest gear. " \n " " \n "Zeus & Co-Zeus " \n "  - Uniform changed from vanilla ""VR Suit Indie"" to CNTO ""Flecktarn Recon"" to make Zeus look a bit more like an HQ commander than a Tron character. " \n "  - Facewear changed from vanilla ""VR Goggles"" to vanilla ""Aviator Glasses"". " \n "  - Insignia added ""Zeus"". " \n " " \n "All Units: " \n "  - Disabled LAMBS AI " \n " " \n "Alpha SL: " \n "  - Enabled ""is Player"". This makes it easier for Mission Makers to quickly test a mission in the editor by just hitting ""play"" instead of having to select a specific unit every time beforehand to avoid ending up in spectator mode by default. " \n " " \n "Crates: " \n "  - Added an ACE3 medical crate with our usual base script. " \n " " \n " " \n "- v1.13.6 " \n "  - ALL Added persistent Call-Signs for all GM's (where not included in v1.13.4) " \n "  - ALL Added the code `this disableAI ""MOVE""; this setSpeaker ""NoVoice""; enableRadio false;` to all playable units to prevent them from running off and spamming the vanilla-radio during local testing. " \n "  - ALL Changed persistent call-signs (map markers) to a consistent formula: ≤ 2 syllables = written out call-sing. ≥ 3 syllables = abbreviated call-sign. " \n "  - ALL Added full changelog to all factions for quick in-game reference " \n "  - TFN Added new yellow owl insignia patches to all uniforms " \n " " \n " " \n "- v1.13.5 " \n "  - ALL Added respective GM's to Standard Faction Compositions for convenience / time saving  " \n "  - ALL Added base clean-up module to Standard Faction Compositions to ensure Mission Makers don't forget it in the future - radius set to 200x200 meters " \n " " \n " " \n "- v1.13.4  " \n "  - ALL Added @ Squad/Team names to leaders so that Team name appears in role select " \n "  - TFN Changed M249 to the FN MINIMI " \n " " \n " " \n "- v1.13.3 " \n "  - US Added Improved Bipod/SAW Grip to AR M249 " \n "  - US Removed M14 Mags " \n "  - TFN Added Bipod to M249 " \n " " \n " " \n "- v1.13.2 " \n "  - ALL Added 1 Extra Tourniquet to every Unit " \n "  - TFN DMT Lead Rifle Changed to D10 Version " \n "  - TFN DMT given extra pistol mag to bring in line with other units " \n "  - TFN AAR Weapon changed to HK416 D14.5 " \n "  - TFN Lead Elements Given AN/PEQ-16A's " \n "  - US Alpha Fireteam 2 AAR vest changed to ALT variant to match rest of faction " \n "  - US Lead Elements Given AN/PEQ-16A's " \n "  - US DMT given extra pistol mag to bring in line with other units " \n "  - US DMT Sniper Rifle Given SU-260/P (MDO) to bring zoom level to the same as Russian and TFN factions " \n "  - US DMT Bipod Changed to Harris Bipod " \n "  - US DMT Marksman Rifle changed to black version of same rifle " \n "  - US DMT Marksman Magazines changed to SR-25 version, as RHS hotfix made M14 mags incompatible with MK11 " \n "  - RUS DMT given extra pistol mag to bring in line with other units " \n "  - RUS DGR Helmets changed to TSH-4 to make distinct from US Helmets " \n "  - RUS NB Helmets changed to ZSH-7A to make distinct from US and TFN helmets " \n "  - RUS Removed RIS Rail adaptors from AK rifles " \n "  - RUS Added PG-7V rocket to MAT ammo crate. This rocket is lighter and packs less payload than the PG-7VL. This gives it an  increased effective range but is less powerful due to decreased payload " \n " " \n " " \n "- v1.12.2 " \n "  - Hotfixed US Vests across the Squads to match V.12 changes. Whoops. " \n "  - Added Angled Grip to TFN HK416s where possible.  " \n " " \n " " \n "- v1.12 " \n "  - Fixed TFN MMG Ammo preloaded into Rifle to 100RND mag from 50rnd. " \n "  - Fixed TFN DMT Marksman Ammo loaded into Rifle to correct SBLR mag. " \n "  - Changed TFN DMT Lead Suppressor to QDSS NT4 Black from Rotex-5 Grey " \n "  - Changed TFN Dagger Uniforms from Gorka R Green to FFCP Green Fatigues [RS] " \n "  - Changed US PLT Commander + Squad Leader Vest from SPCS Rifleman/OEF- CP to SPCS Squad Lead/OEF-CP " \n "  - Changed US Medic Vest from SPCS Rifleman/OEF-CP to SPCS Medic/OEF-CP " \n "  - Changed US PLT Rifleman Vest from SPCS OEF-CP to SPCS Rifleman Alt/OEF-CP " \n "  - Changed US FTL Vest from SPCS Rifleman/OEF-CP to SPCS Team Leader Alt/OEF-CP " \n "  - Changed US AR Vest from SPCS Rifleman/OEF-CP to SPCS SAW/OEF-CP " \n "  - Changed US AAR Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP " \n "  - Changed US Rifleman AT Vest from SPCS OEF-CP to SPCS Rifleman Alt/OEF-CP " \n "  - Changed US MAT/MMG/DMT/ENG/MTR Lead Vest from SPCS Rifleman/OEF-CP to SPCS Team Leader Alt/OEF-CP " \n "  - Changed US MMG Gunner Vest from SPCS Rifleman/OEF-CP to SPCS Machinegunner/OEF-CP " \n "  - Changed US MMG/MAT Ammo Bearer Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP " \n "  - Changed US MAT Gunner Vest from SPCS OEF-CP to SPCS Rifleman Alt/OEF-CP " \n "  - Changed US DMT Marksman vest from SPCS OEF-CP to SPCS Sniper/OEF-CP " \n "  - Fixed US DMT Marksman Rifle Loaded Mag to correct varient. " \n "  - Changed US Engineer Rifleman Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP. " \n "  - Changed US MTR Gunner Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP. " \n "  - Changed US DGR Uniforms from FFCP ACU Fatigues to FFCP ACU Fatigues [RS] " \n "  - Changed US DGR Driver Backpack from Assault Pack Green to Assault Pack Black " \n "  - Changed US Heli Pilot/Copilot Uniforms from Heli pilot Coveralls to FFCP Nomad Fatigues [RS] " \n "  - Fixed US Heli/Jet Pilot Vest White Smoke grenade count to 2. " \n "  - Changed US Heli Pilot/Copilot Helmet from Heli Pilot NATO to HGU-56/P (Black/Visor) " \n "  - Changed US Jet Pilot Uniform from Pilot Coveralls NATO to  FFCP Nomad Fatigues " \n "  - Changed RUS Vic/Heli/Jet Crew Weapons to PP-2000 " \n "  - Upped RUS PP-2000 Ammo counts to 6x Mag to bring in line with ammo counts for TFN and US. " \n "  - Changed RUS Heli Pilot Uniforms from Pilot Coveralls CSAT to FFCP-Fatigues EMR [RS] " \n "  - Changed RUS Heli Pilot Vest from 6B23 (6Sh116) to FFCP Tactical Vest TigerVRS " \n "  - Changed RUS Jet Pilot Uniforms from Pilot Coveralls CSAT to FFCP-Fatigues EMR [RS] " \n "  - Changed RUS Jet Pilot Vest from 6B23 (6Sh116) to FFCP Tactical Vest TigerVRS " \n " " \n " " \n "- v1.11 " \n "  - changed m40 mini grenades to m67 fragmentation " \n "  - replaced mp7 weapons with mp5k-pdw " \n "  - changed ak105 to ak74m (plum)  " \n "  - changed PKM to PKP " \n "  - changed RUS PKM ammo boxes. MMG now loads with 7TZ (AP rounds) " \n "  - added vert grip to us weapons " \n "  - replaced m14 with HK PSG1A1 " \n "  - replaced m260e4 with mg3 " \n "  - updated all ammo boxes respectively.  " \n " " \n " " \n "- v1.10 " \n "  - changed Medic loadouts from 6 x 1000ml blood bags to 2 x 1000ml and 8 x 500ml. " \n " " \n " " \n "- v1.09 " \n "  - updated Fireteam colours A1 Red A2 Yellow, B1 Green B2 Blue, C1 Red C2 Yellow. " \n " " \n " " \n "- v1.08 " \n "  - changed ""Reaper"" to ""Nightbird"", ""RPR"" to ""NB"" " \n "  - changed ""Paladin"" to ""Falcon"", ""PAL"" to ""FC"" " \n "  - changed ""DAGGER"" to ""DGR"" " \n " " \n " " \n "- v1.07 " \n "  - US and RU faction bumped to v1.07 to avoid confusion regarding version numbers (US and RU was 1.05, TFN was 1.06) " \n "  - overhauled the RU faction: updated helmets, uniforms, weapons to a more modern look " \n "  - overhauled the US faction: updated helmets and vests to armour rating of IV " \n "  - corrected some mistakes in all factions (grenade ammount of MMG gunner, ENG not having tourniquetes, DGR not having GPS-s) " \n "  - overhauled the medics of all factions to reflect recent cahnges to ACE medical (less QuikClots, more Elastic Bandages, etc.) " \n " " \n " " \n "- v1.05 " \n "  - Added a MAT ammo box on spawn. " \n " " \n " " \n "- v1.04 " \n "  - All MAT Teams carrying RPG's got the ver3 scopes with ranges for all types " \n "    of ammo. " \n "  - All Callsigns were changed to be uniformed throught no matter the faction. " \n " " \n " " \n "- v1.03 " \n "  - set crew driver/gunner and pilot/copilot/jetpilot as Engineers through the " \n "    Object: ACE Options menu in unit attributes " \n "  - overhauled the TFN faction (weapons, helmets, etc.), changes not applicable " \n "    to derived factions " \n " " \n " " \n "- v1.02 " \n "  - loadout overhaul for DMT, made them lighter + gave them tools for recon " \n "  - specified preset ACRE2 radio channels for most units " \n " " \n " " \n "- v1.01 " \n "  - updated team colors func to `a3ee_team_colors_fnc_setColor`, just load+save " \n "    the composition in editor, this fixes it " \n "  - changed RPG-7 using MAT teams to carry Kitbags " \n "  - removed one PKM ammo box from AAR, MMG gunner, MMG bearer (fixes overload) " \n "  - moved 1-2 AR boxes from AAR to AR, gave AR an Assaultpack " \n "  - added 1-2 more AR boxes to AR's Assaultpack (if enough space) " \n "  - changed HEDP to HE rockets for Carl Gustav (M3MAAWS) " \n "  - changed US crew uniform and helmet to match grey color scheme of US pilots " \n "  - changed backpacks of driver/copilot to use less contrasting colors compared " \n "    to their respective uniform/vest colors " \n "  - changed Carryall backpacks of TFN Engineers to use custom Flecktarn Carryall " \n "  - changed all (GP-25 and normal) AK74m rifles to be the non-NPZ variants " \n "  - removed secondary long-range (PRC148) from Engineers " \n " " \n " " \n "- v1.00 (and before) " \n "  - added a Comment object with version number (`v1.00`) " \n "  - added `respawn_west`, `respawn_east`, `respawn_guerrila` markers " \n "  - added `[this, 200] call a3ee_fnc_boxGuard` to init lines of resupply boxes " \n "  - added `Resupply` green triangle markers on the position of resupply boxes";
+		id=180;
 	};
 };

--- a/reference/PMC%20Faction/composition.sqe
+++ b/reference/PMC%20Faction/composition.sqe
@@ -1,12 +1,12 @@
 version=53;
-center[]={4143.9121,5,5008.2334};
+center[]={5691.8677,5,3918.5508};
 class items
 {
 	items=68;
 	class Item0
 	{
 		dataType="Marker";
-		position[]={0.49804688,1.3349106e+013,-1.2407227};
+		position[]={0.47021484,1.3349106e+013,-1.2651367};
 		name="respawn_guerrila";
 		type="respawn_unknown";
 		id=0;
@@ -15,7 +15,7 @@ class items
 	class Item1
 	{
 		dataType="Marker";
-		position[]={-22.501465,0.29708433,15.759277};
+		position[]={-22.529297,0.29708433,15.734863};
 		name="Rifles_6";
 		text="Rifles";
 		type="mil_triangle";
@@ -35,7 +35,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-22.500977,0.0014390945,5.809082};
+					position[]={-22.528809,0.0014390945,5.784668};
 				};
 				side="Independent";
 				flags=7;
@@ -387,7 +387,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-20.502441,0.0014390945,5.8100586};
+					position[]={-20.530273,0.0014390945,5.7856445};
 				};
 				side="Independent";
 				flags=5;
@@ -663,7 +663,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-19.502441,0.0014390945,5.8100586};
+					position[]={-19.530273,0.0014390945,5.7856445};
 				};
 				side="Independent";
 				flags=5;
@@ -863,7 +863,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-21.500977,0.0014390945,5.809082};
+					position[]={-21.528809,0.0014390945,5.784668};
 				};
 				side="Independent";
 				flags=4;
@@ -1185,7 +1185,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-22.560547,0.0014390945,3.5151367};
+					position[]={-22.588379,0.0014390945,3.4907227};
 				};
 				side="Independent";
 				flags=7;
@@ -1516,7 +1516,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-21.560059,0.0014390945,3.5161133};
+					position[]={-21.587891,0.0014390945,3.4916992};
 				};
 				side="Independent";
 				flags=5;
@@ -1792,7 +1792,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-22.560059,0.0014390945,1.5161133};
+					position[]={-22.587891,0.0014390945,1.4916992};
 				};
 				side="Independent";
 				flags=5;
@@ -2012,6 +2012,25 @@ class items
 				{
 					class Attribute0
 					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="RED";
+							};
+						};
+					};
+					class Attribute1
+					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
 						class Value
@@ -2029,7 +2048,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_acre_channels_chlist";
 						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
@@ -2065,7 +2084,7 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					nAttributes=3;
 				};
 			};
 			class Item3
@@ -2073,7 +2092,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-21.560059,0.0014390945,1.5161133};
+					position[]={-21.587891,0.0014390945,1.4916992};
 				};
 				side="Independent";
 				flags=5;
@@ -2227,6 +2246,25 @@ class items
 				{
 					class Attribute0
 					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="RED";
+							};
+						};
+					};
+					class Attribute1
+					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
 						class Value
@@ -2244,7 +2282,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_acre_channels_chlist";
 						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
@@ -2280,7 +2318,7 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					nAttributes=3;
 				};
 			};
 			class Item4
@@ -2288,7 +2326,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-20.560059,0.0014390945,1.5161133};
+					position[]={-20.587891,0.0014390945,1.4916992};
 				};
 				side="Independent";
 				flags=5;
@@ -2491,6 +2529,25 @@ class items
 				{
 					class Attribute0
 					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="RED";
+							};
+						};
+					};
+					class Attribute1
+					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
 						class Value
@@ -2508,7 +2565,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_acre_channels_chlist";
 						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
@@ -2544,7 +2601,7 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					nAttributes=3;
 				};
 			};
 			class Item5
@@ -2552,7 +2609,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-19.560059,0.0014390945,1.5161133};
+					position[]={-19.587891,0.0014390945,1.4916992};
 				};
 				side="Independent";
 				flags=5;
@@ -2695,6 +2752,25 @@ class items
 				{
 					class Attribute0
 					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="RED";
+							};
+						};
+					};
+					class Attribute1
+					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
 						class Value
@@ -2712,7 +2788,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_acre_channels_chlist";
 						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
@@ -2748,7 +2824,7 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					nAttributes=3;
 				};
 			};
 			class Item6
@@ -2756,7 +2832,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-22.560059,0.0014390945,-0.48388672};
+					position[]={-22.587891,0.0014390945,-0.50830078};
 				};
 				side="Independent";
 				flags=5;
@@ -2976,6 +3052,25 @@ class items
 				{
 					class Attribute0
 					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="YELLOW";
+							};
+						};
+					};
+					class Attribute1
+					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
 						class Value
@@ -2993,7 +3088,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_acre_channels_chlist";
 						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
@@ -3029,7 +3124,7 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					nAttributes=3;
 				};
 			};
 			class Item7
@@ -3037,7 +3132,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-21.560059,0.0014390945,-0.48388672};
+					position[]={-21.587891,0.0014390945,-0.50830078};
 				};
 				side="Independent";
 				flags=5;
@@ -3191,6 +3286,25 @@ class items
 				{
 					class Attribute0
 					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="YELLOW";
+							};
+						};
+					};
+					class Attribute1
+					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
 						class Value
@@ -3208,7 +3322,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_acre_channels_chlist";
 						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
@@ -3244,7 +3358,7 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					nAttributes=3;
 				};
 			};
 			class Item8
@@ -3252,7 +3366,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-20.560059,0.0014390945,-0.48388672};
+					position[]={-20.587891,0.0014390945,-0.50830078};
 				};
 				side="Independent";
 				flags=5;
@@ -3455,6 +3569,25 @@ class items
 				{
 					class Attribute0
 					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="YELLOW";
+							};
+						};
+					};
+					class Attribute1
+					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
 						class Value
@@ -3472,7 +3605,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_acre_channels_chlist";
 						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
@@ -3508,7 +3641,7 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					nAttributes=3;
 				};
 			};
 			class Item9
@@ -3516,7 +3649,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-19.560059,0.0014390945,-0.48388672};
+					position[]={-19.587891,0.0014390945,-0.50830078};
 				};
 				side="Independent";
 				flags=5;
@@ -3659,6 +3792,25 @@ class items
 				{
 					class Attribute0
 					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="YELLOW";
+							};
+						};
+					};
+					class Attribute1
+					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
 						class Value
@@ -3676,7 +3828,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_acre_channels_chlist";
 						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
@@ -3712,7 +3864,7 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					nAttributes=3;
 				};
 			};
 		};
@@ -3756,7 +3908,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-16.997559,0.0014390945,3.4038086};
+					position[]={-17.025391,0.0014390945,3.3793945};
 				};
 				side="Independent";
 				flags=7;
@@ -4068,7 +4220,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-15.998535,0.0014390945,3.4038086};
+					position[]={-16.026367,0.0014390945,3.3793945};
 				};
 				side="Independent";
 				flags=5;
@@ -4344,7 +4496,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-16.998535,0.0014390945,1.4038086};
+					position[]={-17.026367,0.0014390945,1.3793945};
 				};
 				side="Independent";
 				flags=5;
@@ -4564,6 +4716,25 @@ class items
 				{
 					class Attribute0
 					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="BLUE";
+							};
+						};
+					};
+					class Attribute1
+					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
 						class Value
@@ -4581,7 +4752,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_acre_channels_chlist";
 						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
@@ -4617,7 +4788,7 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					nAttributes=3;
 				};
 			};
 			class Item3
@@ -4625,7 +4796,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-15.998535,0.0014390945,1.4038086};
+					position[]={-16.026367,0.0014390945,1.3793945};
 				};
 				side="Independent";
 				flags=5;
@@ -4779,6 +4950,25 @@ class items
 				{
 					class Attribute0
 					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="BLUE";
+							};
+						};
+					};
+					class Attribute1
+					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
 						class Value
@@ -4796,7 +4986,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_acre_channels_chlist";
 						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
@@ -4832,7 +5022,7 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					nAttributes=3;
 				};
 			};
 			class Item4
@@ -4840,7 +5030,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-14.998047,0.0014390945,1.4038086};
+					position[]={-15.025879,0.0014390945,1.3793945};
 				};
 				side="Independent";
 				flags=5;
@@ -5043,6 +5233,25 @@ class items
 				{
 					class Attribute0
 					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="BLUE";
+							};
+						};
+					};
+					class Attribute1
+					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
 						class Value
@@ -5060,7 +5269,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_acre_channels_chlist";
 						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
@@ -5096,7 +5305,7 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					nAttributes=3;
 				};
 			};
 			class Item5
@@ -5104,7 +5313,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-13.998535,0.0014390945,1.4038086};
+					position[]={-14.026367,0.0014390945,1.3793945};
 				};
 				side="Independent";
 				flags=5;
@@ -5247,6 +5456,25 @@ class items
 				{
 					class Attribute0
 					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="BLUE";
+							};
+						};
+					};
+					class Attribute1
+					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
 						class Value
@@ -5264,7 +5492,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_acre_channels_chlist";
 						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
@@ -5300,7 +5528,7 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					nAttributes=3;
 				};
 			};
 			class Item6
@@ -5308,7 +5536,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-16.998535,0.0014390945,-0.59619141};
+					position[]={-17.026367,0.0014390945,-0.62060547};
 				};
 				side="Independent";
 				flags=5;
@@ -5528,6 +5756,25 @@ class items
 				{
 					class Attribute0
 					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="GREEN";
+							};
+						};
+					};
+					class Attribute1
+					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
 						class Value
@@ -5545,7 +5792,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_acre_channels_chlist";
 						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
@@ -5581,7 +5828,7 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					nAttributes=3;
 				};
 			};
 			class Item7
@@ -5589,7 +5836,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-15.998535,0.0014390945,-0.59619141};
+					position[]={-16.026367,0.0014390945,-0.62060547};
 				};
 				side="Independent";
 				flags=5;
@@ -5743,6 +5990,25 @@ class items
 				{
 					class Attribute0
 					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="GREEN";
+							};
+						};
+					};
+					class Attribute1
+					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
 						class Value
@@ -5760,7 +6026,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_acre_channels_chlist";
 						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
@@ -5796,7 +6062,7 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					nAttributes=3;
 				};
 			};
 			class Item8
@@ -5804,7 +6070,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-14.998535,0.0014390945,-0.59619141};
+					position[]={-15.026367,0.0014390945,-0.62060547};
 				};
 				side="Independent";
 				flags=5;
@@ -6007,6 +6273,25 @@ class items
 				{
 					class Attribute0
 					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="GREEN";
+							};
+						};
+					};
+					class Attribute1
+					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
 						class Value
@@ -6024,7 +6309,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_acre_channels_chlist";
 						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
@@ -6060,7 +6345,7 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					nAttributes=3;
 				};
 			};
 			class Item9
@@ -6068,7 +6353,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-13.998535,0.0014390945,-0.59619141};
+					position[]={-14.026367,0.0014390945,-0.62060547};
 				};
 				side="Independent";
 				flags=5;
@@ -6211,6 +6496,25 @@ class items
 				{
 					class Attribute0
 					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="GREEN";
+							};
+						};
+					};
+					class Attribute1
+					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
 						class Value
@@ -6228,7 +6532,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_acre_channels_chlist";
 						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
@@ -6264,7 +6568,7 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					nAttributes=3;
 				};
 			};
 		};
@@ -6308,7 +6612,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-11.950195,0.0014390945,3.2963867};
+					position[]={-11.978027,0.0014390945,3.2719727};
 				};
 				side="Independent";
 				flags=7;
@@ -6620,7 +6924,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-10.950195,0.0014390945,3.2954102};
+					position[]={-10.978027,0.0014390945,3.2709961};
 				};
 				side="Independent";
 				flags=5;
@@ -6896,7 +7200,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-11.950195,0.0014390945,1.2954102};
+					position[]={-11.978027,0.0014390945,1.2709961};
 				};
 				side="Independent";
 				flags=5;
@@ -7116,6 +7420,25 @@ class items
 				{
 					class Attribute0
 					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="RED";
+							};
+						};
+					};
+					class Attribute1
+					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
 						class Value
@@ -7133,7 +7456,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_acre_channels_chlist";
 						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
@@ -7169,7 +7492,7 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					nAttributes=3;
 				};
 			};
 			class Item3
@@ -7177,7 +7500,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-10.950195,0.0014390945,1.2954102};
+					position[]={-10.978027,0.0014390945,1.2709961};
 				};
 				side="Independent";
 				flags=5;
@@ -7331,6 +7654,25 @@ class items
 				{
 					class Attribute0
 					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="RED";
+							};
+						};
+					};
+					class Attribute1
+					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
 						class Value
@@ -7348,7 +7690,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_acre_channels_chlist";
 						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
@@ -7384,7 +7726,7 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					nAttributes=3;
 				};
 			};
 			class Item4
@@ -7392,7 +7734,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-9.9501953,0.0014390945,1.2954102};
+					position[]={-9.9780273,0.0014390945,1.2709961};
 				};
 				side="Independent";
 				flags=5;
@@ -7595,6 +7937,25 @@ class items
 				{
 					class Attribute0
 					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="RED";
+							};
+						};
+					};
+					class Attribute1
+					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
 						class Value
@@ -7612,7 +7973,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_acre_channels_chlist";
 						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
@@ -7648,7 +8009,7 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					nAttributes=3;
 				};
 			};
 			class Item5
@@ -7656,7 +8017,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-8.9501953,0.0014390945,1.2954102};
+					position[]={-8.9780273,0.0014390945,1.2709961};
 				};
 				side="Independent";
 				flags=5;
@@ -7799,6 +8160,25 @@ class items
 				{
 					class Attribute0
 					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="RED";
+							};
+						};
+					};
+					class Attribute1
+					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
 						class Value
@@ -7816,7 +8196,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_acre_channels_chlist";
 						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
@@ -7852,7 +8232,7 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					nAttributes=3;
 				};
 			};
 			class Item6
@@ -7860,7 +8240,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-11.950195,0.0014390945,-0.70458984};
+					position[]={-11.978027,0.0014390945,-0.72900391};
 				};
 				side="Independent";
 				flags=5;
@@ -8080,6 +8460,25 @@ class items
 				{
 					class Attribute0
 					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="YELLOW";
+							};
+						};
+					};
+					class Attribute1
+					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
 						class Value
@@ -8097,7 +8496,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_acre_channels_chlist";
 						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
@@ -8133,7 +8532,7 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					nAttributes=3;
 				};
 			};
 			class Item7
@@ -8141,7 +8540,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-10.950195,0.0014390945,-0.70458984};
+					position[]={-10.978027,0.0014390945,-0.72900391};
 				};
 				side="Independent";
 				flags=5;
@@ -8295,6 +8694,25 @@ class items
 				{
 					class Attribute0
 					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="YELLOW";
+							};
+						};
+					};
+					class Attribute1
+					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
 						class Value
@@ -8312,7 +8730,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_acre_channels_chlist";
 						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
@@ -8348,7 +8766,7 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					nAttributes=3;
 				};
 			};
 			class Item8
@@ -8356,7 +8774,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-9.9501953,0.0014390945,-0.70458984};
+					position[]={-9.9780273,0.0014390945,-0.72900391};
 				};
 				side="Independent";
 				flags=5;
@@ -8559,6 +8977,25 @@ class items
 				{
 					class Attribute0
 					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="YELLOW";
+							};
+						};
+					};
+					class Attribute1
+					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
 						class Value
@@ -8576,7 +9013,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_acre_channels_chlist";
 						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
@@ -8612,7 +9049,7 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					nAttributes=3;
 				};
 			};
 			class Item9
@@ -8620,7 +9057,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-8.9501953,0.0014390945,-0.70458984};
+					position[]={-8.9780273,0.0014390945,-0.72900391};
 				};
 				side="Independent";
 				flags=5;
@@ -8763,6 +9200,25 @@ class items
 				{
 					class Attribute0
 					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="YELLOW";
+							};
+						};
+					};
+					class Attribute1
+					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
 						class Value
@@ -8780,7 +9236,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_acre_channels_chlist";
 						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
@@ -8816,7 +9272,7 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					nAttributes=3;
 				};
 			};
 		};
@@ -8851,7 +9307,7 @@ class items
 	class Item6
 	{
 		dataType="Marker";
-		position[]={-9.5014648,0.036262512,-9.2407227};
+		position[]={-9.5292969,0.035955906,-9.2651367};
 		name="resupply_marker_2";
 		text="Resupply";
 		type="mil_triangle";
@@ -8864,7 +9320,7 @@ class items
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={-22.501465,0.79142618,16.759277};
+			position[]={-22.529297,0.79142618,16.734863};
 		};
 		side="Empty";
 		flags=4;
@@ -8880,7 +9336,7 @@ class items
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={-15.501465,0.79142618,16.759277};
+			position[]={-15.529297,0.79142618,16.734863};
 		};
 		side="Empty";
 		flags=4;
@@ -8896,7 +9352,7 @@ class items
 		dataType="Comment";
 		class PositionInfo
 		{
-			position[]={-22.501465,0,17.759277};
+			position[]={-22.529297,0,17.734863};
 		};
 		title="Standard Rifles";
 		id=43;
@@ -8906,7 +9362,7 @@ class items
 		dataType="Comment";
 		class PositionInfo
 		{
-			position[]={-15.501465,0,17.759277};
+			position[]={-15.529297,0,17.734863};
 		};
 		title="SL & FTLS";
 		id=44;
@@ -8916,7 +9372,7 @@ class items
 		dataType="Comment";
 		class PositionInfo
 		{
-			position[]={-8.5014648,0,17.759277};
+			position[]={-8.5292969,0,17.734863};
 		};
 		title="DMT";
 		id=45;
@@ -8926,7 +9382,7 @@ class items
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={-8.5014648,0.79142618,16.759277};
+			position[]={-8.5292969,0.79142618,16.734863};
 		};
 		side="Empty";
 		flags=4;
@@ -8940,7 +9396,7 @@ class items
 	class Item13
 	{
 		dataType="Marker";
-		position[]={-15.501465,0.29708433,15.759277};
+		position[]={-15.529297,0.29708433,15.734863};
 		name="Rifles_7";
 		text="SL & FTLS";
 		type="mil_triangle";
@@ -8951,7 +9407,7 @@ class items
 	class Item14
 	{
 		dataType="Marker";
-		position[]={-8.5014648,0.29708433,15.759277};
+		position[]={-8.5292969,0.29708433,15.734863};
 		name="Rifles_8";
 		text="DMT";
 		type="mil_triangle";
@@ -8971,7 +9427,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-22.560059,0.0014390945,-4.4838867};
+					position[]={-22.587891,0.0014390945,-4.5083008};
 				};
 				side="Independent";
 				flags=7;
@@ -9296,7 +9752,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-21.560059,0.0014390945,-4.4848633};
+					position[]={-21.587891,0.0014390945,-4.5092773};
 				};
 				side="Independent";
 				flags=5;
@@ -9517,7 +9973,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-20.560059,0.0014390945,-4.4848633};
+					position[]={-20.587891,0.0014390945,-4.5092773};
 				};
 				side="Independent";
 				flags=5;
@@ -9793,7 +10249,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-16.316895,0.0014390945,-4.519043};
+					position[]={-16.344727,0.0014390945,-4.543457};
 				};
 				side="Independent";
 				flags=7;
@@ -10118,7 +10574,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-15.318359,0.0014390945,-4.5170898};
+					position[]={-15.346191,0.0014390945,-4.5415039};
 				};
 				side="Independent";
 				flags=5;
@@ -10367,7 +10823,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-14.318359,0.0014390945,-4.5170898};
+					position[]={-14.346191,0.0014390945,-4.5415039};
 				};
 				side="Independent";
 				flags=5;
@@ -10643,7 +11099,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-22.820801,0.0014390945,-7.152832};
+					position[]={-22.848633,0.0014390945,-7.1772461};
 				};
 				side="Independent";
 				flags=7;
@@ -10929,7 +11385,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-21.821289,0.0014390945,-7.1538086};
+					position[]={-21.849121,0.0014390945,-7.1782227};
 				};
 				side="Independent";
 				flags=4;
@@ -11213,7 +11669,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-16.689941,0.0014390945,-7.2143555};
+					position[]={-16.717773,0.0014390945,-7.2387695};
 				};
 				side="Independent";
 				flags=7;
@@ -11434,7 +11890,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-15.688965,0.0014390945,-7.2143555};
+					position[]={-15.716797,0.0014390945,-7.2387695};
 				};
 				side="Independent";
 				flags=5;
@@ -11668,7 +12124,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-11.421875,0.0014390945,-4.4799805};
+					position[]={-11.449707,0.0014390945,-4.5043945};
 				};
 				side="Independent";
 				flags=7;
@@ -11956,7 +12412,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-10.421875,0.0014390945,-4.4799805};
+					position[]={-10.449707,0.0014390945,-4.5043945};
 				};
 				side="Independent";
 				flags=5;
@@ -12209,7 +12665,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-9.421875,0.0014390945,-4.4799805};
+					position[]={-9.449707,0.0014390945,-4.5043945};
 				};
 				side="Independent";
 				flags=5;
@@ -12472,7 +12928,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-8.421875,0.0014390945,-4.4799805};
+					position[]={-8.449707,0.0014390945,-4.5043945};
 				};
 				side="Independent";
 				flags=5;
@@ -12765,7 +13221,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-23.089844,0.0014390945,-9.831543};
+					position[]={-23.117676,0.0014390945,-9.855957};
 				};
 				side="Independent";
 				flags=7;
@@ -13031,7 +13487,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-22.089844,0.0014390945,-9.831543};
+					position[]={-22.117676,0.0014390945,-9.855957};
 				};
 				side="Independent";
 				flags=5;
@@ -13256,7 +13712,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-21.089844,0.0014390945,-9.831543};
+					position[]={-21.117676,0.0014390945,-9.855957};
 				};
 				side="Independent";
 				flags=5;
@@ -13503,7 +13959,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-16.810059,0.0014390945,-10.02002};
+					position[]={-16.837891,0.0014390945,-10.044434};
 				};
 				side="Independent";
 				flags=7;
@@ -13788,7 +14244,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-15.810059,0.0014390945,-10.019043};
+					position[]={-15.837891,0.0014390945,-10.043457};
 				};
 				side="Independent";
 				flags=5;
@@ -14132,7 +14588,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-13.07373,0.0014390945,-10.148926};
+					position[]={-13.101563,0.0014390945,-10.17334};
 				};
 				side="Independent";
 				flags=7;
@@ -14443,7 +14899,7 @@ class items
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={-8.9423828,0.28405476,-8.5698242};
+			position[]={-8.9702148,0.28405476,-8.5942383};
 		};
 		side="Empty";
 		flags=4;
@@ -14482,7 +14938,7 @@ class items
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={-8.8896484,0.89242268,-10.95166};
+			position[]={-8.9174805,0.89242268,-10.976074};
 		};
 		side="Empty";
 		flags=4;
@@ -14521,7 +14977,7 @@ class items
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={-11.060547,0.14963102,-9.8803711};
+			position[]={-11.088379,0.14963102,-9.9047852};
 			angles[]={-0,4.7330365,0};
 		};
 		side="Empty";
@@ -14567,7 +15023,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-11.421875,0.0014390945,-7.2143555};
+					position[]={-11.449707,0.0014390945,-7.2387695};
 				};
 				side="Independent";
 				flags=7;
@@ -14778,7 +15234,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-10.421875,0.0014390945,-7.2143555};
+					position[]={-10.449707,0.0014390945,-7.2387695};
 				};
 				side="Independent";
 				flags=5;
@@ -15013,7 +15469,7 @@ class items
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={-8.5097656,0,-6.8950195};
+			position[]={-8.5375977,0,-6.9194336};
 		};
 		side="Empty";
 		flags=4;
@@ -15059,7 +15515,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={9.4985352,0.0014390945,5.809082};
+					position[]={9.4707031,0.0014390945,5.784668};
 				};
 				side="Independent";
 				flags=7;
@@ -15309,7 +15765,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={11.497559,0.0014390945,5.8100586};
+					position[]={11.469727,0.0014390945,5.7856445};
 				};
 				side="Independent";
 				flags=5;
@@ -15554,7 +16010,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={12.498535,0.0014390945,5.809082};
+					position[]={12.470703,0.0014390945,5.784668};
 				};
 				side="Independent";
 				flags=5;
@@ -15718,7 +16174,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={10.498535,0.0014390945,5.809082};
+					position[]={10.470703,0.0014390945,5.784668};
 				};
 				side="Independent";
 				flags=4;
@@ -15938,7 +16394,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={9.4394531,0.0014390945,3.5161133};
+					position[]={9.4116211,0.0014390945,3.4916992};
 				};
 				side="Independent";
 				flags=7;
@@ -16269,7 +16725,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={10.439941,0.0014390945,3.5161133};
+					position[]={10.412109,0.0014390945,3.4916992};
 				};
 				side="Independent";
 				flags=5;
@@ -16545,7 +17001,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={9.4399414,0.0014390945,1.5161133};
+					position[]={9.4121094,0.0014390945,1.4916992};
 				};
 				side="Independent";
 				flags=5;
@@ -16765,6 +17221,25 @@ class items
 				{
 					class Attribute0
 					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="RED";
+							};
+						};
+					};
+					class Attribute1
+					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
 						class Value
@@ -16782,7 +17257,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_acre_channels_chlist";
 						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
@@ -16818,7 +17293,7 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					nAttributes=3;
 				};
 			};
 			class Item3
@@ -16826,7 +17301,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={10.439941,0.0014390945,1.5161133};
+					position[]={10.412109,0.0014390945,1.4916992};
 				};
 				side="Independent";
 				flags=5;
@@ -16980,6 +17455,25 @@ class items
 				{
 					class Attribute0
 					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="RED";
+							};
+						};
+					};
+					class Attribute1
+					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
 						class Value
@@ -16997,7 +17491,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_acre_channels_chlist";
 						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
@@ -17033,7 +17527,7 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					nAttributes=3;
 				};
 			};
 			class Item4
@@ -17041,7 +17535,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={11.439941,0.0014390945,1.5161133};
+					position[]={11.412109,0.0014390945,1.4916992};
 				};
 				side="Independent";
 				flags=5;
@@ -17250,6 +17744,25 @@ class items
 				{
 					class Attribute0
 					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="RED";
+							};
+						};
+					};
+					class Attribute1
+					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
 						class Value
@@ -17267,7 +17780,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_acre_channels_chlist";
 						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
@@ -17303,7 +17816,7 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					nAttributes=3;
 				};
 			};
 			class Item5
@@ -17311,7 +17824,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={12.439941,0.0014390945,1.5161133};
+					position[]={12.412109,0.0014390945,1.4916992};
 				};
 				side="Independent";
 				flags=5;
@@ -17454,6 +17967,25 @@ class items
 				{
 					class Attribute0
 					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="RED";
+							};
+						};
+					};
+					class Attribute1
+					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
 						class Value
@@ -17471,7 +18003,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_acre_channels_chlist";
 						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
@@ -17507,7 +18039,7 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					nAttributes=3;
 				};
 			};
 			class Item6
@@ -17515,7 +18047,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={9.4394531,0.0014390945,-0.48388672};
+					position[]={9.4116211,0.0014390945,-0.50830078};
 				};
 				side="Independent";
 				flags=5;
@@ -17735,6 +18267,25 @@ class items
 				{
 					class Attribute0
 					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="YELLOW";
+							};
+						};
+					};
+					class Attribute1
+					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
 						class Value
@@ -17752,7 +18303,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_acre_channels_chlist";
 						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
@@ -17788,7 +18339,7 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					nAttributes=3;
 				};
 			};
 			class Item7
@@ -17796,7 +18347,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={10.439941,0.0014390945,-0.48388672};
+					position[]={10.412109,0.0014390945,-0.50830078};
 				};
 				side="Independent";
 				flags=5;
@@ -17950,6 +18501,25 @@ class items
 				{
 					class Attribute0
 					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="YELLOW";
+							};
+						};
+					};
+					class Attribute1
+					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
 						class Value
@@ -17967,7 +18537,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_acre_channels_chlist";
 						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
@@ -18003,7 +18573,7 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					nAttributes=3;
 				};
 			};
 			class Item8
@@ -18011,7 +18581,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={11.439941,0.0014390945,-0.48388672};
+					position[]={11.412109,0.0014390945,-0.50830078};
 				};
 				side="Independent";
 				flags=5;
@@ -18220,6 +18790,25 @@ class items
 				{
 					class Attribute0
 					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="YELLOW";
+							};
+						};
+					};
+					class Attribute1
+					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
 						class Value
@@ -18237,7 +18826,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_acre_channels_chlist";
 						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
@@ -18273,7 +18862,7 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					nAttributes=3;
 				};
 			};
 			class Item9
@@ -18281,7 +18870,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={12.439941,0.0014390945,-0.48388672};
+					position[]={12.412109,0.0014390945,-0.50830078};
 				};
 				side="Independent";
 				flags=5;
@@ -18424,6 +19013,25 @@ class items
 				{
 					class Attribute0
 					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="YELLOW";
+							};
+						};
+					};
+					class Attribute1
+					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
 						class Value
@@ -18441,7 +19049,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_acre_channels_chlist";
 						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
@@ -18477,7 +19085,7 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					nAttributes=3;
 				};
 			};
 		};
@@ -18521,7 +19129,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={15.002441,0.0014390945,3.4047852};
+					position[]={14.974609,0.0014390945,3.3803711};
 				};
 				side="Independent";
 				flags=7;
@@ -18833,7 +19441,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={16.001465,0.0014390945,3.4047852};
+					position[]={15.973633,0.0014390945,3.3803711};
 				};
 				side="Independent";
 				flags=5;
@@ -19109,7 +19717,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={15.001465,0.0014390945,1.4047852};
+					position[]={14.973633,0.0014390945,1.3803711};
 				};
 				side="Independent";
 				flags=5;
@@ -19329,6 +19937,25 @@ class items
 				{
 					class Attribute0
 					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="BLUE";
+							};
+						};
+					};
+					class Attribute1
+					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
 						class Value
@@ -19346,7 +19973,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_acre_channels_chlist";
 						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
@@ -19382,7 +20009,7 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					nAttributes=3;
 				};
 			};
 			class Item3
@@ -19390,7 +20017,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={16.001465,0.0014390945,1.4047852};
+					position[]={15.973633,0.0014390945,1.3803711};
 				};
 				side="Independent";
 				flags=5;
@@ -19544,6 +20171,25 @@ class items
 				{
 					class Attribute0
 					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="BLUE";
+							};
+						};
+					};
+					class Attribute1
+					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
 						class Value
@@ -19561,7 +20207,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_acre_channels_chlist";
 						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
@@ -19597,7 +20243,7 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					nAttributes=3;
 				};
 			};
 			class Item4
@@ -19605,7 +20251,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={17.001953,0.0014390945,1.4047852};
+					position[]={16.974121,0.0014390945,1.3803711};
 				};
 				side="Independent";
 				flags=5;
@@ -19814,6 +20460,25 @@ class items
 				{
 					class Attribute0
 					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="BLUE";
+							};
+						};
+					};
+					class Attribute1
+					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
 						class Value
@@ -19831,7 +20496,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_acre_channels_chlist";
 						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
@@ -19867,7 +20532,7 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					nAttributes=3;
 				};
 			};
 			class Item5
@@ -19875,7 +20540,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={18.001465,0.0014390945,1.4047852};
+					position[]={17.973633,0.0014390945,1.3803711};
 				};
 				side="Independent";
 				flags=5;
@@ -20018,6 +20683,25 @@ class items
 				{
 					class Attribute0
 					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="BLUE";
+							};
+						};
+					};
+					class Attribute1
+					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
 						class Value
@@ -20035,7 +20719,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_acre_channels_chlist";
 						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
@@ -20071,7 +20755,7 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					nAttributes=3;
 				};
 			};
 			class Item6
@@ -20079,7 +20763,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={15.001465,0.0014390945,-0.59521484};
+					position[]={14.973633,0.0014390945,-0.61962891};
 				};
 				side="Independent";
 				flags=5;
@@ -20299,6 +20983,25 @@ class items
 				{
 					class Attribute0
 					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="GREEN";
+							};
+						};
+					};
+					class Attribute1
+					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
 						class Value
@@ -20316,7 +21019,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_acre_channels_chlist";
 						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
@@ -20352,7 +21055,7 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					nAttributes=3;
 				};
 			};
 			class Item7
@@ -20360,7 +21063,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={16.001465,0.0014390945,-0.59521484};
+					position[]={15.973633,0.0014390945,-0.61962891};
 				};
 				side="Independent";
 				flags=5;
@@ -20514,6 +21217,25 @@ class items
 				{
 					class Attribute0
 					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="GREEN";
+							};
+						};
+					};
+					class Attribute1
+					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
 						class Value
@@ -20531,7 +21253,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_acre_channels_chlist";
 						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
@@ -20567,7 +21289,7 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					nAttributes=3;
 				};
 			};
 			class Item8
@@ -20575,7 +21297,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={17.001465,0.0014390945,-0.59521484};
+					position[]={16.973633,0.0014390945,-0.61962891};
 				};
 				side="Independent";
 				flags=5;
@@ -20784,6 +21506,25 @@ class items
 				{
 					class Attribute0
 					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="GREEN";
+							};
+						};
+					};
+					class Attribute1
+					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
 						class Value
@@ -20801,7 +21542,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_acre_channels_chlist";
 						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
@@ -20837,7 +21578,7 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					nAttributes=3;
 				};
 			};
 			class Item9
@@ -20845,7 +21586,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={18.001465,0.0014390945,-0.59521484};
+					position[]={17.973633,0.0014390945,-0.61962891};
 				};
 				side="Independent";
 				flags=5;
@@ -20988,6 +21729,25 @@ class items
 				{
 					class Attribute0
 					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="GREEN";
+							};
+						};
+					};
+					class Attribute1
+					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
 						class Value
@@ -21005,7 +21765,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_acre_channels_chlist";
 						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
@@ -21041,7 +21801,7 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					nAttributes=3;
 				};
 			};
 		};
@@ -21085,7 +21845,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={20.049805,0.0014390945,3.2963867};
+					position[]={20.021973,0.0014390945,3.2719727};
 				};
 				side="Independent";
 				flags=7;
@@ -21397,7 +22157,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={21.049805,0.0014390945,3.2954102};
+					position[]={21.021973,0.0014390945,3.2709961};
 				};
 				side="Independent";
 				flags=5;
@@ -21673,7 +22433,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={20.049805,0.0014390945,1.2954102};
+					position[]={20.021973,0.0014390945,1.2709961};
 				};
 				side="Independent";
 				flags=5;
@@ -21893,6 +22653,25 @@ class items
 				{
 					class Attribute0
 					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="RED";
+							};
+						};
+					};
+					class Attribute1
+					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
 						class Value
@@ -21910,7 +22689,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_acre_channels_chlist";
 						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
@@ -21946,7 +22725,7 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					nAttributes=3;
 				};
 			};
 			class Item3
@@ -21954,7 +22733,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={21.049805,0.0014390945,1.2954102};
+					position[]={21.021973,0.0014390945,1.2709961};
 				};
 				side="Independent";
 				flags=5;
@@ -22108,6 +22887,25 @@ class items
 				{
 					class Attribute0
 					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="RED";
+							};
+						};
+					};
+					class Attribute1
+					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
 						class Value
@@ -22125,7 +22923,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_acre_channels_chlist";
 						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
@@ -22161,7 +22959,7 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					nAttributes=3;
 				};
 			};
 			class Item4
@@ -22169,7 +22967,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={22.049805,0.0014390945,1.2954102};
+					position[]={22.021973,0.0014390945,1.2709961};
 				};
 				side="Independent";
 				flags=5;
@@ -22378,6 +23176,25 @@ class items
 				{
 					class Attribute0
 					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="RED";
+							};
+						};
+					};
+					class Attribute1
+					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
 						class Value
@@ -22395,7 +23212,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_acre_channels_chlist";
 						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
@@ -22431,7 +23248,7 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					nAttributes=3;
 				};
 			};
 			class Item5
@@ -22439,7 +23256,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={23.049805,0.0014390945,1.2954102};
+					position[]={23.021973,0.0014390945,1.2709961};
 				};
 				side="Independent";
 				flags=5;
@@ -22582,6 +23399,25 @@ class items
 				{
 					class Attribute0
 					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="RED";
+							};
+						};
+					};
+					class Attribute1
+					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
 						class Value
@@ -22599,7 +23435,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_acre_channels_chlist";
 						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
@@ -22635,7 +23471,7 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					nAttributes=3;
 				};
 			};
 			class Item6
@@ -22643,7 +23479,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={20.049805,0.0014390945,-0.70458984};
+					position[]={20.021973,0.0014390945,-0.72900391};
 				};
 				side="Independent";
 				flags=5;
@@ -22863,6 +23699,25 @@ class items
 				{
 					class Attribute0
 					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="YELLOW";
+							};
+						};
+					};
+					class Attribute1
+					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
 						class Value
@@ -22880,7 +23735,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_acre_channels_chlist";
 						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
@@ -22916,7 +23771,7 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					nAttributes=3;
 				};
 			};
 			class Item7
@@ -22924,7 +23779,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={21.049805,0.0014390945,-0.70458984};
+					position[]={21.021973,0.0014390945,-0.72900391};
 				};
 				side="Independent";
 				flags=5;
@@ -23078,6 +23933,25 @@ class items
 				{
 					class Attribute0
 					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="YELLOW";
+							};
+						};
+					};
+					class Attribute1
+					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
 						class Value
@@ -23095,7 +23969,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_acre_channels_chlist";
 						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
@@ -23131,7 +24005,7 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					nAttributes=3;
 				};
 			};
 			class Item8
@@ -23139,7 +24013,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={22.049805,0.0014390945,-0.70458984};
+					position[]={22.021973,0.0014390945,-0.72900391};
 				};
 				side="Independent";
 				flags=5;
@@ -23348,6 +24222,25 @@ class items
 				{
 					class Attribute0
 					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="YELLOW";
+							};
+						};
+					};
+					class Attribute1
+					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
 						class Value
@@ -23365,7 +24258,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_acre_channels_chlist";
 						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
@@ -23401,7 +24294,7 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					nAttributes=3;
 				};
 			};
 			class Item9
@@ -23409,7 +24302,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={23.049805,0.0014390945,-0.70458984};
+					position[]={23.021973,0.0014390945,-0.72900391};
 				};
 				side="Independent";
 				flags=5;
@@ -23552,6 +24445,25 @@ class items
 				{
 					class Attribute0
 					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="YELLOW";
+							};
+						};
+					};
+					class Attribute1
+					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
 						class Value
@@ -23569,7 +24481,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_acre_channels_chlist";
 						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
@@ -23605,7 +24517,7 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					nAttributes=3;
 				};
 			};
 		};
@@ -23649,7 +24561,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={9.4399414,0.0014390945,-4.4838867};
+					position[]={9.4121094,0.0014390945,-4.5083008};
 				};
 				side="Independent";
 				flags=7;
@@ -23974,7 +24886,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={10.439941,0.0014390945,-4.4848633};
+					position[]={10.412109,0.0014390945,-4.5092773};
 				};
 				side="Independent";
 				flags=5;
@@ -24201,7 +25113,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={11.439941,0.0014390945,-4.4848633};
+					position[]={11.412109,0.0014390945,-4.5092773};
 				};
 				side="Independent";
 				flags=5;
@@ -24483,7 +25395,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={15.683105,0.0014390945,-4.519043};
+					position[]={15.655273,0.0014390945,-4.543457};
 				};
 				side="Independent";
 				flags=7;
@@ -24808,7 +25720,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={16.681641,0.0014390945,-4.5170898};
+					position[]={16.653809,0.0014390945,-4.5415039};
 				};
 				side="Independent";
 				flags=5;
@@ -25052,7 +25964,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={17.681641,0.0014390945,-4.5170898};
+					position[]={17.653809,0.0014390945,-4.5415039};
 				};
 				side="Independent";
 				flags=5;
@@ -25322,7 +26234,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={9.1791992,0.0014390945,-7.152832};
+					position[]={9.1513672,0.0014390945,-7.1772461};
 				};
 				side="Independent";
 				flags=7;
@@ -25608,7 +26520,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={10.178711,0.0014390945,-7.1538086};
+					position[]={10.150879,0.0014390945,-7.1782227};
 				};
 				side="Independent";
 				flags=4;
@@ -25896,7 +26808,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={15.310059,0.0014390945,-7.2143555};
+					position[]={15.282227,0.0014390945,-7.2387695};
 				};
 				side="Independent";
 				flags=7;
@@ -26117,7 +27029,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={16.311035,0.0014390945,-7.2143555};
+					position[]={16.283203,0.0014390945,-7.2387695};
 				};
 				side="Independent";
 				flags=5;
@@ -26351,7 +27263,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={20.578125,0.0014390945,-4.4799805};
+					position[]={20.550293,0.0014390945,-4.5043945};
 				};
 				side="Independent";
 				flags=7;
@@ -26624,7 +27536,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={21.578125,0.0014390945,-4.4799805};
+					position[]={21.550293,0.0014390945,-4.5043945};
 				};
 				side="Independent";
 				flags=5;
@@ -26877,7 +27789,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={22.578125,0.0014390945,-4.4799805};
+					position[]={22.550293,0.0014390945,-4.5043945};
 				};
 				side="Independent";
 				flags=5;
@@ -27130,7 +28042,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={23.578125,0.0014390945,-4.4799805};
+					position[]={23.550293,0.0014390945,-4.5043945};
 				};
 				side="Independent";
 				flags=5;
@@ -27423,7 +28335,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={8.9101563,0.0014390945,-9.831543};
+					position[]={8.8823242,0.0014390945,-9.855957};
 				};
 				side="Independent";
 				flags=7;
@@ -27689,7 +28601,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={9.9101563,0.0014390945,-9.831543};
+					position[]={9.8823242,0.0014390945,-9.855957};
 				};
 				side="Independent";
 				flags=5;
@@ -27914,7 +28826,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={10.910156,0.0014390945,-9.831543};
+					position[]={10.882324,0.0014390945,-9.855957};
 				};
 				side="Independent";
 				flags=5;
@@ -28161,7 +29073,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={15.189941,0.0014390945,-10.02002};
+					position[]={15.162109,0.0014390945,-10.044434};
 				};
 				side="Independent";
 				flags=7;
@@ -28446,7 +29358,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={16.189941,0.0014390945,-10.019043};
+					position[]={16.162109,0.0014390945,-10.043457};
 				};
 				side="Independent";
 				flags=5;
@@ -28800,7 +29712,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={18.92627,0.0014390945,-10.148926};
+					position[]={18.898438,0.0014390945,-10.17334};
 				};
 				side="Independent";
 				flags=7;
@@ -29111,7 +30023,7 @@ class items
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={23.057617,0.28405476,-8.5698242};
+			position[]={23.029785,0.28405476,-8.5942383};
 		};
 		side="Empty";
 		flags=4;
@@ -29150,7 +30062,7 @@ class items
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={23.110352,0.89242268,-10.95166};
+			position[]={23.08252,0.89242268,-10.976074};
 		};
 		side="Empty";
 		flags=4;
@@ -29196,7 +30108,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={20.578125,0.0014390945,-7.2143555};
+					position[]={20.550293,0.0014390945,-7.2387695};
 				};
 				side="Independent";
 				flags=7;
@@ -29269,7 +30181,7 @@ class items
 						headgear="H_ShemagOpen_khk";
 					};
 				};
-				id=154;
+				id=153;
 				type="I_Protagonist_VR_F";
 				class CustomAttributes
 				{
@@ -29402,7 +30314,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={21.578125,0.0014390945,-7.2143555};
+					position[]={21.550293,0.0014390945,-7.2387695};
 				};
 				side="Independent";
 				flags=5;
@@ -29475,7 +30387,7 @@ class items
 						headgear="rhsusf_bowman_cap";
 					};
 				};
-				id=155;
+				id=154;
 				type="I_Protagonist_VR_F";
 				class CustomAttributes
 				{
@@ -29607,7 +30519,7 @@ class items
 		class Attributes
 		{
 		};
-		id=153;
+		id=152;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -29637,7 +30549,7 @@ class items
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={23.489258,0,-6.8950195};
+			position[]={23.461426,0,-6.9194336};
 		};
 		side="Empty";
 		flags=4;
@@ -29645,7 +30557,7 @@ class items
 		{
 			init="call{[this, 200] call a3aa_fnc_boxGuard}";
 		};
-		id=156;
+		id=155;
 		type="ACE_medicalSupplyCrate";
 		class CustomAttributes
 		{
@@ -29676,27 +30588,43 @@ class items
 		dataType="Comment";
 		class PositionInfo
 		{
-			position[]={-15.501465,0,6.7587891};
+			position[]={-15.529297,0,6.734375};
 		};
 		title="WESTERN PMC";
-		id=157;
+		id=156;
 	};
 	class Item45
 	{
 		dataType="Comment";
 		class PositionInfo
 		{
-			position[]={16.498535,0,6.7587891};
+			position[]={16.470703,0,6.734375};
 		};
 		title="EASTERN PMC";
-		id=158;
+		id=157;
 	};
 	class Item46
 	{
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={9.4985352,0.79142618,16.759277};
+			position[]={9.4707031,0.79142618,16.734863};
+		};
+		side="Empty";
+		flags=4;
+		class Attributes
+		{
+			disableSimulation=1;
+		};
+		id=158;
+		type="Land_Noticeboard_F";
+	};
+	class Item47
+	{
+		dataType="Object";
+		class PositionInfo
+		{
+			position[]={16.470703,0.79142618,16.734863};
 		};
 		side="Empty";
 		flags=4;
@@ -29707,58 +30635,42 @@ class items
 		id=159;
 		type="Land_Noticeboard_F";
 	};
-	class Item47
-	{
-		dataType="Object";
-		class PositionInfo
-		{
-			position[]={16.498535,0.79142618,16.759277};
-		};
-		side="Empty";
-		flags=4;
-		class Attributes
-		{
-			disableSimulation=1;
-		};
-		id=160;
-		type="Land_Noticeboard_F";
-	};
 	class Item48
 	{
 		dataType="Comment";
 		class PositionInfo
 		{
-			position[]={9.4985352,0,17.759277};
+			position[]={9.4707031,0,17.734863};
 		};
 		title="Standard Rifles";
-		id=161;
+		id=160;
 	};
 	class Item49
 	{
 		dataType="Comment";
 		class PositionInfo
 		{
-			position[]={16.498535,0,17.759277};
+			position[]={16.470703,0,17.734863};
 		};
 		title="SL & FTLS";
-		id=162;
+		id=161;
 	};
 	class Item50
 	{
 		dataType="Comment";
 		class PositionInfo
 		{
-			position[]={23.498047,0,17.759277};
+			position[]={23.470215,0,17.734863};
 		};
 		title="DMT";
-		id=163;
+		id=162;
 	};
 	class Item51
 	{
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={23.498047,0.79142618,16.759277};
+			position[]={23.470215,0.79142618,16.734863};
 		};
 		side="Empty";
 		flags=4;
@@ -29766,48 +30678,48 @@ class items
 		{
 			disableSimulation=1;
 		};
-		id=164;
+		id=163;
 		type="Land_Noticeboard_F";
 	};
 	class Item52
 	{
 		dataType="Marker";
-		position[]={9.4985352,0.29708433,15.759277};
+		position[]={9.4707031,0.29708433,15.734863};
 		name="Rifles_9";
 		text="Rifles";
 		type="mil_triangle";
 		colorName="ColorGreen";
 		angle=2.177;
-		id=165;
+		id=164;
 	};
 	class Item53
 	{
 		dataType="Marker";
-		position[]={16.498535,0.29708433,15.759277};
+		position[]={16.470703,0.29708433,15.734863};
 		name="Rifles_10";
 		text="SL & FTLS";
 		type="mil_triangle";
 		colorName="ColorGreen";
 		angle=2.177;
-		id=166;
+		id=165;
 	};
 	class Item54
 	{
 		dataType="Marker";
-		position[]={23.498047,0.29708433,15.759277};
+		position[]={23.470215,0.29708433,15.734863};
 		name="Rifles_11";
 		text="DMT";
 		type="mil_triangle";
 		colorName="ColorGreen";
 		angle=2.177;
-		id=167;
+		id=166;
 	};
 	class Item55
 	{
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={21.498535,0.14963102,-9.2407227};
+			position[]={21.470703,0.14963102,-9.2651367};
 			angles[]={-0,1.5418237,0};
 		};
 		side="Empty";
@@ -29815,7 +30727,7 @@ class items
 		class Attributes
 		{
 		};
-		id=168;
+		id=167;
 		type="Box_East_WpsLaunch_F";
 		class CustomAttributes
 		{
@@ -29844,12 +30756,12 @@ class items
 	class Item56
 	{
 		dataType="Marker";
-		position[]={22.498047,0.036262512,-9.2407227};
+		position[]={22.470215,0.035955906,-9.2651367};
 		name="resupply_marker_3";
 		text="Resupply";
 		type="mil_triangle";
 		colorName="ColorGreen";
-		id=169;
+		id=168;
 		atlOffset=0.00015306473;
 	};
 	class Item57
@@ -29857,7 +30769,7 @@ class items
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={-8.5019531,0.1566577,15.759277};
+			position[]={-8.5297852,0.1566577,15.734863};
 			angles[]={-0,4.7261076,0};
 		};
 		side="Empty";
@@ -29867,7 +30779,7 @@ class items
 			init="call{{    " \n "    _x params [""_classname"", ""_text""];    " \n "    this addAction [    " \n "        _text,    " \n "  {if (count ((player weaponAccessories primaryWeapon player)-[""""]) != 0) then {hint ""Remove weapon attachments before changing weapon""} else {player addWeapon (_this select 3), player addItemToVest ""20Rnd_762x51_Mag""}; " \n "  },    " \n "  _classname, 0.1, true, true, """", ""typeOf _this in ['I_Sniper_F']"",3   " \n "    ];    " \n "} forEach [    " \n "   " \n "[""srifle_EBR_F"",""<t color='#e6e600'>M18 ABR</t>""],   " \n "[""arifle_SPAR_03_blk_F"",""<t color='#ff0000'>SPAR 7.62 DMR Black</t>""],     " \n "[""arifle_SPAR_03_khk_F"",""<t color='#009933'>SPAR 7.62 DMR Woodland</t>""],    " \n "[""arifle_SPAR_03_snd_F"",""<t color='e6e600'>SPAR 7.62 DMR Sand</t>""],    " \n "[""srifle_DMR_06_olive_F"",""<t color='#e6e600'>Mk14 DMR Woodland</t>""],    " \n "[""srifle_DMR_06_camo_F"",""<t color='#e6e600'>Mk14 DMR Sand</t>""],    " \n "[""srifle_DMR_03_tan_F"",""<t color='#e6e600'>Mk1 EMR Sand""],    " \n "[""srifle_DMR_03_khaki_F"",""<t color='#009933'>Mk1 EMR Woodland</t>""],    " \n "[""srifle_DMR_03_multicam_F"",""<t color='#ff0000'>Mk1 EMR Camo 1</t>""],   " \n "[""srifle_DMR_03_multicam_F"",""<t color='#ff0000'>Mk1 EMR Camo 2</t>""],   " \n "[""hlc_rifle_M14dmr_Rail"",""<t color='#ff0000'>M14 DMR Black</t>""]   " \n "   " \n "];}";
 			disableSimulation=1;
 		};
-		id=170;
+		id=169;
 		type="Land_PlasticCase_01_small_F";
 		class CustomAttributes
 		{
@@ -29898,7 +30810,7 @@ class items
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={9.4980469,0.1566577,15.759277};
+			position[]={9.4702148,0.1566577,15.734863};
 			angles[]={-0,4.7261076,0};
 		};
 		side="Empty";
@@ -29908,7 +30820,7 @@ class items
 			init="call{{   " \n "    _x params [""_classname"", ""_text""];   " \n "    this addAction [   " \n "        _text,   " \n "  {player addWeapon (_this select 3), player addItemToVest ""rhs_30Rnd_545x39_7N22_AK"", player addPrimaryWeaponItem ""rhs_acc_dtk""},   " \n "  _classname, 0.1, true, true, """", ""typeOf _this in ['I_medic_F', 'I_soldier_F', 'I_Soldier_AAR_F', 'I_Soldier_LAT_F', 'I_Soldier_AT_F', 'I_Soldier_AAT_F', 'I_engineer_F', 'I_crew_F', 'I_support_MORT_F', 'I_support_AMORT_F']"",3    " \n "    ];   " \n "} forEach [   " \n "  " \n "[""rhs_weap_ak105"",""<t color='#ff0000'>AK 105</t>""],     " \n "[""rhs_weap_ak105_npz"",""<t color='#009933'>AK 105 - Rail mod</t>""],    " \n "[""rhs_weap_ak105_zenitco01"",""<t color='#009933'>AK 105 Zentico</t>""],    " \n "[""rhs_weap_ak105_zenitco01_b33"",""<t color='#e6e600'>AK 105 Zentico - Rail mod</t>""],    " \n "[""rhs_weap_ak74"",""<t color='#e6e600'>AK 74</t>""],    " \n "[""rhs_weap_ak74m_camo"",""<t color='#e6e600'>AK74M Camo</t>""],    " \n "[""rhs_weap_ak74m_desert_npz"",""<t color='#009933'>AK74M Desert - Rail mod</t>""],    " \n "[""rhs_weap_ak74mr"",""<t color='#e6e600'>AK74MR</t>""],    " \n "[""hlc_rifle_ak12"",""<t color='#009933'>AK12</t>""],    " \n "[""hlc_rifle_aku12"",""<t color='#ff0000'>AK12U</t>""],    " \n "[""hlc_rifle_ak74m"",""<t color='#ff0000'>AK74M</t>""],    " \n "[""hlc_rifle_aks74"",""<t color='#ff0000'>AKS74</t>""],      " \n "[""hlc_rifle_aek971_mtk"",""<t color='#e6e600'>AEK971</t>""]  " \n "  " \n "]; " \n "}";
 			disableSimulation=1;
 		};
-		id=171;
+		id=170;
 		type="Land_PlasticCase_01_small_F";
 		class CustomAttributes
 		{
@@ -29939,7 +30851,7 @@ class items
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={16.498047,0.1566577,15.759277};
+			position[]={16.470215,0.1566577,15.734863};
 			angles[]={-0,4.7261076,0};
 		};
 		side="Empty";
@@ -29949,7 +30861,7 @@ class items
 			init="call{{   " \n "    _x params [""_classname"", ""_text""];   " \n "    this addAction [   " \n "        _text,   " \n "  {player addWeapon (_this select 3), player addItemToVest ""rhs_30Rnd_545x39_7N22_AK"", player addItemToBackpack ""rhs_VOG25"", player addPrimaryWeaponItem ""rhs_acc_dtk""},  " \n "  _classname, 0.1, true, true, """", ""typeOf _this in ['I_officer_F', 'I_Soldier_SL_F', 'I_Soldier_TL_F', 'I_Spotter_F']"",3 " \n "    ];   " \n "} forEach [   " \n "  " \n "[""rhs_weap_ak74_gp25"",""<t color='#ff0000'>AK74 GL</t>""],    " \n "[""rhs_weap_ak74mr_gp25"",""<t color='#009933'>AK74MR 21 GL</t>""],   " \n "[""hlc_rifle_ak12GL"",""<t color='#009933'>AK12 GL</t>""],   " \n "[""hlc_rifle_ak74m_gl"",""<t color='#e6e600'>AK74M GL</t>""],  " \n "[""hlc_rifle_aks74_GL"",""<t color='#e6e600'>AKS74 GL</t>""]  " \n "  " \n "];}";
 			disableSimulation=1;
 		};
-		id=172;
+		id=171;
 		type="Land_PlasticCase_01_small_F";
 		class CustomAttributes
 		{
@@ -29980,7 +30892,7 @@ class items
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={-22.501953,0.1566577,15.758789};
+			position[]={-22.529785,0.1566577,15.734375};
 			angles[]={-0,4.7261076,0};
 		};
 		side="Empty";
@@ -29990,7 +30902,7 @@ class items
 			init="call{{  " \n "    _x params [""_classname"", ""_text""];    " \n "    this addAction [    " \n "        _text,    " \n "  {player addWeapon (_this select 3), player addItemToVest ""rhs_mag_30Rnd_556x45_M855A1_Stanag"", player addPrimaryWeaponItem ""rhsusf_acc_M952V""},    " \n "  _classname, 0.1, true, true, """", ""typeOf _this in ['I_medic_F', 'I_soldier_F', 'I_Soldier_AAR_F', 'I_Soldier_LAT_F', 'I_Soldier_AT_F', 'I_Soldier_AAT_F', 'I_engineer_F', 'I_crew_F', 'I_support_MORT_F', 'I_support_AMORT_F']"",3  " \n "    ];    " \n "} forEach [    " \n "   " \n "[""arifle_Mk20C_plain_F"",""<t color='#ff0000'>Mk20 Carbine</t>""],      " \n "[""arifle_TRG21_F"",""<t color='#009933'>TRG 21</t>""],     " \n "[""arifle_SPAR_01_khk_F"",""<t color='#009933'>SPAR Woodland</t>""],     " \n "[""arifle_SPAR_01_snd_F"",""<t color='#e6e600'>SPAR Sand</t>""],     " \n "[""rhs_weap_hk416d145_d"",""<t color='#e6e600'>HK416 Sand</t>""],     " \n "[""rhs_weap_m4a1_blockII_d"",""<t color='#e6e600'>M4A1 Sand</t>""],     " \n "[""rhs_weap_m4a1_blockII_wd"",""<t color='#009933'>M4A1 Woodland</t>""],     " \n "[""rhs_weap_mk18_KAC_d"",""<t color='#e6e600'>Mk18 Sand</t>""],     " \n "[""rhs_weap_mk18_KAC_wd"",""<t color='#009933'>Mk18 Woodland</t>""],     " \n "[""hlc_rifle_RU5562"",""<t color='#ff0000'>Sanitiser</t>""],     " \n "[""hlc_rifle_RU556"",""<t color='#ff0000'>Liquidator</t>""],     " \n "[""hlc_rifle_bcmjack"",""<t color='#ff0000'>Jack</t>""],     " \n "[""hlc_rifle_ACR_SBR_green"",""<t color='#009933'>ACR Woodland</t>""],     " \n "[""hlc_rifle_ACR_SBR_tan"",""<t color='#e6e600'>ACR Sand</t>""]   " \n "   " \n "];}";
 			disableSimulation=1;
 		};
-		id=173;
+		id=172;
 		type="Land_PlasticCase_01_small_F";
 		class CustomAttributes
 		{
@@ -30021,7 +30933,7 @@ class items
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={23.498047,0.1566577,15.759277};
+			position[]={23.470215,0.1566577,15.734863};
 			angles[]={-0,4.7261076,0};
 		};
 		side="Empty";
@@ -30031,7 +30943,7 @@ class items
 			init="call{{   " \n "    _x params [""_classname"", ""_text""];   " \n "    this addAction [   " \n "        _text,   " \n "  {if (count ((player weaponAccessories primaryWeapon player)-[""""]) != 0) then {hint ""Remove weapon attachments before changing weapon""} else {player addWeapon (_this select 3), player addItemToVest ""10Rnd_762x54_Mag""}; " \n "  },   " \n "  _classname, 0.1, true, true, """", ""typeOf _this in ['I_Sniper_F']"",3 " \n "    ];   " \n "} forEach [   " \n "  " \n "[""rhs_weap_svdp_wd"",""<t color='#e6e600'>SVD Camo</t>""],  " \n "[""rhs_weap_svds_npz"",""<t color='#ff0000'>SVD Blk - Rail mod</t>""],  " \n "[""UK3CB_SVD_OLD"",""<t color='#ff0000'>Dragunov</t>""]  " \n "  " \n "];}";
 			disableSimulation=1;
 		};
-		id=174;
+		id=173;
 		type="Land_PlasticCase_01_small_F";
 		class CustomAttributes
 		{
@@ -30062,7 +30974,7 @@ class items
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={-15.501953,0.1566577,15.759277};
+			position[]={-15.529785,0.1566577,15.734863};
 			angles[]={-0,4.7261076,0};
 		};
 		side="Empty";
@@ -30072,7 +30984,7 @@ class items
 			init="call{{    " \n "    _x params [""_classname"", ""_text""];    " \n "    this addAction [    " \n "    _text,    " \n "     {player addWeapon (_this select 3), player addItemToVest ""rhs_mag_30Rnd_556x45_M855A1_Stanag"", player addItemToBackpack ""1Rnd_HE_Grenade_shell"", player addPrimaryWeaponItem ""rhsusf_acc_M952V""},    " \n "     _classname, 0.1, true, true, """", ""typeOf _this in ['I_officer_F', 'I_Soldier_SL_F', 'I_Soldier_TL_F', 'I_Spotter_F']"",  3  " \n "  ];    " \n "} forEach [    " \n "   " \n "[""arifle_Mk20_GL_plain_F"",""<t color='#ff0000'>Mk20 Carbine GL</t>""],     " \n "[""arifle_TRG21_GL_F"",""<t color='#009933'>TRG 21 GL</t>""],    " \n "[""arifle_SPAR_01_GL_khk_F"",""<t color='#009933'>SPAR Woodland GL</t>""],    " \n "[""arifle_SPAR_01_GL_snd_F"",""<t color='#e6e600'>SPAR Sand GL</t>""],    " \n "[""rhs_weap_m4a1_blockII_M203_d"",""<t color='#e6e600'>M4A1 Sand GL</t>""],    " \n "[""rhs_weap_m4a1_blockII_M203_wd"",""<t color='#009933'>M4A1 Woodland GL""],    " \n "[""hlc_rifle_ACR_GL_SBR_green"",""<t color='#009933'>ACR Woodland GL</t>""],    " \n "[""hlc_rifle_ACR_GL_SBR_tan"",""<t color='#e6e600'>ACR Sand GL</t>""]   " \n "   " \n "];  " \n "}";
 			disableSimulation=1;
 		};
-		id=175;
+		id=174;
 		type="Land_PlasticCase_01_small_F";
 		class CustomAttributes
 		{
@@ -30103,12 +31015,12 @@ class items
 		dataType="Logic";
 		class PositionInfo
 		{
-			position[]={16.499023,0,-2.2412109};
+			position[]={16.471191,0,-2.265625};
 		};
 		areaSize[]={200,0,200};
 		areaIsRectangle=1;
 		flags=1;
-		id=176;
+		id=175;
 		type="a3aa_ee_custom_location";
 		class CustomAttributes
 		{
@@ -30177,12 +31089,12 @@ class items
 		dataType="Logic";
 		class PositionInfo
 		{
-			position[]={-15.501465,0,-2.2407227};
+			position[]={-15.529297,0,-2.2651367};
 		};
 		areaSize[]={200,-1,200};
 		areaIsRectangle=1;
 		flags=1;
-		id=177;
+		id=176;
 		type="a3aa_ee_custom_location";
 		class CustomAttributes
 		{
@@ -30251,7 +31163,45 @@ class items
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={23.371094,0.18872452,-13.023926};
+			position[]={23.343262,0.18872452,-13.04834};
+		};
+		side="Empty";
+		flags=4;
+		class Attributes
+		{
+		};
+		id=177;
+		type="Box_IND_Wps_F";
+		class CustomAttributes
+		{
+			class Attribute0
+			{
+				property="ammoBox";
+				expression="[_this,_value] call bis_fnc_initAmmoBox;";
+				class Value
+				{
+					class data
+					{
+						class type
+						{
+							type[]=
+							{
+								"STRING"
+							};
+						};
+						value="[[[[""arifle_Mk20C_F"",""arifle_Mk20_F"",""arifle_Mk20_GL_F"",""LMG_Mk200_F"",""hgun_PDW2000_F"",""hgun_ACPC2_F""],[2,4,2,2,1,1]],[[""30Rnd_556x45_Stanag"",""9Rnd_45ACP_Mag"",""30Rnd_9x21_Mag"",""200Rnd_65x39_cased_Box"",""ACE_30Rnd_556x45_Stanag_M995_AP_mag"",""ACE_30Rnd_556x45_Stanag_Mk262_mag"",""ACE_30Rnd_556x45_Stanag_Mk318_mag""],[8,1,1,2,4,4,4]],[[""ACE_MapTools"",""ACE_RangeTable_82mm""],[2,2]],[[""I_Mortar_01_support_F"",""I_Mortar_01_weapon_F""],[2,2]]],false]";
+					};
+				};
+			};
+			nAttributes=1;
+		};
+	};
+	class Item66
+	{
+		dataType="Object";
+		class PositionInfo
+		{
+			position[]={-8.7231445,0.18872452,-13.100586};
 		};
 		side="Empty";
 		flags=4;
@@ -30284,53 +31234,15 @@ class items
 			nAttributes=1;
 		};
 	};
-	class Item66
-	{
-		dataType="Object";
-		class PositionInfo
-		{
-			position[]={-8.6953125,0.18872452,-13.076172};
-		};
-		side="Empty";
-		flags=4;
-		class Attributes
-		{
-		};
-		id=179;
-		type="Box_IND_Wps_F";
-		class CustomAttributes
-		{
-			class Attribute0
-			{
-				property="ammoBox";
-				expression="[_this,_value] call bis_fnc_initAmmoBox;";
-				class Value
-				{
-					class data
-					{
-						class type
-						{
-							type[]=
-							{
-								"STRING"
-							};
-						};
-						value="[[[[""arifle_Mk20C_F"",""arifle_Mk20_F"",""arifle_Mk20_GL_F"",""LMG_Mk200_F"",""hgun_PDW2000_F"",""hgun_ACPC2_F""],[2,4,2,2,1,1]],[[""30Rnd_556x45_Stanag"",""9Rnd_45ACP_Mag"",""30Rnd_9x21_Mag"",""200Rnd_65x39_cased_Box"",""ACE_30Rnd_556x45_Stanag_M995_AP_mag"",""ACE_30Rnd_556x45_Stanag_Mk262_mag"",""ACE_30Rnd_556x45_Stanag_Mk318_mag""],[8,1,1,2,4,4,4]],[[""ACE_MapTools"",""ACE_RangeTable_82mm""],[2,2]],[[""I_Mortar_01_support_F"",""I_Mortar_01_weapon_F""],[2,2]]],false]";
-					};
-				};
-			};
-			nAttributes=1;
-		};
-	};
 	class Item67
 	{
 		dataType="Comment";
 		class PositionInfo
 		{
-			position[]={0.23144531,0,-14.811035};
+			position[]={0.203125,0,-14.835693};
 		};
 		title="v1.14.2";
-		description="-v1.14.2" \n "-Replaced NIArms MG3 with BWMod MG3 " \n "-GM: Fixed ""assign zeus to this unit"" not being present " \n "-All Groups: Fixed radio channel presets " \n "-Gave every unit 1 epi in Uniform, or Vest if uniform was full (medic not included) " \n "-Moved element lead LR radio to backpack " \n "-Added mortar supply crate " \n "-DMT: Removed NVG scope, and replaced main scope with one that can be used with goggles. " \n "-Gave engineers more ammo (1 tracer + 1 for members, 2 tracer for leader)" \n "" \n "-v1.14.1" \n " - A3EE box guard updated to A3AA." \n " - Custom location re-added." \n "" \n "- v1.14.0 " \n "PL: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Boonie Hat"" for more visual diversity in the platoon and to bring PL headgear in line with RU and US Standard Factions. " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n "  - Removed CNTO ""Beret"" from Backpack gear due to old logo texture. " \n " " \n "Platoon Sergeant: " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n "  - Backpack added 3CB ""Radio Backpack MR3000"" and filled it with the ACRE2 ""AN/PRC-117F"" backpack radio. This gives more incentive to bring the PLT Sgt along since he is the only one who can act as a max range radio man for the platoon. " \n " " \n "Platoon Medic: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n " " \n "Platoon Rifleman: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n " " \n "Squad Medic: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n " " \n "FTL: " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n " " \n "AR: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n "  - Added muzzle attachment RHS ""SF3P-556 1/2-28"". " \n " " \n "AAR: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n " " \n "LAT: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n " " \n "MMG Teamleader: " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n " " \n "MMG Gunner: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n "  - Unfortunately no muzzle attachments available for the MG-3! " \n " " \n "MMG Asst. Gunner: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n " " \n "MAT Teamleader: " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n " " \n "MAT Gunner: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n " " \n "MAT Asst. Gunner: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n " " \n "ENG Leader: " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Heavy"" to differentiate ENG from the rest of the platoon. " \n " " \n "ENG Rifleman: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Heavy"" to differentiate ENG from the rest of the platoon. " \n " " \n "Mortar Leader: " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Special"" to visually differentiate the Mortar Team from the rest of the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n "  - Reduced STANAG mags from 10 to 5 to match the ENG ammo count. " \n " " \n "Mortar Gunner: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Special"" to visually differentiate the Mortar Team from the rest of the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n "  - Reduced STANAG mags from 10 to 5 to match the ENG ammo count. " \n " " \n "DMT Leader " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n " " \n "DMT Marksman " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n "  - Added NVG scope RHS ""AN/PVS-27"" to the vest gear. " \n " " \n "Zeus & Co-Zeus " \n "  - Uniform changed from vanilla ""VR Suit Indie"" to CNTO ""Flecktarn Recon"" to make Zeus look a bit more like an HQ commander than a Tron character. " \n "  - Facewear changed from vanilla ""VR Goggles"" to vanilla ""Aviator Glasses"". " \n "  - Insignia added ""Zeus"". " \n " " \n "All Units: " \n "  - Disabled LAMBS AI " \n " " \n "Alpha SL: " \n "  - Enabled ""is Player"". This makes it easier for Mission Makers to quickly test a mission in the editor by just hitting ""play"" instead of having to select a specific unit every time beforehand to avoid ending up in spectator mode by default. " \n " " \n "Crates: " \n "  - Added an ACE3 medical crate with our usual base script. " \n " " \n " " \n "- v1.13.6 " \n "  - ALL Added persistent Call-Signs for all GM's (where not included in v1.13.4) " \n "  - ALL Added the code `this disableAI ""MOVE""; this setSpeaker ""NoVoice""; enableRadio false;` to all playable units to prevent them from running off and spamming the vanilla-radio during local testing. " \n "  - ALL Changed persistent call-signs (map markers) to a consistent formula: ≤ 2 syllables = written out call-sing. ≥ 3 syllables = abbreviated call-sign. " \n "  - ALL Added full changelog to all factions for quick in-game reference " \n "  - TFN Added new yellow owl insignia patches to all uniforms " \n " " \n " " \n "- v1.13.5 " \n "  - ALL Added respective GM's to Standard Faction Compositions for convenience / time saving  " \n "  - ALL Added base clean-up module to Standard Faction Compositions to ensure Mission Makers don't forget it in the future - radius set to 200x200 meters " \n " " \n " " \n "- v1.13.4  " \n "  - ALL Added @ Squad/Team names to leaders so that Team name appears in role select " \n "  - TFN Changed M249 to the FN MINIMI " \n " " \n " " \n "- v1.13.3 " \n "  - US Added Improved Bipod/SAW Grip to AR M249 " \n "  - US Removed M14 Mags " \n "  - TFN Added Bipod to M249 " \n " " \n " " \n "- v1.13.2 " \n "  - ALL Added 1 Extra Tourniquet to every Unit " \n "  - TFN DMT Lead Rifle Changed to D10 Version " \n "  - TFN DMT given extra pistol mag to bring in line with other units " \n "  - TFN AAR Weapon changed to HK416 D14.5 " \n "  - TFN Lead Elements Given AN/PEQ-16A's " \n "  - US Alpha Fireteam 2 AAR vest changed to ALT variant to match rest of faction " \n "  - US Lead Elements Given AN/PEQ-16A's " \n "  - US DMT given extra pistol mag to bring in line with other units " \n "  - US DMT Sniper Rifle Given SU-260/P (MDO) to bring zoom level to the same as Russian and TFN factions " \n "  - US DMT Bipod Changed to Harris Bipod " \n "  - US DMT Marksman Rifle changed to black version of same rifle " \n "  - US DMT Marksman Magazines changed to SR-25 version, as RHS hotfix made M14 mags incompatible with MK11 " \n "  - RUS DMT given extra pistol mag to bring in line with other units " \n "  - RUS DGR Helmets changed to TSH-4 to make distinct from US Helmets " \n "  - RUS NB Helmets changed to ZSH-7A to make distinct from US and TFN helmets " \n "  - RUS Removed RIS Rail adaptors from AK rifles " \n "  - RUS Added PG-7V rocket to MAT ammo crate. This rocket is lighter and packs less payload than the PG-7VL. This gives it an  increased effective range but is less powerful due to decreased payload " \n " " \n " " \n "- v1.12.2 " \n "  - Hotfixed US Vests across the Squads to match V.12 changes. Whoops. " \n "  - Added Angled Grip to TFN HK416s where possible.  " \n " " \n " " \n "- v1.12 " \n "  - Fixed TFN MMG Ammo preloaded into Rifle to 100RND mag from 50rnd. " \n "  - Fixed TFN DMT Marksman Ammo loaded into Rifle to correct SBLR mag. " \n "  - Changed TFN DMT Lead Suppressor to QDSS NT4 Black from Rotex-5 Grey " \n "  - Changed TFN Dagger Uniforms from Gorka R Green to FFCP Green Fatigues [RS] " \n "  - Changed US PLT Commander + Squad Leader Vest from SPCS Rifleman/OEF- CP to SPCS Squad Lead/OEF-CP " \n "  - Changed US Medic Vest from SPCS Rifleman/OEF-CP to SPCS Medic/OEF-CP " \n "  - Changed US PLT Rifleman Vest from SPCS OEF-CP to SPCS Rifleman Alt/OEF-CP " \n "  - Changed US FTL Vest from SPCS Rifleman/OEF-CP to SPCS Team Leader Alt/OEF-CP " \n "  - Changed US AR Vest from SPCS Rifleman/OEF-CP to SPCS SAW/OEF-CP " \n "  - Changed US AAR Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP " \n "  - Changed US Rifleman AT Vest from SPCS OEF-CP to SPCS Rifleman Alt/OEF-CP " \n "  - Changed US MAT/MMG/DMT/ENG/MTR Lead Vest from SPCS Rifleman/OEF-CP to SPCS Team Leader Alt/OEF-CP " \n "  - Changed US MMG Gunner Vest from SPCS Rifleman/OEF-CP to SPCS Machinegunner/OEF-CP " \n "  - Changed US MMG/MAT Ammo Bearer Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP " \n "  - Changed US MAT Gunner Vest from SPCS OEF-CP to SPCS Rifleman Alt/OEF-CP " \n "  - Changed US DMT Marksman vest from SPCS OEF-CP to SPCS Sniper/OEF-CP " \n "  - Fixed US DMT Marksman Rifle Loaded Mag to correct varient. " \n "  - Changed US Engineer Rifleman Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP. " \n "  - Changed US MTR Gunner Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP. " \n "  - Changed US DGR Uniforms from FFCP ACU Fatigues to FFCP ACU Fatigues [RS] " \n "  - Changed US DGR Driver Backpack from Assault Pack Green to Assault Pack Black " \n "  - Changed US Heli Pilot/Copilot Uniforms from Heli pilot Coveralls to FFCP Nomad Fatigues [RS] " \n "  - Fixed US Heli/Jet Pilot Vest White Smoke grenade count to 2. " \n "  - Changed US Heli Pilot/Copilot Helmet from Heli Pilot NATO to HGU-56/P (Black/Visor) " \n "  - Changed US Jet Pilot Uniform from Pilot Coveralls NATO to  FFCP Nomad Fatigues " \n "  - Changed RUS Vic/Heli/Jet Crew Weapons to PP-2000 " \n "  - Upped RUS PP-2000 Ammo counts to 6x Mag to bring in line with ammo counts for TFN and US. " \n "  - Changed RUS Heli Pilot Uniforms from Pilot Coveralls CSAT to FFCP-Fatigues EMR [RS] " \n "  - Changed RUS Heli Pilot Vest from 6B23 (6Sh116) to FFCP Tactical Vest TigerVRS " \n "  - Changed RUS Jet Pilot Uniforms from Pilot Coveralls CSAT to FFCP-Fatigues EMR [RS] " \n "  - Changed RUS Jet Pilot Vest from 6B23 (6Sh116) to FFCP Tactical Vest TigerVRS " \n " " \n " " \n "- v1.11 " \n "  - changed m40 mini grenades to m67 fragmentation " \n "  - replaced mp7 weapons with mp5k-pdw " \n "  - changed ak105 to ak74m (plum)  " \n "  - changed PKM to PKP " \n "  - changed RUS PKM ammo boxes. MMG now loads with 7TZ (AP rounds) " \n "  - added vert grip to us weapons " \n "  - replaced m14 with HK PSG1A1 " \n "  - replaced m260e4 with mg3 " \n "  - updated all ammo boxes respectively.  " \n " " \n " " \n "- v1.10 " \n "  - changed Medic loadouts from 6 x 1000ml blood bags to 2 x 1000ml and 8 x 500ml. " \n " " \n " " \n "- v1.09 " \n "  - updated Fireteam colours A1 Red A2 Yellow, B1 Green B2 Blue, C1 Red C2 Yellow. " \n " " \n " " \n "- v1.08 " \n "  - changed ""Reaper"" to ""Nightbird"", ""RPR"" to ""NB"" " \n "  - changed ""Paladin"" to ""Falcon"", ""PAL"" to ""FC"" " \n "  - changed ""DAGGER"" to ""DGR"" " \n " " \n " " \n "- v1.07 " \n "  - US and RU faction bumped to v1.07 to avoid confusion regarding version numbers (US and RU was 1.05, TFN was 1.06) " \n "  - overhauled the RU faction: updated helmets, uniforms, weapons to a more modern look " \n "  - overhauled the US faction: updated helmets and vests to armour rating of IV " \n "  - corrected some mistakes in all factions (grenade ammount of MMG gunner, ENG not having tourniquetes, DGR not having GPS-s) " \n "  - overhauled the medics of all factions to reflect recent cahnges to ACE medical (less QuikClots, more Elastic Bandages, etc.) " \n " " \n " " \n "- v1.05 " \n "  - Added a MAT ammo box on spawn. " \n " " \n " " \n "- v1.04 " \n "  - All MAT Teams carrying RPG's got the ver3 scopes with ranges for all types " \n "    of ammo. " \n "  - All Callsigns were changed to be uniformed throught no matter the faction. " \n " " \n " " \n "- v1.03 " \n "  - set crew driver/gunner and pilot/copilot/jetpilot as Engineers through the " \n "    Object: ACE Options menu in unit attributes " \n "  - overhauled the TFN faction (weapons, helmets, etc.), changes not applicable " \n "    to derived factions " \n " " \n " " \n "- v1.02 " \n "  - loadout overhaul for DMT, made them lighter + gave them tools for recon " \n "  - specified preset ACRE2 radio channels for most units " \n " " \n " " \n "- v1.01 " \n "  - updated team colors func to `a3ee_team_colors_fnc_setColor`, just load+save " \n "    the composition in editor, this fixes it " \n "  - changed RPG-7 using MAT teams to carry Kitbags " \n "  - removed one PKM ammo box from AAR, MMG gunner, MMG bearer (fixes overload) " \n "  - moved 1-2 AR boxes from AAR to AR, gave AR an Assaultpack " \n "  - added 1-2 more AR boxes to AR's Assaultpack (if enough space) " \n "  - changed HEDP to HE rockets for Carl Gustav (M3MAAWS) " \n "  - changed US crew uniform and helmet to match grey color scheme of US pilots " \n "  - changed backpacks of driver/copilot to use less contrasting colors compared " \n "    to their respective uniform/vest colors " \n "  - changed Carryall backpacks of TFN Engineers to use custom Flecktarn Carryall " \n "  - changed all (GP-25 and normal) AK74m rifles to be the non-NPZ variants " \n "  - removed secondary long-range (PRC148) from Engineers " \n " " \n " " \n "- v1.00 (and before) " \n "  - added a Comment object with version number (`v1.00`) " \n "  - added `respawn_west`, `respawn_east`, `respawn_guerrila` markers " \n "  - added `[this, 200] call a3ee_fnc_boxGuard` to init lines of resupply boxes " \n "  - added `Resupply` green triangle markers on the position of resupply boxes";
-		id=180;
+		description="-v1.14.2" \n "-Replaced NIArms MG3 with BWMod MG3 " \n "-GM: Fixed ""assign zeus to this unit"" not being present " \n "-All Groups: Fixed radio channel presets " \n "-Fixed fireteam colours from A3AA update." \n "-Gave every unit 1 epi in Uniform, or Vest if uniform was full (medic not included) " \n "-Moved element lead LR radio to backpack " \n "-Added mortar supply crate " \n "-DMT: Removed NVG scope, and replaced main scope with one that can be used with goggles. " \n "-Gave engineers more ammo (1 tracer + 1 for members, 2 tracer for leader)" \n "" \n "-v1.14.1" \n " - A3EE box guard updated to A3AA." \n " - Custom location re-added." \n "" \n "- v1.14.0 " \n "PL: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Boonie Hat"" for more visual diversity in the platoon and to bring PL headgear in line with RU and US Standard Factions. " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n "  - Removed CNTO ""Beret"" from Backpack gear due to old logo texture. " \n " " \n "Platoon Sergeant: " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n "  - Backpack added 3CB ""Radio Backpack MR3000"" and filled it with the ACRE2 ""AN/PRC-117F"" backpack radio. This gives more incentive to bring the PLT Sgt along since he is the only one who can act as a max range radio man for the platoon. " \n " " \n "Platoon Medic: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n " " \n "Platoon Rifleman: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n " " \n "Squad Medic: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n " " \n "FTL: " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n " " \n "AR: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n "  - Added muzzle attachment RHS ""SF3P-556 1/2-28"". " \n " " \n "AAR: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n " " \n "LAT: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n " " \n "MMG Teamleader: " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n " " \n "MMG Gunner: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n "  - Unfortunately no muzzle attachments available for the MG-3! " \n " " \n "MMG Asst. Gunner: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n " " \n "MAT Teamleader: " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n " " \n "MAT Gunner: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n " " \n "MAT Asst. Gunner: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n " " \n "ENG Leader: " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Heavy"" to differentiate ENG from the rest of the platoon. " \n " " \n "ENG Rifleman: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Heavy"" to differentiate ENG from the rest of the platoon. " \n " " \n "Mortar Leader: " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Special"" to visually differentiate the Mortar Team from the rest of the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n "  - Reduced STANAG mags from 10 to 5 to match the ENG ammo count. " \n " " \n "Mortar Gunner: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Special"" to visually differentiate the Mortar Team from the rest of the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n "  - Reduced STANAG mags from 10 to 5 to match the ENG ammo count. " \n " " \n "DMT Leader " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n " " \n "DMT Marksman " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n "  - Added NVG scope RHS ""AN/PVS-27"" to the vest gear. " \n " " \n "Zeus & Co-Zeus " \n "  - Uniform changed from vanilla ""VR Suit Indie"" to CNTO ""Flecktarn Recon"" to make Zeus look a bit more like an HQ commander than a Tron character. " \n "  - Facewear changed from vanilla ""VR Goggles"" to vanilla ""Aviator Glasses"". " \n "  - Insignia added ""Zeus"". " \n " " \n "All Units: " \n "  - Disabled LAMBS AI " \n " " \n "Alpha SL: " \n "  - Enabled ""is Player"". This makes it easier for Mission Makers to quickly test a mission in the editor by just hitting ""play"" instead of having to select a specific unit every time beforehand to avoid ending up in spectator mode by default. " \n " " \n "Crates: " \n "  - Added an ACE3 medical crate with our usual base script. " \n " " \n " " \n "- v1.13.6 " \n "  - ALL Added persistent Call-Signs for all GM's (where not included in v1.13.4) " \n "  - ALL Added the code `this disableAI ""MOVE""; this setSpeaker ""NoVoice""; enableRadio false;` to all playable units to prevent them from running off and spamming the vanilla-radio during local testing. " \n "  - ALL Changed persistent call-signs (map markers) to a consistent formula: ≤ 2 syllables = written out call-sing. ≥ 3 syllables = abbreviated call-sign. " \n "  - ALL Added full changelog to all factions for quick in-game reference " \n "  - TFN Added new yellow owl insignia patches to all uniforms " \n " " \n " " \n "- v1.13.5 " \n "  - ALL Added respective GM's to Standard Faction Compositions for convenience / time saving  " \n "  - ALL Added base clean-up module to Standard Faction Compositions to ensure Mission Makers don't forget it in the future - radius set to 200x200 meters " \n " " \n " " \n "- v1.13.4  " \n "  - ALL Added @ Squad/Team names to leaders so that Team name appears in role select " \n "  - TFN Changed M249 to the FN MINIMI " \n " " \n " " \n "- v1.13.3 " \n "  - US Added Improved Bipod/SAW Grip to AR M249 " \n "  - US Removed M14 Mags " \n "  - TFN Added Bipod to M249 " \n " " \n " " \n "- v1.13.2 " \n "  - ALL Added 1 Extra Tourniquet to every Unit " \n "  - TFN DMT Lead Rifle Changed to D10 Version " \n "  - TFN DMT given extra pistol mag to bring in line with other units " \n "  - TFN AAR Weapon changed to HK416 D14.5 " \n "  - TFN Lead Elements Given AN/PEQ-16A's " \n "  - US Alpha Fireteam 2 AAR vest changed to ALT variant to match rest of faction " \n "  - US Lead Elements Given AN/PEQ-16A's " \n "  - US DMT given extra pistol mag to bring in line with other units " \n "  - US DMT Sniper Rifle Given SU-260/P (MDO) to bring zoom level to the same as Russian and TFN factions " \n "  - US DMT Bipod Changed to Harris Bipod " \n "  - US DMT Marksman Rifle changed to black version of same rifle " \n "  - US DMT Marksman Magazines changed to SR-25 version, as RHS hotfix made M14 mags incompatible with MK11 " \n "  - RUS DMT given extra pistol mag to bring in line with other units " \n "  - RUS DGR Helmets changed to TSH-4 to make distinct from US Helmets " \n "  - RUS NB Helmets changed to ZSH-7A to make distinct from US and TFN helmets " \n "  - RUS Removed RIS Rail adaptors from AK rifles " \n "  - RUS Added PG-7V rocket to MAT ammo crate. This rocket is lighter and packs less payload than the PG-7VL. This gives it an  increased effective range but is less powerful due to decreased payload " \n " " \n " " \n "- v1.12.2 " \n "  - Hotfixed US Vests across the Squads to match V.12 changes. Whoops. " \n "  - Added Angled Grip to TFN HK416s where possible.  " \n " " \n " " \n "- v1.12 " \n "  - Fixed TFN MMG Ammo preloaded into Rifle to 100RND mag from 50rnd. " \n "  - Fixed TFN DMT Marksman Ammo loaded into Rifle to correct SBLR mag. " \n "  - Changed TFN DMT Lead Suppressor to QDSS NT4 Black from Rotex-5 Grey " \n "  - Changed TFN Dagger Uniforms from Gorka R Green to FFCP Green Fatigues [RS] " \n "  - Changed US PLT Commander + Squad Leader Vest from SPCS Rifleman/OEF- CP to SPCS Squad Lead/OEF-CP " \n "  - Changed US Medic Vest from SPCS Rifleman/OEF-CP to SPCS Medic/OEF-CP " \n "  - Changed US PLT Rifleman Vest from SPCS OEF-CP to SPCS Rifleman Alt/OEF-CP " \n "  - Changed US FTL Vest from SPCS Rifleman/OEF-CP to SPCS Team Leader Alt/OEF-CP " \n "  - Changed US AR Vest from SPCS Rifleman/OEF-CP to SPCS SAW/OEF-CP " \n "  - Changed US AAR Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP " \n "  - Changed US Rifleman AT Vest from SPCS OEF-CP to SPCS Rifleman Alt/OEF-CP " \n "  - Changed US MAT/MMG/DMT/ENG/MTR Lead Vest from SPCS Rifleman/OEF-CP to SPCS Team Leader Alt/OEF-CP " \n "  - Changed US MMG Gunner Vest from SPCS Rifleman/OEF-CP to SPCS Machinegunner/OEF-CP " \n "  - Changed US MMG/MAT Ammo Bearer Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP " \n "  - Changed US MAT Gunner Vest from SPCS OEF-CP to SPCS Rifleman Alt/OEF-CP " \n "  - Changed US DMT Marksman vest from SPCS OEF-CP to SPCS Sniper/OEF-CP " \n "  - Fixed US DMT Marksman Rifle Loaded Mag to correct varient. " \n "  - Changed US Engineer Rifleman Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP. " \n "  - Changed US MTR Gunner Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP. " \n "  - Changed US DGR Uniforms from FFCP ACU Fatigues to FFCP ACU Fatigues [RS] " \n "  - Changed US DGR Driver Backpack from Assault Pack Green to Assault Pack Black " \n "  - Changed US Heli Pilot/Copilot Uniforms from Heli pilot Coveralls to FFCP Nomad Fatigues [RS] " \n "  - Fixed US Heli/Jet Pilot Vest White Smoke grenade count to 2. " \n "  - Changed US Heli Pilot/Copilot Helmet from Heli Pilot NATO to HGU-56/P (Black/Visor) " \n "  - Changed US Jet Pilot Uniform from Pilot Coveralls NATO to  FFCP Nomad Fatigues " \n "  - Changed RUS Vic/Heli/Jet Crew Weapons to PP-2000 " \n "  - Upped RUS PP-2000 Ammo counts to 6x Mag to bring in line with ammo counts for TFN and US. " \n "  - Changed RUS Heli Pilot Uniforms from Pilot Coveralls CSAT to FFCP-Fatigues EMR [RS] " \n "  - Changed RUS Heli Pilot Vest from 6B23 (6Sh116) to FFCP Tactical Vest TigerVRS " \n "  - Changed RUS Jet Pilot Uniforms from Pilot Coveralls CSAT to FFCP-Fatigues EMR [RS] " \n "  - Changed RUS Jet Pilot Vest from 6B23 (6Sh116) to FFCP Tactical Vest TigerVRS " \n " " \n " " \n "- v1.11 " \n "  - changed m40 mini grenades to m67 fragmentation " \n "  - replaced mp7 weapons with mp5k-pdw " \n "  - changed ak105 to ak74m (plum)  " \n "  - changed PKM to PKP " \n "  - changed RUS PKM ammo boxes. MMG now loads with 7TZ (AP rounds) " \n "  - added vert grip to us weapons " \n "  - replaced m14 with HK PSG1A1 " \n "  - replaced m260e4 with mg3 " \n "  - updated all ammo boxes respectively.  " \n " " \n " " \n "- v1.10 " \n "  - changed Medic loadouts from 6 x 1000ml blood bags to 2 x 1000ml and 8 x 500ml. " \n " " \n " " \n "- v1.09 " \n "  - updated Fireteam colours A1 Red A2 Yellow, B1 Green B2 Blue, C1 Red C2 Yellow. " \n " " \n " " \n "- v1.08 " \n "  - changed ""Reaper"" to ""Nightbird"", ""RPR"" to ""NB"" " \n "  - changed ""Paladin"" to ""Falcon"", ""PAL"" to ""FC"" " \n "  - changed ""DAGGER"" to ""DGR"" " \n " " \n " " \n "- v1.07 " \n "  - US and RU faction bumped to v1.07 to avoid confusion regarding version numbers (US and RU was 1.05, TFN was 1.06) " \n "  - overhauled the RU faction: updated helmets, uniforms, weapons to a more modern look " \n "  - overhauled the US faction: updated helmets and vests to armour rating of IV " \n "  - corrected some mistakes in all factions (grenade ammount of MMG gunner, ENG not having tourniquetes, DGR not having GPS-s) " \n "  - overhauled the medics of all factions to reflect recent cahnges to ACE medical (less QuikClots, more Elastic Bandages, etc.) " \n " " \n " " \n "- v1.05 " \n "  - Added a MAT ammo box on spawn. " \n " " \n " " \n "- v1.04 " \n "  - All MAT Teams carrying RPG's got the ver3 scopes with ranges for all types " \n "    of ammo. " \n "  - All Callsigns were changed to be uniformed throught no matter the faction. " \n " " \n " " \n "- v1.03 " \n "  - set crew driver/gunner and pilot/copilot/jetpilot as Engineers through the " \n "    Object: ACE Options menu in unit attributes " \n "  - overhauled the TFN faction (weapons, helmets, etc.), changes not applicable " \n "    to derived factions " \n " " \n " " \n "- v1.02 " \n "  - loadout overhaul for DMT, made them lighter + gave them tools for recon " \n "  - specified preset ACRE2 radio channels for most units " \n " " \n " " \n "- v1.01 " \n "  - updated team colors func to `a3ee_team_colors_fnc_setColor`, just load+save " \n "    the composition in editor, this fixes it " \n "  - changed RPG-7 using MAT teams to carry Kitbags " \n "  - removed one PKM ammo box from AAR, MMG gunner, MMG bearer (fixes overload) " \n "  - moved 1-2 AR boxes from AAR to AR, gave AR an Assaultpack " \n "  - added 1-2 more AR boxes to AR's Assaultpack (if enough space) " \n "  - changed HEDP to HE rockets for Carl Gustav (M3MAAWS) " \n "  - changed US crew uniform and helmet to match grey color scheme of US pilots " \n "  - changed backpacks of driver/copilot to use less contrasting colors compared " \n "    to their respective uniform/vest colors " \n "  - changed Carryall backpacks of TFN Engineers to use custom Flecktarn Carryall " \n "  - changed all (GP-25 and normal) AK74m rifles to be the non-NPZ variants " \n "  - removed secondary long-range (PRC148) from Engineers " \n " " \n " " \n "- v1.00 (and before) " \n "  - added a Comment object with version number (`v1.00`) " \n "  - added `respawn_west`, `respawn_east`, `respawn_guerrila` markers " \n "  - added `[this, 200] call a3ee_fnc_boxGuard` to init lines of resupply boxes " \n "  - added `Resupply` green triangle markers on the position of resupply boxes";
+		id=179;
 	};
 };

--- a/reference/PMC%20Faction/composition.sqe
+++ b/reference/PMC%20Faction/composition.sqe
@@ -1,27 +1,27 @@
 version=53;
-center[]={5961.0049,5,5298.2031};
+center[]={3000.5588,5,3837.3384};
 class items
 {
-	items=67;
+	items=69;
 	class Item0
 	{
 		dataType="Marker";
-		position[]={0.54931641,1.3349106e+013,-1.4169922};
+		position[]={0.54541016,1.3349106e+013,-1.2211914};
 		name="respawn_guerrila";
 		type="respawn_unknown";
-		id=231;
+		id=0;
 		atlOffset=1.3349106e+013;
 	};
 	class Item1
 	{
 		dataType="Marker";
-		position[]={-22.450195,0.29708433,15.583008};
+		position[]={-22.454102,0.29708433,15.778809};
 		name="Rifles_6";
 		text="Rifles";
 		type="mil_triangle";
 		colorName="ColorGreen";
 		angle=2.177;
-		id=232;
+		id=1;
 	};
 	class Item2
 	{
@@ -35,7 +35,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-22.450195,0.0014390945,5.6328125};
+					position[]={-22.453857,0.0014390945,5.8286133};
 				};
 				side="Independent";
 				flags=7;
@@ -82,7 +82,7 @@ class items
 							isBackpack=0;
 							class ItemCargo
 							{
-								items=10;
+								items=8;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -121,16 +121,6 @@ class items
 								class Item7
 								{
 									name="ACE_MapTools";
-									count=1;
-								};
-								class Item8
-								{
-									name="ACRE_PRC152";
-									count=1;
-								};
-								class Item9
-								{
-									name="ACRE_PRC148";
 									count=1;
 								};
 							};
@@ -175,10 +165,15 @@ class items
 							};
 							class ItemCargo
 							{
-								items=1;
+								items=2;
 								class Item0
 								{
 									name="ACE_tourniquet";
+									count=1;
+								};
+								class Item1
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -229,7 +224,7 @@ class items
 							};
 							class ItemCargo
 							{
-								items=2;
+								items=4;
 								class Item0
 								{
 									name="ACE_IR_Strobe_Item";
@@ -238,6 +233,16 @@ class items
 								class Item1
 								{
 									name="cnto_flecktarn_h_beret";
+									count=1;
+								};
+								class Item2
+								{
+									name="ACRE_PRC152";
+									count=1;
+								};
+								class Item3
+								{
+									name="ACRE_PRC148";
 									count=1;
 								};
 							};
@@ -249,11 +254,30 @@ class items
 						headgear="cnto_flecktarn_h_beret";
 					};
 				};
-				id=234;
+				id=3;
 				type="I_officer_F";
 				class CustomAttributes
 				{
 					class Attribute0
+					{
+						property="speaker";
+						expression="_this setspeaker _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="Male06GRE";
+							};
+						};
+					};
+					class Attribute1
 					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
@@ -272,7 +296,90 @@ class items
 							};
 						};
 					};
-					nAttributes=1;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=3;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="4";
+										};
+									};
+									class Item1
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+									class Item2
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="5";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute3
+					{
+						property="pitch";
+						expression="_this setpitch _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"SCALAR"
+									};
+								};
+								value=1;
+							};
+						};
+					};
+					nAttributes=4;
 				};
 			};
 			class Item1
@@ -280,7 +387,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-20.451172,0.0014390945,5.6337891};
+					position[]={-20.455078,0.0014390945,5.8295898};
 				};
 				side="Independent";
 				flags=5;
@@ -489,7 +596,7 @@ class items
 						headgear="LOP_H_Cowboy_hat";
 					};
 				};
-				id=235;
+				id=4;
 				type="I_medic_F";
 				class CustomAttributes
 				{
@@ -512,7 +619,43 @@ class items
 							};
 						};
 					};
-					nAttributes=1;
+					class Attribute1
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="4";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=2;
 				};
 			};
 			class Item2
@@ -520,7 +663,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-19.451172,0.0014390945,5.6337891};
+					position[]={-19.455078,0.0014390945,5.8295898};
 				};
 				side="Independent";
 				flags=5;
@@ -567,7 +710,7 @@ class items
 							};
 							class ItemCargo
 							{
-								items=6;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -596,6 +739,11 @@ class items
 								class Item5
 								{
 									name="ACRE_PRC343";
+									count=1;
+								};
+								class Item6
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -648,7 +796,7 @@ class items
 						headgear="cnto_flecktarn_h_boo_mediterranean";
 					};
 				};
-				id=236;
+				id=5;
 				type="I_soldier_F";
 				class CustomAttributes
 				{
@@ -671,7 +819,43 @@ class items
 							};
 						};
 					};
-					nAttributes=1;
+					class Attribute1
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="4";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=2;
 				};
 			};
 			class Item3
@@ -679,7 +863,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-21.450195,0.0014390945,5.6328125};
+					position[]={-21.453857,0.0014390945,5.8286133};
 				};
 				side="Independent";
 				flags=4;
@@ -812,10 +996,15 @@ class items
 							};
 							class ItemCargo
 							{
-								items=1;
+								items=2;
 								class Item0
 								{
 									name="ACE_tourniquet";
+									count=1;
+								};
+								class Item1
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -827,11 +1016,30 @@ class items
 						headgear="cnto_flecktarn_h_s_mediterranean";
 					};
 				};
-				id=237;
+				id=6;
 				type="I_soldier_F";
 				class CustomAttributes
 				{
 					class Attribute0
+					{
+						property="speaker";
+						expression="_this setspeaker _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="Male06GRE";
+							};
+						};
+					};
+					class Attribute1
 					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
@@ -850,14 +1058,97 @@ class items
 							};
 						};
 					};
-					nAttributes=1;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=3;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="4";
+										};
+									};
+									class Item1
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+									class Item2
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="3";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute3
+					{
+						property="pitch";
+						expression="_this setpitch _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"SCALAR"
+									};
+								};
+								value=0.94999999;
+							};
+						};
+					};
+					nAttributes=4;
 				};
 			};
 		};
 		class Attributes
 		{
 		};
-		id=233;
+		id=2;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -894,7 +1185,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-22.509277,0.0014390945,3.3388672};
+					position[]={-22.513184,0.0014390945,3.534668};
 				};
 				side="Independent";
 				flags=7;
@@ -1000,7 +1291,7 @@ class items
 								};
 								class Item8
 								{
-									name="ACRE_PRC152";
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -1105,10 +1396,15 @@ class items
 							};
 							class ItemCargo
 							{
-								items=1;
+								items=2;
 								class Item0
 								{
 									name="ACE_IR_Strobe_Item";
+									count=1;
+								};
+								class Item1
+								{
+									name="ACRE_PRC152";
 									count=1;
 								};
 							};
@@ -1120,11 +1416,30 @@ class items
 						headgear="H_Cap_headphones";
 					};
 				};
-				id=239;
+				id=8;
 				type="I_Soldier_SL_F";
 				class CustomAttributes
 				{
 					class Attribute0
+					{
+						property="speaker";
+						expression="_this setspeaker _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="Male04GRE";
+							};
+						};
+					};
+					class Attribute1
 					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
@@ -1143,7 +1458,57 @@ class items
 							};
 						};
 					};
-					nAttributes=1;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=2;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+									class Item1
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=3;
 				};
 			};
 			class Item1
@@ -1151,7 +1516,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-21.508789,0.0014390945,3.3398438};
+					position[]={-21.512695,0.0014390945,3.5356445};
 				};
 				side="Independent";
 				flags=5;
@@ -1360,7 +1725,7 @@ class items
 						headgear="LOP_H_Cowboy_hat";
 					};
 				};
-				id=240;
+				id=9;
 				type="I_medic_F";
 				class CustomAttributes
 				{
@@ -1383,7 +1748,43 @@ class items
 							};
 						};
 					};
-					nAttributes=1;
+					class Attribute1
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=2;
 				};
 			};
 			class Item2
@@ -1391,7 +1792,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-22.508789,0.0014390945,1.3398438};
+					position[]={-22.512695,0.0014390945,1.5356445};
 				};
 				side="Independent";
 				flags=5;
@@ -1531,10 +1932,15 @@ class items
 							};
 							class ItemCargo
 							{
-								items=1;
+								items=2;
 								class Item0
 								{
 									name="ACE_tourniquet";
+									count=1;
+								};
+								class Item1
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -1600,7 +2006,7 @@ class items
 						headgear="rhsusf_bowman_cap";
 					};
 				};
-				id=241;
+				id=10;
 				type="I_Soldier_TL_F";
 				class CustomAttributes
 				{
@@ -1623,7 +2029,43 @@ class items
 							};
 						};
 					};
-					nAttributes=1;
+					class Attribute1
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=2;
 				};
 			};
 			class Item3
@@ -1631,7 +2073,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-21.508789,0.0014390945,1.3398438};
+					position[]={-21.512695,0.0014390945,1.5356445};
 				};
 				side="Independent";
 				flags=5;
@@ -1677,7 +2119,7 @@ class items
 							};
 							class ItemCargo
 							{
-								items=6;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -1706,6 +2148,11 @@ class items
 								class Item5
 								{
 									name="ACRE_PRC343";
+									count=1;
+								};
+								class Item6
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -1774,7 +2221,7 @@ class items
 						headgear="H_ShemagOpen_khk";
 					};
 				};
-				id=242;
+				id=11;
 				type="I_Soldier_AR_F";
 				class CustomAttributes
 				{
@@ -1797,7 +2244,43 @@ class items
 							};
 						};
 					};
-					nAttributes=1;
+					class Attribute1
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=2;
 				};
 			};
 			class Item4
@@ -1805,7 +2288,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-20.508789,0.0014390945,1.3398438};
+					position[]={-20.512695,0.0014390945,1.5356445};
 				};
 				side="Independent";
 				flags=5;
@@ -1863,7 +2346,7 @@ class items
 							};
 							class ItemCargo
 							{
-								items=8;
+								items=9;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -1902,6 +2385,11 @@ class items
 								class Item7
 								{
 									name="ACE_MapTools";
+									count=1;
+								};
+								class Item8
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -1997,7 +2485,7 @@ class items
 						headgear="H_Booniehat_khk_hs";
 					};
 				};
-				id=243;
+				id=12;
 				type="I_Soldier_AAR_F";
 				class CustomAttributes
 				{
@@ -2020,7 +2508,43 @@ class items
 							};
 						};
 					};
-					nAttributes=1;
+					class Attribute1
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=2;
 				};
 			};
 			class Item5
@@ -2028,7 +2552,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-19.508789,0.0014390945,1.3398438};
+					position[]={-19.512695,0.0014390945,1.5356445};
 				};
 				side="Independent";
 				flags=5;
@@ -2079,7 +2603,7 @@ class items
 							};
 							class ItemCargo
 							{
-								items=6;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -2108,6 +2632,11 @@ class items
 								class Item5
 								{
 									name="ACRE_PRC343";
+									count=1;
+								};
+								class Item6
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -2160,7 +2689,7 @@ class items
 						headgear="LOP_H_Beanie_dpmw";
 					};
 				};
-				id=244;
+				id=13;
 				type="I_Soldier_LAT_F";
 				class CustomAttributes
 				{
@@ -2183,7 +2712,43 @@ class items
 							};
 						};
 					};
-					nAttributes=1;
+					class Attribute1
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=2;
 				};
 			};
 			class Item6
@@ -2191,7 +2756,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-22.508789,0.0014390945,-0.66015625};
+					position[]={-22.512695,0.0014390945,-0.46435547};
 				};
 				side="Independent";
 				flags=5;
@@ -2331,10 +2896,15 @@ class items
 							};
 							class ItemCargo
 							{
-								items=1;
+								items=2;
 								class Item0
 								{
 									name="ACE_tourniquet";
+									count=1;
+								};
+								class Item1
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -2400,7 +2970,7 @@ class items
 						headgear="rhsusf_bowman_cap";
 					};
 				};
-				id=245;
+				id=14;
 				type="I_Soldier_TL_F";
 				class CustomAttributes
 				{
@@ -2423,7 +2993,43 @@ class items
 							};
 						};
 					};
-					nAttributes=1;
+					class Attribute1
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=2;
 				};
 			};
 			class Item7
@@ -2431,7 +3037,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-21.508789,0.0014390945,-0.66015625};
+					position[]={-21.512695,0.0014390945,-0.46435547};
 				};
 				side="Independent";
 				flags=5;
@@ -2477,7 +3083,7 @@ class items
 							};
 							class ItemCargo
 							{
-								items=6;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -2506,6 +3112,11 @@ class items
 								class Item5
 								{
 									name="ACRE_PRC343";
+									count=1;
+								};
+								class Item6
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -2574,7 +3185,7 @@ class items
 						headgear="H_ShemagOpen_khk";
 					};
 				};
-				id=246;
+				id=15;
 				type="I_Soldier_AR_F";
 				class CustomAttributes
 				{
@@ -2597,7 +3208,43 @@ class items
 							};
 						};
 					};
-					nAttributes=1;
+					class Attribute1
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=2;
 				};
 			};
 			class Item8
@@ -2605,7 +3252,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-20.508789,0.0014390945,-0.66015625};
+					position[]={-20.512695,0.0014390945,-0.46435547};
 				};
 				side="Independent";
 				flags=5;
@@ -2663,7 +3310,7 @@ class items
 							};
 							class ItemCargo
 							{
-								items=8;
+								items=9;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -2702,6 +3349,11 @@ class items
 								class Item7
 								{
 									name="ACE_MapTools";
+									count=1;
+								};
+								class Item8
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -2797,7 +3449,7 @@ class items
 						headgear="H_Booniehat_khk_hs";
 					};
 				};
-				id=247;
+				id=16;
 				type="I_Soldier_AAR_F";
 				class CustomAttributes
 				{
@@ -2820,7 +3472,43 @@ class items
 							};
 						};
 					};
-					nAttributes=1;
+					class Attribute1
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=2;
 				};
 			};
 			class Item9
@@ -2828,7 +3516,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-19.508789,0.0014390945,-0.66015625};
+					position[]={-19.512695,0.0014390945,-0.46435547};
 				};
 				side="Independent";
 				flags=5;
@@ -2879,7 +3567,7 @@ class items
 							};
 							class ItemCargo
 							{
-								items=6;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -2908,6 +3596,11 @@ class items
 								class Item5
 								{
 									name="ACRE_PRC343";
+									count=1;
+								};
+								class Item6
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -2960,7 +3653,7 @@ class items
 						headgear="LOP_H_Beanie_dpmw";
 					};
 				};
-				id=248;
+				id=17;
 				type="I_Soldier_LAT_F";
 				class CustomAttributes
 				{
@@ -2983,14 +3676,50 @@ class items
 							};
 						};
 					};
-					nAttributes=1;
+					class Attribute1
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=2;
 				};
 			};
 		};
 		class Attributes
 		{
 		};
-		id=238;
+		id=7;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -3027,7 +3756,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-16.946289,0.0014390945,3.2275391};
+					position[]={-16.950195,0.0014390945,3.4233398};
 				};
 				side="Independent";
 				flags=7;
@@ -3133,7 +3862,7 @@ class items
 								};
 								class Item8
 								{
-									name="ACRE_PRC152";
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -3238,10 +3967,15 @@ class items
 							};
 							class ItemCargo
 							{
-								items=1;
+								items=2;
 								class Item0
 								{
 									name="ACE_IR_Strobe_Item";
+									count=1;
+								};
+								class Item1
+								{
+									name="ACRE_PRC152";
 									count=1;
 								};
 							};
@@ -3253,7 +3987,7 @@ class items
 						headgear="H_Cap_headphones";
 					};
 				};
-				id=250;
+				id=19;
 				type="I_Soldier_SL_F";
 				class CustomAttributes
 				{
@@ -3276,7 +4010,57 @@ class items
 							};
 						};
 					};
-					nAttributes=1;
+					class Attribute1
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=2;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="2";
+										};
+									};
+									class Item1
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=2;
 				};
 			};
 			class Item1
@@ -3284,7 +4068,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-15.947266,0.0014390945,3.2275391};
+					position[]={-15.951172,0.0014390945,3.4233398};
 				};
 				side="Independent";
 				flags=5;
@@ -3493,7 +4277,7 @@ class items
 						headgear="LOP_H_Cowboy_hat";
 					};
 				};
-				id=251;
+				id=20;
 				type="I_medic_F";
 				class CustomAttributes
 				{
@@ -3516,7 +4300,43 @@ class items
 							};
 						};
 					};
-					nAttributes=1;
+					class Attribute1
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="2";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=2;
 				};
 			};
 			class Item2
@@ -3524,7 +4344,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-16.947266,0.0014390945,1.2275391};
+					position[]={-16.951172,0.0014390945,1.4233398};
 				};
 				side="Independent";
 				flags=5;
@@ -3664,10 +4484,15 @@ class items
 							};
 							class ItemCargo
 							{
-								items=1;
+								items=2;
 								class Item0
 								{
 									name="ACE_tourniquet";
+									count=1;
+								};
+								class Item1
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -3733,7 +4558,7 @@ class items
 						headgear="rhsusf_bowman_cap";
 					};
 				};
-				id=252;
+				id=21;
 				type="I_Soldier_TL_F";
 				class CustomAttributes
 				{
@@ -3756,7 +4581,43 @@ class items
 							};
 						};
 					};
-					nAttributes=1;
+					class Attribute1
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="2";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=2;
 				};
 			};
 			class Item3
@@ -3764,7 +4625,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-15.947266,0.0014390945,1.2275391};
+					position[]={-15.951172,0.0014390945,1.4233398};
 				};
 				side="Independent";
 				flags=5;
@@ -3810,7 +4671,7 @@ class items
 							};
 							class ItemCargo
 							{
-								items=6;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -3839,6 +4700,11 @@ class items
 								class Item5
 								{
 									name="ACRE_PRC343";
+									count=1;
+								};
+								class Item6
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -3907,7 +4773,7 @@ class items
 						headgear="H_ShemagOpen_khk";
 					};
 				};
-				id=253;
+				id=22;
 				type="I_Soldier_AR_F";
 				class CustomAttributes
 				{
@@ -3930,7 +4796,43 @@ class items
 							};
 						};
 					};
-					nAttributes=1;
+					class Attribute1
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="2";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=2;
 				};
 			};
 			class Item4
@@ -3938,7 +4840,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-14.946777,0.0014390945,1.2275391};
+					position[]={-14.950684,0.0014390945,1.4233398};
 				};
 				side="Independent";
 				flags=5;
@@ -3996,7 +4898,7 @@ class items
 							};
 							class ItemCargo
 							{
-								items=8;
+								items=9;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -4035,6 +4937,11 @@ class items
 								class Item7
 								{
 									name="ACE_MapTools";
+									count=1;
+								};
+								class Item8
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -4130,7 +5037,7 @@ class items
 						headgear="H_Booniehat_khk_hs";
 					};
 				};
-				id=254;
+				id=23;
 				type="I_Soldier_AAR_F";
 				class CustomAttributes
 				{
@@ -4153,7 +5060,43 @@ class items
 							};
 						};
 					};
-					nAttributes=1;
+					class Attribute1
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="2";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=2;
 				};
 			};
 			class Item5
@@ -4161,7 +5104,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-13.947266,0.0014390945,1.2275391};
+					position[]={-13.951172,0.0014390945,1.4233398};
 				};
 				side="Independent";
 				flags=5;
@@ -4212,7 +5155,7 @@ class items
 							};
 							class ItemCargo
 							{
-								items=6;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -4241,6 +5184,11 @@ class items
 								class Item5
 								{
 									name="ACRE_PRC343";
+									count=1;
+								};
+								class Item6
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -4293,7 +5241,7 @@ class items
 						headgear="LOP_H_Beanie_dpmw";
 					};
 				};
-				id=255;
+				id=24;
 				type="I_Soldier_LAT_F";
 				class CustomAttributes
 				{
@@ -4316,7 +5264,43 @@ class items
 							};
 						};
 					};
-					nAttributes=1;
+					class Attribute1
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="2";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=2;
 				};
 			};
 			class Item6
@@ -4324,7 +5308,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-16.947266,0.0014390945,-0.77246094};
+					position[]={-16.951172,0.0014390945,-0.57666016};
 				};
 				side="Independent";
 				flags=5;
@@ -4464,10 +5448,15 @@ class items
 							};
 							class ItemCargo
 							{
-								items=1;
+								items=2;
 								class Item0
 								{
 									name="ACE_tourniquet";
+									count=1;
+								};
+								class Item1
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -4533,7 +5522,7 @@ class items
 						headgear="rhsusf_bowman_cap";
 					};
 				};
-				id=256;
+				id=25;
 				type="I_Soldier_TL_F";
 				class CustomAttributes
 				{
@@ -4556,7 +5545,43 @@ class items
 							};
 						};
 					};
-					nAttributes=1;
+					class Attribute1
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="2";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=2;
 				};
 			};
 			class Item7
@@ -4564,7 +5589,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-15.947266,0.0014390945,-0.77246094};
+					position[]={-15.951172,0.0014390945,-0.57666016};
 				};
 				side="Independent";
 				flags=5;
@@ -4610,7 +5635,7 @@ class items
 							};
 							class ItemCargo
 							{
-								items=6;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -4639,6 +5664,11 @@ class items
 								class Item5
 								{
 									name="ACRE_PRC343";
+									count=1;
+								};
+								class Item6
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -4707,7 +5737,7 @@ class items
 						headgear="H_ShemagOpen_khk";
 					};
 				};
-				id=257;
+				id=26;
 				type="I_Soldier_AR_F";
 				class CustomAttributes
 				{
@@ -4730,7 +5760,43 @@ class items
 							};
 						};
 					};
-					nAttributes=1;
+					class Attribute1
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="2";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=2;
 				};
 			};
 			class Item8
@@ -4738,7 +5804,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-14.947266,0.0014390945,-0.77246094};
+					position[]={-14.951172,0.0014390945,-0.57666016};
 				};
 				side="Independent";
 				flags=5;
@@ -4796,7 +5862,7 @@ class items
 							};
 							class ItemCargo
 							{
-								items=8;
+								items=9;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -4835,6 +5901,11 @@ class items
 								class Item7
 								{
 									name="ACE_MapTools";
+									count=1;
+								};
+								class Item8
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -4930,7 +6001,7 @@ class items
 						headgear="H_Booniehat_khk_hs";
 					};
 				};
-				id=258;
+				id=27;
 				type="I_Soldier_AAR_F";
 				class CustomAttributes
 				{
@@ -4953,7 +6024,43 @@ class items
 							};
 						};
 					};
-					nAttributes=1;
+					class Attribute1
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="2";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=2;
 				};
 			};
 			class Item9
@@ -4961,7 +6068,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-13.947266,0.0014390945,-0.77246094};
+					position[]={-13.951172,0.0014390945,-0.57666016};
 				};
 				side="Independent";
 				flags=5;
@@ -5012,7 +6119,7 @@ class items
 							};
 							class ItemCargo
 							{
-								items=6;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -5041,6 +6148,11 @@ class items
 								class Item5
 								{
 									name="ACRE_PRC343";
+									count=1;
+								};
+								class Item6
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -5093,7 +6205,7 @@ class items
 						headgear="LOP_H_Beanie_dpmw";
 					};
 				};
-				id=259;
+				id=28;
 				type="I_Soldier_LAT_F";
 				class CustomAttributes
 				{
@@ -5116,14 +6228,50 @@ class items
 							};
 						};
 					};
-					nAttributes=1;
+					class Attribute1
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="2";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=2;
 				};
 			};
 		};
 		class Attributes
 		{
 		};
-		id=249;
+		id=18;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -5160,7 +6308,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-11.898926,0.0014390945,3.1201172};
+					position[]={-11.902832,0.0014390945,3.315918};
 				};
 				side="Independent";
 				flags=7;
@@ -5266,7 +6414,7 @@ class items
 								};
 								class Item8
 								{
-									name="ACRE_PRC152";
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -5371,10 +6519,15 @@ class items
 							};
 							class ItemCargo
 							{
-								items=1;
+								items=2;
 								class Item0
 								{
 									name="ACE_IR_Strobe_Item";
+									count=1;
+								};
+								class Item1
+								{
+									name="ACRE_PRC152";
 									count=1;
 								};
 							};
@@ -5386,7 +6539,7 @@ class items
 						headgear="H_Cap_headphones";
 					};
 				};
-				id=261;
+				id=30;
 				type="I_Soldier_SL_F";
 				class CustomAttributes
 				{
@@ -5409,7 +6562,57 @@ class items
 							};
 						};
 					};
-					nAttributes=1;
+					class Attribute1
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=2;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="3";
+										};
+									};
+									class Item1
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=2;
 				};
 			};
 			class Item1
@@ -5417,7 +6620,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-10.898926,0.0014390945,3.1191406};
+					position[]={-10.902832,0.0014390945,3.3149414};
 				};
 				side="Independent";
 				flags=5;
@@ -5626,7 +6829,7 @@ class items
 						headgear="LOP_H_Cowboy_hat";
 					};
 				};
-				id=262;
+				id=31;
 				type="I_medic_F";
 				class CustomAttributes
 				{
@@ -5649,7 +6852,43 @@ class items
 							};
 						};
 					};
-					nAttributes=1;
+					class Attribute1
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="3";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=2;
 				};
 			};
 			class Item2
@@ -5657,7 +6896,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-11.898926,0.0014390945,1.1191406};
+					position[]={-11.902832,0.0014390945,1.3149414};
 				};
 				side="Independent";
 				flags=5;
@@ -5797,10 +7036,15 @@ class items
 							};
 							class ItemCargo
 							{
-								items=1;
+								items=2;
 								class Item0
 								{
 									name="ACE_tourniquet";
+									count=1;
+								};
+								class Item1
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -5866,7 +7110,7 @@ class items
 						headgear="rhsusf_bowman_cap";
 					};
 				};
-				id=263;
+				id=32;
 				type="I_Soldier_TL_F";
 				class CustomAttributes
 				{
@@ -5889,7 +7133,43 @@ class items
 							};
 						};
 					};
-					nAttributes=1;
+					class Attribute1
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="3";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=2;
 				};
 			};
 			class Item3
@@ -5897,7 +7177,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-10.898926,0.0014390945,1.1191406};
+					position[]={-10.902832,0.0014390945,1.3149414};
 				};
 				side="Independent";
 				flags=5;
@@ -5943,7 +7223,7 @@ class items
 							};
 							class ItemCargo
 							{
-								items=6;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -5972,6 +7252,11 @@ class items
 								class Item5
 								{
 									name="ACRE_PRC343";
+									count=1;
+								};
+								class Item6
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -6040,7 +7325,7 @@ class items
 						headgear="H_ShemagOpen_khk";
 					};
 				};
-				id=264;
+				id=33;
 				type="I_Soldier_AR_F";
 				class CustomAttributes
 				{
@@ -6063,7 +7348,43 @@ class items
 							};
 						};
 					};
-					nAttributes=1;
+					class Attribute1
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="3";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=2;
 				};
 			};
 			class Item4
@@ -6071,7 +7392,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-9.8989258,0.0014390945,1.1191406};
+					position[]={-9.902832,0.0014390945,1.3149414};
 				};
 				side="Independent";
 				flags=5;
@@ -6129,7 +7450,7 @@ class items
 							};
 							class ItemCargo
 							{
-								items=8;
+								items=9;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -6168,6 +7489,11 @@ class items
 								class Item7
 								{
 									name="ACE_MapTools";
+									count=1;
+								};
+								class Item8
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -6263,7 +7589,7 @@ class items
 						headgear="H_Booniehat_khk_hs";
 					};
 				};
-				id=265;
+				id=34;
 				type="I_Soldier_AAR_F";
 				class CustomAttributes
 				{
@@ -6286,7 +7612,43 @@ class items
 							};
 						};
 					};
-					nAttributes=1;
+					class Attribute1
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="3";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=2;
 				};
 			};
 			class Item5
@@ -6294,7 +7656,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-8.8989258,0.0014390945,1.1191406};
+					position[]={-8.902832,0.0014390945,1.3149414};
 				};
 				side="Independent";
 				flags=5;
@@ -6345,7 +7707,7 @@ class items
 							};
 							class ItemCargo
 							{
-								items=6;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -6374,6 +7736,11 @@ class items
 								class Item5
 								{
 									name="ACRE_PRC343";
+									count=1;
+								};
+								class Item6
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -6426,7 +7793,7 @@ class items
 						headgear="LOP_H_Beanie_dpmw";
 					};
 				};
-				id=266;
+				id=35;
 				type="I_Soldier_LAT_F";
 				class CustomAttributes
 				{
@@ -6449,7 +7816,43 @@ class items
 							};
 						};
 					};
-					nAttributes=1;
+					class Attribute1
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="3";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=2;
 				};
 			};
 			class Item6
@@ -6457,7 +7860,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-11.898926,0.0014390945,-0.88085938};
+					position[]={-11.902832,0.0014390945,-0.68505859};
 				};
 				side="Independent";
 				flags=5;
@@ -6597,10 +8000,15 @@ class items
 							};
 							class ItemCargo
 							{
-								items=1;
+								items=2;
 								class Item0
 								{
 									name="ACE_tourniquet";
+									count=1;
+								};
+								class Item1
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -6666,7 +8074,7 @@ class items
 						headgear="rhsusf_bowman_cap";
 					};
 				};
-				id=267;
+				id=36;
 				type="I_Soldier_TL_F";
 				class CustomAttributes
 				{
@@ -6689,7 +8097,43 @@ class items
 							};
 						};
 					};
-					nAttributes=1;
+					class Attribute1
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="3";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=2;
 				};
 			};
 			class Item7
@@ -6697,7 +8141,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-10.898926,0.0014390945,-0.88085938};
+					position[]={-10.902832,0.0014390945,-0.68505859};
 				};
 				side="Independent";
 				flags=5;
@@ -6743,7 +8187,7 @@ class items
 							};
 							class ItemCargo
 							{
-								items=6;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -6772,6 +8216,11 @@ class items
 								class Item5
 								{
 									name="ACRE_PRC343";
+									count=1;
+								};
+								class Item6
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -6840,7 +8289,7 @@ class items
 						headgear="H_ShemagOpen_khk";
 					};
 				};
-				id=268;
+				id=37;
 				type="I_Soldier_AR_F";
 				class CustomAttributes
 				{
@@ -6863,7 +8312,43 @@ class items
 							};
 						};
 					};
-					nAttributes=1;
+					class Attribute1
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="3";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=2;
 				};
 			};
 			class Item8
@@ -6871,7 +8356,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-9.8989258,0.0014390945,-0.88085938};
+					position[]={-9.902832,0.0014390945,-0.68505859};
 				};
 				side="Independent";
 				flags=5;
@@ -6929,7 +8414,7 @@ class items
 							};
 							class ItemCargo
 							{
-								items=8;
+								items=9;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -6968,6 +8453,11 @@ class items
 								class Item7
 								{
 									name="ACE_MapTools";
+									count=1;
+								};
+								class Item8
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -7063,7 +8553,7 @@ class items
 						headgear="H_Booniehat_khk_hs";
 					};
 				};
-				id=269;
+				id=38;
 				type="I_Soldier_AAR_F";
 				class CustomAttributes
 				{
@@ -7086,7 +8576,43 @@ class items
 							};
 						};
 					};
-					nAttributes=1;
+					class Attribute1
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="3";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=2;
 				};
 			};
 			class Item9
@@ -7094,7 +8620,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-8.8989258,0.0014390945,-0.88085938};
+					position[]={-8.902832,0.0014390945,-0.68505859};
 				};
 				side="Independent";
 				flags=5;
@@ -7145,7 +8671,7 @@ class items
 							};
 							class ItemCargo
 							{
-								items=6;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -7174,6 +8700,11 @@ class items
 								class Item5
 								{
 									name="ACRE_PRC343";
+									count=1;
+								};
+								class Item6
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -7226,7 +8757,7 @@ class items
 						headgear="LOP_H_Beanie_dpmw";
 					};
 				};
-				id=270;
+				id=39;
 				type="I_Soldier_LAT_F";
 				class CustomAttributes
 				{
@@ -7249,14 +8780,50 @@ class items
 							};
 						};
 					};
-					nAttributes=1;
+					class Attribute1
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="3";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=2;
 				};
 			};
 		};
 		class Attributes
 		{
 		};
-		id=260;
+		id=29;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -7284,12 +8851,12 @@ class items
 	class Item6
 	{
 		dataType="Marker";
-		position[]={-9.4501953,0.036262512,-9.4169922};
+		position[]={-9.4541016,0.035955906,-9.2211914};
 		name="resupply_marker_2";
 		text="Resupply";
 		type="mil_triangle";
 		colorName="ColorGreen";
-		id=271;
+		id=40;
 		atlOffset=0.00015306473;
 	};
 	class Item7
@@ -7297,7 +8864,7 @@ class items
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={-22.450195,0.79142618,16.583008};
+			position[]={-22.454102,0.79142618,16.778809};
 		};
 		side="Empty";
 		flags=4;
@@ -7305,7 +8872,7 @@ class items
 		{
 			disableSimulation=1;
 		};
-		id=272;
+		id=41;
 		type="Land_Noticeboard_F";
 	};
 	class Item8
@@ -7313,7 +8880,7 @@ class items
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={-15.450195,0.79142618,16.583008};
+			position[]={-15.454102,0.79142618,16.778809};
 		};
 		side="Empty";
 		flags=4;
@@ -7321,7 +8888,7 @@ class items
 		{
 			disableSimulation=1;
 		};
-		id=273;
+		id=42;
 		type="Land_Noticeboard_F";
 	};
 	class Item9
@@ -7329,37 +8896,37 @@ class items
 		dataType="Comment";
 		class PositionInfo
 		{
-			position[]={-22.450195,0,17.583008};
+			position[]={-22.454102,0,17.778809};
 		};
 		title="Standard Rifles";
-		id=274;
+		id=43;
 	};
 	class Item10
 	{
 		dataType="Comment";
 		class PositionInfo
 		{
-			position[]={-15.450195,0,17.583008};
+			position[]={-15.454102,0,17.778809};
 		};
 		title="SL & FTLS";
-		id=275;
+		id=44;
 	};
 	class Item11
 	{
 		dataType="Comment";
 		class PositionInfo
 		{
-			position[]={-8.4501953,0,17.583008};
+			position[]={-8.4541016,0,17.778809};
 		};
 		title="DMT";
-		id=276;
+		id=45;
 	};
 	class Item12
 	{
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={-8.4501953,0.79142618,16.583008};
+			position[]={-8.4541016,0.79142618,16.778809};
 		};
 		side="Empty";
 		flags=4;
@@ -7367,30 +8934,30 @@ class items
 		{
 			disableSimulation=1;
 		};
-		id=277;
+		id=46;
 		type="Land_Noticeboard_F";
 	};
 	class Item13
 	{
 		dataType="Marker";
-		position[]={-15.450195,0.29708433,15.583008};
+		position[]={-15.454102,0.29708433,15.778809};
 		name="Rifles_7";
 		text="SL & FTLS";
 		type="mil_triangle";
 		colorName="ColorGreen";
 		angle=2.177;
-		id=278;
+		id=47;
 	};
 	class Item14
 	{
 		dataType="Marker";
-		position[]={-8.4501953,0.29708433,15.583008};
+		position[]={-8.4541016,0.29708433,15.778809};
 		name="Rifles_8";
 		text="DMT";
 		type="mil_triangle";
 		colorName="ColorGreen";
 		angle=2.177;
-		id=279;
+		id=48;
 	};
 	class Item15
 	{
@@ -7404,7 +8971,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-22.508789,0.0014390945,-4.6601563};
+					position[]={-22.512695,0.0014390945,-4.4643555};
 				};
 				side="Independent";
 				flags=7;
@@ -7461,7 +9028,7 @@ class items
 							};
 							class ItemCargo
 							{
-								items=9;
+								items=8;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -7500,11 +9067,6 @@ class items
 								class Item7
 								{
 									name="ACE_MapTools";
-									count=1;
-								};
-								class Item8
-								{
-									name="ACRE_PRC152";
 									count=1;
 								};
 							};
@@ -7549,10 +9111,15 @@ class items
 							};
 							class ItemCargo
 							{
-								items=1;
+								items=2;
 								class Item0
 								{
 									name="ACE_tourniquet";
+									count=1;
+								};
+								class Item1
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -7609,10 +9176,15 @@ class items
 							};
 							class ItemCargo
 							{
-								items=1;
+								items=2;
 								class Item0
 								{
 									name="ACE_IR_Strobe_Item";
+									count=1;
+								};
+								class Item1
+								{
+									name="ACRE_PRC152";
 									count=1;
 								};
 							};
@@ -7624,7 +9196,7 @@ class items
 						headgear="LOP_H_Beanie_dpmw";
 					};
 				};
-				id=281;
+				id=50;
 				type="I_Soldier_TL_F";
 				class CustomAttributes
 				{
@@ -7666,7 +9238,57 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=2;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="5";
+										};
+									};
+									class Item1
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=3;
 				};
 			};
 			class Item1
@@ -7674,7 +9296,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-21.508789,0.0014390945,-4.6611328};
+					position[]={-21.512695,0.0014390945,-4.465332};
 				};
 				side="Independent";
 				flags=5;
@@ -7720,7 +9342,7 @@ class items
 							};
 							class ItemCargo
 							{
-								items=6;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -7749,6 +9371,11 @@ class items
 								class Item5
 								{
 									name="ACRE_PRC343";
+									count=1;
+								};
+								class Item6
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -7804,7 +9431,7 @@ class items
 						headgear="LOP_H_Cowboy_hat";
 					};
 				};
-				id=282;
+				id=51;
 				type="I_Soldier_AR_F";
 				class CustomAttributes
 				{
@@ -7846,7 +9473,43 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="5";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=3;
 				};
 			};
 			class Item2
@@ -7854,7 +9517,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-20.508789,0.0014390945,-4.6611328};
+					position[]={-20.512695,0.0014390945,-4.465332};
 				};
 				side="Independent";
 				flags=5;
@@ -7907,7 +9570,7 @@ class items
 							};
 							class ItemCargo
 							{
-								items=6;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -7936,6 +9599,11 @@ class items
 								class Item5
 								{
 									name="ACRE_PRC343";
+									count=1;
+								};
+								class Item6
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -8003,7 +9671,7 @@ class items
 						headgear="LOP_H_Beanie_dpmw";
 					};
 				};
-				id=283;
+				id=52;
 				type="I_Soldier_AAR_F";
 				class CustomAttributes
 				{
@@ -8045,14 +9713,50 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="5";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=3;
 				};
 			};
 		};
 		class Attributes
 		{
 		};
-		id=280;
+		id=49;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -8089,7 +9793,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-16.265625,0.0014390945,-4.6953125};
+					position[]={-16.269531,0.0014390945,-4.4995117};
 				};
 				side="Independent";
 				flags=7;
@@ -8146,7 +9850,7 @@ class items
 							};
 							class ItemCargo
 							{
-								items=9;
+								items=8;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -8185,11 +9889,6 @@ class items
 								class Item7
 								{
 									name="ACE_MapTools";
-									count=1;
-								};
-								class Item8
-								{
-									name="ACRE_PRC152";
 									count=1;
 								};
 							};
@@ -8294,10 +9993,20 @@ class items
 							};
 							class ItemCargo
 							{
-								items=1;
+								items=3;
 								class Item0
 								{
 									name="ACE_IR_Strobe_Item";
+									count=1;
+								};
+								class Item1
+								{
+									name="ACE_epinephrine";
+									count=1;
+								};
+								class Item2
+								{
+									name="ACRE_PRC152";
 									count=1;
 								};
 							};
@@ -8309,7 +10018,7 @@ class items
 						headgear="H_ShemagOpen_khk";
 					};
 				};
-				id=285;
+				id=54;
 				type="I_Soldier_TL_F";
 				class CustomAttributes
 				{
@@ -8351,7 +10060,57 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=2;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="6";
+										};
+									};
+									class Item1
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=3;
 				};
 			};
 			class Item1
@@ -8359,7 +10118,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-15.26709,0.0014390945,-4.6933594};
+					position[]={-15.270996,0.0014390945,-4.4975586};
 				};
 				side="Independent";
 				flags=5;
@@ -8415,7 +10174,7 @@ class items
 							};
 							class ItemCargo
 							{
-								items=6;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -8444,6 +10203,11 @@ class items
 								class Item5
 								{
 									name="ACRE_PRC343";
+									count=1;
+								};
+								class Item6
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -8517,7 +10281,7 @@ class items
 						headgear="LOP_H_Cowboy_hat";
 					};
 				};
-				id=286;
+				id=55;
 				type="I_Soldier_AT_F";
 				class CustomAttributes
 				{
@@ -8559,7 +10323,43 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="6";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=3;
 				};
 			};
 			class Item2
@@ -8567,7 +10367,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-14.26709,0.0014390945,-4.6933594};
+					position[]={-14.270996,0.0014390945,-4.4975586};
 				};
 				side="Independent";
 				flags=5;
@@ -8614,7 +10414,7 @@ class items
 							};
 							class ItemCargo
 							{
-								items=6;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -8643,6 +10443,11 @@ class items
 								class Item5
 								{
 									name="ACRE_PRC343";
+									count=1;
+								};
+								class Item6
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -8716,7 +10521,7 @@ class items
 						headgear="LOP_H_Beanie_dpmw";
 					};
 				};
-				id=287;
+				id=56;
 				type="I_Soldier_AAT_F";
 				class CustomAttributes
 				{
@@ -8758,14 +10563,50 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="6";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=3;
 				};
 			};
 		};
 		class Attributes
 		{
 		};
-		id=284;
+		id=53;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -8802,7 +10643,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-22.769531,0.0014390945,-7.3291016};
+					position[]={-22.773438,0.0014390945,-7.1333008};
 				};
 				side="Independent";
 				flags=7;
@@ -8865,7 +10706,7 @@ class items
 							};
 							class ItemCargo
 							{
-								items=9;
+								items=10;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -8909,6 +10750,11 @@ class items
 								class Item8
 								{
 									name="ACRE_PRC152";
+									count=1;
+								};
+								class Item9
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -8983,7 +10829,7 @@ class items
 						headgear="H_Booniehat_khk_hs";
 					};
 				};
-				id=289;
+				id=58;
 				type="I_Spotter_F";
 				class CustomAttributes
 				{
@@ -9025,7 +10871,57 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=2;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="8";
+										};
+									};
+									class Item1
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=3;
 				};
 			};
 			class Item1
@@ -9033,7 +10929,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-21.77002,0.0014390945,-7.3300781};
+					position[]={-21.773926,0.0014390945,-7.1342773};
 				};
 				side="Independent";
 				flags=4;
@@ -9047,7 +10943,7 @@ class items
 						class primaryWeapon
 						{
 							name="arifle_SPAR_03_khk_F";
-							optics="optic_SOS";
+							optics="rhsusf_acc_ACOG3_USMC";
 							class primaryMuzzleMag
 							{
 								name="20Rnd_762x51_Mag";
@@ -9084,7 +10980,7 @@ class items
 							};
 							class ItemCargo
 							{
-								items=11;
+								items=12;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -9140,6 +11036,11 @@ class items
 									name="ACRE_PRC343";
 									count=1;
 								};
+								class Item11
+								{
+									name="ACE_epinephrine";
+									count=1;
+								};
 							};
 						};
 						class vest
@@ -9170,7 +11071,7 @@ class items
 							};
 							class ItemCargo
 							{
-								items=3;
+								items=2;
 								class Item0
 								{
 									name="ACE_IR_Strobe_Item";
@@ -9179,11 +11080,6 @@ class items
 								class Item1
 								{
 									name="ACE_tourniquet";
-									count=1;
-								};
-								class Item2
-								{
-									name="rhsusf_acc_anpvs27";
 									count=1;
 								};
 							};
@@ -9195,7 +11091,7 @@ class items
 						headgear="LOP_H_Beanie_dpmw";
 					};
 				};
-				id=290;
+				id=59;
 				type="I_Sniper_F";
 				class CustomAttributes
 				{
@@ -9237,14 +11133,50 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="8";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=3;
 				};
 			};
 		};
 		class Attributes
 		{
 		};
-		id=288;
+		id=57;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -9281,7 +11213,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-16.638672,0.0014390945,-7.390625};
+					position[]={-16.642578,0.0014390945,-7.1948242};
 				};
 				side="Independent";
 				flags=7;
@@ -9333,7 +11265,7 @@ class items
 							};
 							class ItemCargo
 							{
-								items=9;
+								items=10;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -9377,6 +11309,11 @@ class items
 								class Item8
 								{
 									name="ACRE_PRC152";
+									count=1;
+								};
+								class Item9
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -9447,7 +11384,7 @@ class items
 						headgear="H_ShemagOpen_khk";
 					};
 				};
-				id=292;
+				id=61;
 				type="I_support_AMort_F";
 				class CustomAttributes
 				{
@@ -9497,7 +11434,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-15.637695,0.0014390945,-7.390625};
+					position[]={-15.641602,0.0014390945,-7.1948242};
 				};
 				side="Independent";
 				flags=5;
@@ -9544,7 +11481,7 @@ class items
 							};
 							class ItemCargo
 							{
-								items=8;
+								items=9;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -9583,6 +11520,11 @@ class items
 								class Item7
 								{
 									name="ACE_RangeTable_82mm";
+									count=1;
+								};
+								class Item8
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -9640,7 +11582,7 @@ class items
 						headgear="H_Booniehat_khk_hs";
 					};
 				};
-				id=293;
+				id=62;
 				type="I_support_Mort_F";
 				class CustomAttributes
 				{
@@ -9689,7 +11631,7 @@ class items
 		class Attributes
 		{
 		};
-		id=291;
+		id=60;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -9726,7 +11668,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-11.370605,0.0014390945,-4.65625};
+					position[]={-11.374512,0.0014390945,-4.4604492};
 				};
 				side="Independent";
 				flags=7;
@@ -9816,7 +11758,7 @@ class items
 								};
 								class Item7
 								{
-									name="ACRE_PRC152";
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -9843,19 +11785,19 @@ class items
 								class Item2
 								{
 									name="rhs_mag_30Rnd_556x45_M855A1_Stanag";
-									count=6;
+									count=2;
 									ammoLeft=30;
 								};
 								class Item3
 								{
 									name="rhs_mag_30Rnd_556x45_M855A1_Stanag_Tracer_Red";
-									count=1;
+									count=2;
 									ammoLeft=30;
 								};
 							};
 							class ItemCargo
 							{
-								items=5;
+								items=6;
 								class Item0
 								{
 									name="ACE_M26_Clacker";
@@ -9881,28 +11823,28 @@ class items
 									name="ACE_tourniquet";
 									count=1;
 								};
+								class Item5
+								{
+									name="ACE_epinephrine";
+									count=1;
+								};
 							};
 						};
 						class backpack
 						{
 							typeName="cnto_flecktarn_b_ca_grassland";
 							isBackpack=1;
-							class MagazineCargo
-							{
-								items=1;
-								class Item0
-								{
-									name="rhs_mag_30Rnd_556x45_M855A1_Stanag_Tracer_Red";
-									count=1;
-									ammoLeft=30;
-								};
-							};
 							class ItemCargo
 							{
-								items=1;
+								items=2;
 								class Item0
 								{
 									name="ToolKit";
+									count=1;
+								};
+								class Item1
+								{
+									name="ACRE_PRC152";
 									count=1;
 								};
 							};
@@ -9914,7 +11856,7 @@ class items
 						headgear="LOP_H_Beanie_dpmw";
 					};
 				};
-				id=295;
+				id=64;
 				type="I_engineer_F";
 				class CustomAttributes
 				{
@@ -9956,7 +11898,57 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=2;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="7";
+										};
+									};
+									class Item1
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=3;
 				};
 			};
 			class Item1
@@ -9964,7 +11956,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-10.370605,0.0014390945,-4.65625};
+					position[]={-10.374512,0.0014390945,-4.4604492};
 				};
 				side="Independent";
 				flags=5;
@@ -10003,19 +11995,9 @@ class items
 						{
 							typeName="cnto_flecktarn_u_t_urban";
 							isBackpack=0;
-							class MagazineCargo
-							{
-								items=1;
-								class Item0
-								{
-									name="rhs_mag_30Rnd_556x45_M855A1_Stanag";
-									count=1;
-									ammoLeft=30;
-								};
-							};
 							class ItemCargo
 							{
-								items=7;
+								items=8;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -10051,6 +12033,11 @@ class items
 									name="ACRE_PRC343";
 									count=1;
 								};
+								class Item7
+								{
+									name="ACE_epinephrine";
+									count=1;
+								};
 							};
 						};
 						class vest
@@ -10075,7 +12062,7 @@ class items
 								class Item2
 								{
 									name="rhs_mag_30Rnd_556x45_M855A1_Stanag";
-									count=7;
+									count=5;
 									ammoLeft=30;
 								};
 								class Item3
@@ -10119,16 +12106,6 @@ class items
 						{
 							typeName="cnto_flecktarn_b_ca_grassland";
 							isBackpack=1;
-							class MagazineCargo
-							{
-								items=1;
-								class Item0
-								{
-									name="rhs_mag_30Rnd_556x45_M855A1_Stanag_Tracer_Red";
-									count=1;
-									ammoLeft=30;
-								};
-							};
 							class ItemCargo
 							{
 								items=1;
@@ -10146,7 +12123,7 @@ class items
 						headgear="H_ShemagOpen_khk";
 					};
 				};
-				id=296;
+				id=65;
 				type="I_engineer_F";
 				class CustomAttributes
 				{
@@ -10188,7 +12165,43 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="7";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=3;
 				};
 			};
 			class Item2
@@ -10196,7 +12209,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-9.3706055,0.0014390945,-4.65625};
+					position[]={-9.3745117,0.0014390945,-4.4604492};
 				};
 				side="Independent";
 				flags=5;
@@ -10235,16 +12248,6 @@ class items
 						{
 							typeName="NatoU_CCE_Combo_rs";
 							isBackpack=0;
-							class MagazineCargo
-							{
-								items=1;
-								class Item0
-								{
-									name="rhs_mag_30Rnd_556x45_M855A1_Stanag";
-									count=1;
-									ammoLeft=30;
-								};
-							};
 							class ItemCargo
 							{
 								items=7;
@@ -10307,7 +12310,7 @@ class items
 								class Item2
 								{
 									name="rhs_mag_30Rnd_556x45_M855A1_Stanag";
-									count=7;
+									count=5;
 									ammoLeft=30;
 								};
 								class Item3
@@ -10319,7 +12322,7 @@ class items
 							};
 							class ItemCargo
 							{
-								items=5;
+								items=6;
 								class Item0
 								{
 									name="ACE_M26_Clacker";
@@ -10343,6 +12346,11 @@ class items
 								class Item4
 								{
 									name="ACE_tourniquet";
+									count=1;
+								};
+								class Item5
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -10378,7 +12386,7 @@ class items
 						headgear="H_Booniehat_khk_hs";
 					};
 				};
-				id=297;
+				id=66;
 				type="I_engineer_F";
 				class CustomAttributes
 				{
@@ -10420,7 +12428,43 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="7";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=3;
 				};
 			};
 			class Item3
@@ -10428,7 +12472,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-8.3706055,0.0014390945,-4.65625};
+					position[]={-8.3745117,0.0014390945,-4.4604492};
 				};
 				side="Independent";
 				flags=5;
@@ -10473,19 +12517,19 @@ class items
 								class Item0
 								{
 									name="rhs_mag_30Rnd_556x45_M855A1_Stanag";
-									count=8;
+									count=5;
 									ammoLeft=30;
 								};
 								class Item1
 								{
 									name="rhs_mag_30Rnd_556x45_M855A1_Stanag_Tracer_Red";
-									count=2;
+									count=1;
 									ammoLeft=30;
 								};
 							};
 							class ItemCargo
 							{
-								items=7;
+								items=8;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -10519,6 +12563,11 @@ class items
 								class Item6
 								{
 									name="ACRE_PRC343";
+									count=1;
+								};
+								class Item7
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -10594,7 +12643,7 @@ class items
 						headgear="LOP_H_Cowboy_hat";
 					};
 				};
-				id=298;
+				id=67;
 				type="I_engineer_F";
 				class CustomAttributes
 				{
@@ -10636,14 +12685,50 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="7";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=3;
 				};
 			};
 		};
 		class Attributes
 		{
 		};
-		id=294;
+		id=63;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -10680,7 +12765,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-23.038574,0.0014390945,-10.007813};
+					position[]={-23.04248,0.0014390945,-9.8120117};
 				};
 				side="Independent";
 				flags=7;
@@ -10722,7 +12807,7 @@ class items
 							isBackpack=0;
 							class ItemCargo
 							{
-								items=8;
+								items=9;
 								class Item0
 								{
 									name="ACE_quikclot";
@@ -10761,6 +12846,11 @@ class items
 								class Item7
 								{
 									name="ACRE_PRC148";
+									count=1;
+								};
+								class Item8
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -10827,7 +12917,7 @@ class items
 						headgear="H_Booniehat_khk_hs";
 					};
 				};
-				id=300;
+				id=69;
 				type="I_crew_F";
 				class CustomAttributes
 				{
@@ -10869,7 +12959,71 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=3;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="0";
+										};
+									};
+									class Item1
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+									class Item2
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="2";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=3;
 				};
 			};
 			class Item1
@@ -10877,7 +13031,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-22.038574,0.0014390945,-10.007813};
+					position[]={-22.04248,0.0014390945,-9.8120117};
 				};
 				side="Independent";
 				flags=5;
@@ -10998,10 +13152,15 @@ class items
 							};
 							class ItemCargo
 							{
-								items=1;
+								items=2;
 								class Item0
 								{
 									name="ACE_tourniquet";
+									count=1;
+								};
+								class Item1
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -11028,7 +13187,7 @@ class items
 						headgear="rhsusf_bowman_cap";
 					};
 				};
-				id=301;
+				id=70;
 				type="I_crew_F";
 				class CustomAttributes
 				{
@@ -11097,7 +13256,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-21.038574,0.0014390945,-10.007813};
+					position[]={-21.04248,0.0014390945,-9.8120117};
 				};
 				side="Independent";
 				flags=5;
@@ -11219,10 +13378,15 @@ class items
 							};
 							class ItemCargo
 							{
-								items=1;
+								items=2;
 								class Item0
 								{
 									name="ACE_tourniquet";
+									count=1;
+								};
+								class Item1
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -11234,7 +13398,7 @@ class items
 						headgear="LOP_H_Beanie_dpmw";
 					};
 				};
-				id=302;
+				id=71;
 				type="I_crew_F";
 				class CustomAttributes
 				{
@@ -11302,7 +13466,7 @@ class items
 		class Attributes
 		{
 		};
-		id=299;
+		id=68;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -11339,7 +13503,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-16.758789,0.0014390945,-10.196289};
+					position[]={-16.762695,0.0014390945,-10.000488};
 				};
 				side="Independent";
 				flags=7;
@@ -11381,7 +13545,7 @@ class items
 							isBackpack=0;
 							class ItemCargo
 							{
-								items=8;
+								items=9;
 								class Item0
 								{
 									name="ACE_quikclot";
@@ -11420,6 +13584,11 @@ class items
 								class Item7
 								{
 									name="ACE_tourniquet";
+									count=1;
+								};
+								class Item8
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -11486,7 +13655,7 @@ class items
 						headgear="H_ShemagOpen_khk";
 					};
 				};
-				id=304;
+				id=73;
 				type="I_pilot_F";
 				class CustomAttributes
 				{
@@ -11547,7 +13716,71 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					class Attribute3
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=3;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="0";
+										};
+									};
+									class Item1
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+									class Item2
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="3";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=4;
 				};
 			};
 			class Item1
@@ -11555,7 +13788,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-15.758789,0.0014390945,-10.195313};
+					position[]={-15.762695,0.0014390945,-9.9995117};
 				};
 				side="Independent";
 				flags=5;
@@ -11606,7 +13839,7 @@ class items
 							};
 							class ItemCargo
 							{
-								items=8;
+								items=9;
 								class Item0
 								{
 									name="ACE_quikclot";
@@ -11645,6 +13878,11 @@ class items
 								class Item7
 								{
 									name="ACE_tourniquet";
+									count=1;
+								};
+								class Item8
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -11725,7 +13963,7 @@ class items
 						headgear="LOP_H_Cowboy_hat";
 					};
 				};
-				id=305;
+				id=74;
 				type="I_pilot_F";
 				class CustomAttributes
 				{
@@ -11786,14 +14024,78 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					class Attribute3
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=3;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="0";
+										};
+									};
+									class Item1
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+									class Item2
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="3";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=4;
 				};
 			};
 		};
 		class Attributes
 		{
 		};
-		id=303;
+		id=72;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -11830,7 +14132,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-13.022461,0.0014390945,-10.325195};
+					position[]={-13.026367,0.0014390945,-10.129395};
 				};
 				side="Independent";
 				flags=7;
@@ -11871,7 +14173,7 @@ class items
 							isBackpack=0;
 							class ItemCargo
 							{
-								items=8;
+								items=9;
 								class Item0
 								{
 									name="ACE_quikclot";
@@ -11910,6 +14212,11 @@ class items
 								class Item7
 								{
 									name="ACE_tourniquet";
+									count=1;
+								};
+								class Item8
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -11974,7 +14281,7 @@ class items
 						headgear="H_PilotHelmetFighter_I";
 					};
 				};
-				id=307;
+				id=76;
 				type="I_pilot_F";
 				class CustomAttributes
 				{
@@ -12035,14 +14342,78 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					class Attribute3
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=3;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="0";
+										};
+									};
+									class Item1
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+									class Item2
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="3";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=4;
 				};
 			};
 		};
 		class Attributes
 		{
 		};
-		id=306;
+		id=75;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -12072,7 +14443,7 @@ class items
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={-8.8911133,0.28405476,-8.7460938};
+			position[]={-8.8950195,0.28405476,-8.550293};
 		};
 		side="Empty";
 		flags=4;
@@ -12080,7 +14451,7 @@ class items
 		{
 			init="call{[this, 200] call a3aa_fnc_boxGuard}";
 		};
-		id=308;
+		id=77;
 		type="Box_IND_Ammo_F";
 		class CustomAttributes
 		{
@@ -12111,7 +14482,7 @@ class items
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={-8.8383789,0.89242268,-11.12793};
+			position[]={-8.8422852,0.89242268,-10.932129};
 		};
 		side="Empty";
 		flags=4;
@@ -12119,7 +14490,7 @@ class items
 		{
 			init="call{[this, 200] call a3aa_fnc_boxGuard}";
 		};
-		id=309;
+		id=78;
 		type="I_supplyCrate_F";
 		class CustomAttributes
 		{
@@ -12150,7 +14521,7 @@ class items
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={-11.009277,0.14963102,-10.056641};
+			position[]={-11.013184,0.14963102,-9.8608398};
 			angles[]={-0,4.7330365,0};
 		};
 		side="Empty";
@@ -12158,7 +14529,7 @@ class items
 		class Attributes
 		{
 		};
-		id=310;
+		id=79;
 		type="Box_IND_WpsLaunch_F";
 		class CustomAttributes
 		{
@@ -12186,17 +14557,6 @@ class items
 	};
 	class Item26
 	{
-		dataType="Comment";
-		class PositionInfo
-		{
-			position[]={-13.096191,0,-8.1464844};
-		};
-		title="v1.14.1";
-		description="-v1.14.1" \n " - A3EE box guard updated to A3AA." \n " - Custom location re-added." \n "" \n "- v1.14.0" \n "PL: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Boonie Hat"" for more visual diversity in the platoon and to bring PL headgear in line with RU and US Standard Factions. " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n "  - Removed CNTO ""Beret"" from Backpack gear due to old logo texture. " \n " " \n "Platoon Sergeant: " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n "  - Backpack added 3CB ""Radio Backpack MR3000"" and filled it with the ACRE2 ""AN/PRC-117F"" backpack radio. This gives more incentive to bring the PLT Sgt along since he is the only one who can act as a max range radio man for the platoon. " \n " " \n "Platoon Medic: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n " " \n "Platoon Rifleman: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n " " \n "Squad Medic: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n " " \n "FTL: " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n " " \n "AR: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n "  - Added muzzle attachment RHS ""SF3P-556 1/2-28"". " \n " " \n "AAR: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n " " \n "LAT: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n " " \n "MMG Teamleader: " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n " " \n "MMG Gunner: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n "  - Unfortunately no muzzle attachments available for the MG-3! " \n " " \n "MMG Asst. Gunner: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n " " \n "MAT Teamleader: " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n " " \n "MAT Gunner: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n " " \n "MAT Asst. Gunner: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n " " \n "ENG Leader: " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Heavy"" to differentiate ENG from the rest of the platoon. " \n " " \n "ENG Rifleman: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Heavy"" to differentiate ENG from the rest of the platoon. " \n " " \n "Mortar Leader: " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Special"" to visually differentiate the Mortar Team from the rest of the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n "  - Reduced STANAG mags from 10 to 5 to match the ENG ammo count. " \n " " \n "Mortar Gunner: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Special"" to visually differentiate the Mortar Team from the rest of the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n "  - Reduced STANAG mags from 10 to 5 to match the ENG ammo count. " \n " " \n "DMT Leader " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n " " \n "DMT Marksman " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n "  - Added NVG scope RHS ""AN/PVS-27"" to the vest gear. " \n " " \n "Zeus & Co-Zeus " \n "  - Uniform changed from vanilla ""VR Suit Indie"" to CNTO ""Flecktarn Recon"" to make Zeus look a bit more like an HQ commander than a Tron character. " \n "  - Facewear changed from vanilla ""VR Goggles"" to vanilla ""Aviator Glasses"". " \n "  - Insignia added ""Zeus"". " \n " " \n "All Units: " \n "  - Disabled LAMBS AI " \n " " \n "Alpha SL: " \n "  - Enabled ""is Player"". This makes it easier for Mission Makers to quickly test a mission in the editor by just hitting ""play"" instead of having to select a specific unit every time beforehand to avoid ending up in spectator mode by default. " \n " " \n "Crates: " \n "  - Added an ACE3 medical crate with our usual base script. " \n " " \n " " \n "- v1.13.6 " \n "  - ALL Added persistent Call-Signs for all GM's (where not included in v1.13.4) " \n "  - ALL Added the code `this disableAI ""MOVE""; this setSpeaker ""NoVoice""; enableRadio false;` to all playable units to prevent them from running off and spamming the vanilla-radio during local testing. " \n "  - ALL Changed persistent call-signs (map markers) to a consistent formula: ≤ 2 syllables = written out call-sing. ≥ 3 syllables = abbreviated call-sign. " \n "  - ALL Added full changelog to all factions for quick in-game reference " \n "  - TFN Added new yellow owl insignia patches to all uniforms " \n " " \n " " \n "- v1.13.5 " \n "  - ALL Added respective GM's to Standard Faction Compositions for convenience / time saving  " \n "  - ALL Added base clean-up module to Standard Faction Compositions to ensure Mission Makers don't forget it in the future - radius set to 200x200 meters " \n " " \n " " \n "- v1.13.4  " \n "  - ALL Added @ Squad/Team names to leaders so that Team name appears in role select " \n "  - TFN Changed M249 to the FN MINIMI " \n " " \n " " \n "- v1.13.3 " \n "  - US Added Improved Bipod/SAW Grip to AR M249 " \n "  - US Removed M14 Mags " \n "  - TFN Added Bipod to M249 " \n " " \n " " \n "- v1.13.2 " \n "  - ALL Added 1 Extra Tourniquet to every Unit " \n "  - TFN DMT Lead Rifle Changed to D10 Version " \n "  - TFN DMT given extra pistol mag to bring in line with other units " \n "  - TFN AAR Weapon changed to HK416 D14.5 " \n "  - TFN Lead Elements Given AN/PEQ-16A's " \n "  - US Alpha Fireteam 2 AAR vest changed to ALT variant to match rest of faction " \n "  - US Lead Elements Given AN/PEQ-16A's " \n "  - US DMT given extra pistol mag to bring in line with other units " \n "  - US DMT Sniper Rifle Given SU-260/P (MDO) to bring zoom level to the same as Russian and TFN factions " \n "  - US DMT Bipod Changed to Harris Bipod " \n "  - US DMT Marksman Rifle changed to black version of same rifle " \n "  - US DMT Marksman Magazines changed to SR-25 version, as RHS hotfix made M14 mags incompatible with MK11 " \n "  - RUS DMT given extra pistol mag to bring in line with other units " \n "  - RUS DGR Helmets changed to TSH-4 to make distinct from US Helmets " \n "  - RUS NB Helmets changed to ZSH-7A to make distinct from US and TFN helmets " \n "  - RUS Removed RIS Rail adaptors from AK rifles " \n "  - RUS Added PG-7V rocket to MAT ammo crate. This rocket is lighter and packs less payload than the PG-7VL. This gives it an  increased effective range but is less powerful due to decreased payload " \n " " \n " " \n "- v1.12.2 " \n "  - Hotfixed US Vests across the Squads to match V.12 changes. Whoops. " \n "  - Added Angled Grip to TFN HK416s where possible.  " \n " " \n " " \n "- v1.12 " \n "  - Fixed TFN MMG Ammo preloaded into Rifle to 100RND mag from 50rnd. " \n "  - Fixed TFN DMT Marksman Ammo loaded into Rifle to correct SBLR mag. " \n "  - Changed TFN DMT Lead Suppressor to QDSS NT4 Black from Rotex-5 Grey " \n "  - Changed TFN Dagger Uniforms from Gorka R Green to FFCP Green Fatigues [RS] " \n "  - Changed US PLT Commander + Squad Leader Vest from SPCS Rifleman/OEF- CP to SPCS Squad Lead/OEF-CP " \n "  - Changed US Medic Vest from SPCS Rifleman/OEF-CP to SPCS Medic/OEF-CP " \n "  - Changed US PLT Rifleman Vest from SPCS OEF-CP to SPCS Rifleman Alt/OEF-CP " \n "  - Changed US FTL Vest from SPCS Rifleman/OEF-CP to SPCS Team Leader Alt/OEF-CP " \n "  - Changed US AR Vest from SPCS Rifleman/OEF-CP to SPCS SAW/OEF-CP " \n "  - Changed US AAR Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP " \n "  - Changed US Rifleman AT Vest from SPCS OEF-CP to SPCS Rifleman Alt/OEF-CP " \n "  - Changed US MAT/MMG/DMT/ENG/MTR Lead Vest from SPCS Rifleman/OEF-CP to SPCS Team Leader Alt/OEF-CP " \n "  - Changed US MMG Gunner Vest from SPCS Rifleman/OEF-CP to SPCS Machinegunner/OEF-CP " \n "  - Changed US MMG/MAT Ammo Bearer Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP " \n "  - Changed US MAT Gunner Vest from SPCS OEF-CP to SPCS Rifleman Alt/OEF-CP " \n "  - Changed US DMT Marksman vest from SPCS OEF-CP to SPCS Sniper/OEF-CP " \n "  - Fixed US DMT Marksman Rifle Loaded Mag to correct varient. " \n "  - Changed US Engineer Rifleman Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP. " \n "  - Changed US MTR Gunner Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP. " \n "  - Changed US DGR Uniforms from FFCP ACU Fatigues to FFCP ACU Fatigues [RS] " \n "  - Changed US DGR Driver Backpack from Assault Pack Green to Assault Pack Black " \n "  - Changed US Heli Pilot/Copilot Uniforms from Heli pilot Coveralls to FFCP Nomad Fatigues [RS] " \n "  - Fixed US Heli/Jet Pilot Vest White Smoke grenade count to 2. " \n "  - Changed US Heli Pilot/Copilot Helmet from Heli Pilot NATO to HGU-56/P (Black/Visor) " \n "  - Changed US Jet Pilot Uniform from Pilot Coveralls NATO to  FFCP Nomad Fatigues " \n "  - Changed RUS Vic/Heli/Jet Crew Weapons to PP-2000 " \n "  - Upped RUS PP-2000 Ammo counts to 6x Mag to bring in line with ammo counts for TFN and US. " \n "  - Changed RUS Heli Pilot Uniforms from Pilot Coveralls CSAT to FFCP-Fatigues EMR [RS] " \n "  - Changed RUS Heli Pilot Vest from 6B23 (6Sh116) to FFCP Tactical Vest TigerVRS " \n "  - Changed RUS Jet Pilot Uniforms from Pilot Coveralls CSAT to FFCP-Fatigues EMR [RS] " \n "  - Changed RUS Jet Pilot Vest from 6B23 (6Sh116) to FFCP Tactical Vest TigerVRS " \n " " \n " " \n "- v1.11 " \n "  - changed m40 mini grenades to m67 fragmentation " \n "  - replaced mp7 weapons with mp5k-pdw " \n "  - changed ak105 to ak74m (plum)  " \n "  - changed PKM to PKP " \n "  - changed RUS PKM ammo boxes. MMG now loads with 7TZ (AP rounds) " \n "  - added vert grip to us weapons " \n "  - replaced m14 with HK PSG1A1 " \n "  - replaced m260e4 with mg3 " \n "  - updated all ammo boxes respectively.  " \n " " \n " " \n "- v1.10 " \n "  - changed Medic loadouts from 6 x 1000ml blood bags to 2 x 1000ml and 8 x 500ml. " \n " " \n " " \n "- v1.09 " \n "  - updated Fireteam colours A1 Red A2 Yellow, B1 Green B2 Blue, C1 Red C2 Yellow. " \n " " \n " " \n "- v1.08 " \n "  - changed ""Reaper"" to ""Nightbird"", ""RPR"" to ""NB"" " \n "  - changed ""Paladin"" to ""Falcon"", ""PAL"" to ""FC"" " \n "  - changed ""DAGGER"" to ""DGR"" " \n " " \n " " \n "- v1.07 " \n "  - US and RU faction bumped to v1.07 to avoid confusion regarding version numbers (US and RU was 1.05, TFN was 1.06) " \n "  - overhauled the RU faction: updated helmets, uniforms, weapons to a more modern look " \n "  - overhauled the US faction: updated helmets and vests to armour rating of IV " \n "  - corrected some mistakes in all factions (grenade ammount of MMG gunner, ENG not having tourniquetes, DGR not having GPS-s) " \n "  - overhauled the medics of all factions to reflect recent cahnges to ACE medical (less QuikClots, more Elastic Bandages, etc.) " \n " " \n " " \n "- v1.05 " \n "  - Added a MAT ammo box on spawn. " \n " " \n " " \n "- v1.04 " \n "  - All MAT Teams carrying RPG's got the ver3 scopes with ranges for all types " \n "    of ammo. " \n "  - All Callsigns were changed to be uniformed throught no matter the faction. " \n " " \n " " \n "- v1.03 " \n "  - set crew driver/gunner and pilot/copilot/jetpilot as Engineers through the " \n "    Object: ACE Options menu in unit attributes " \n "  - overhauled the TFN faction (weapons, helmets, etc.), changes not applicable " \n "    to derived factions " \n " " \n " " \n "- v1.02 " \n "  - loadout overhaul for DMT, made them lighter + gave them tools for recon " \n "  - specified preset ACRE2 radio channels for most units " \n " " \n " " \n "- v1.01 " \n "  - updated team colors func to `a3ee_team_colors_fnc_setColor`, just load+save " \n "    the composition in editor, this fixes it " \n "  - changed RPG-7 using MAT teams to carry Kitbags " \n "  - removed one PKM ammo box from AAR, MMG gunner, MMG bearer (fixes overload) " \n "  - moved 1-2 AR boxes from AAR to AR, gave AR an Assaultpack " \n "  - added 1-2 more AR boxes to AR's Assaultpack (if enough space) " \n "  - changed HEDP to HE rockets for Carl Gustav (M3MAAWS) " \n "  - changed US crew uniform and helmet to match grey color scheme of US pilots " \n "  - changed backpacks of driver/copilot to use less contrasting colors compared " \n "    to their respective uniform/vest colors " \n "  - changed Carryall backpacks of TFN Engineers to use custom Flecktarn Carryall " \n "  - changed all (GP-25 and normal) AK74m rifles to be the non-NPZ variants " \n "  - removed secondary long-range (PRC148) from Engineers " \n " " \n " " \n "- v1.00 (and before) " \n "  - added a Comment object with version number (`v1.00`) " \n "  - added `respawn_west`, `respawn_east`, `respawn_guerrila` markers " \n "  - added `[this, 200] call a3ee_fnc_boxGuard` to init lines of resupply boxes " \n "  - added `Resupply` green triangle markers on the position of resupply boxes";
-		id=311;
-	};
-	class Item27
-	{
 		dataType="Group";
 		side="Independent";
 		class Entities
@@ -12207,7 +14567,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-11.370605,0.0014390945,-7.390625};
+					position[]={-11.374512,0.0014390945,-7.1948242};
 				};
 				side="Independent";
 				flags=7;
@@ -12244,7 +14604,7 @@ class items
 							};
 							class ItemCargo
 							{
-								items=5;
+								items=6;
 								class Item0
 								{
 									name="ACE_MapTools";
@@ -12270,6 +14630,11 @@ class items
 									name="ACRE_PRC148";
 									count=1;
 								};
+								class Item5
+								{
+									name="ACE_epinephrine";
+									count=1;
+								};
 							};
 						};
 						map="ItemMap";
@@ -12280,7 +14645,7 @@ class items
 						headgear="H_ShemagOpen_khk";
 					};
 				};
-				id=313;
+				id=82;
 				type="I_Protagonist_VR_F";
 				class CustomAttributes
 				{
@@ -12322,7 +14687,90 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=3;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="0";
+										};
+									};
+									class Item1
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+									class Item2
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="3";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute3
+					{
+						property="a3aa_insta_zeus_unit_curator";
+						expression="[_this, _value] call a3aa_insta_zeus_fnc_createUnitCurator";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"BOOL"
+									};
+								};
+								value=1;
+							};
+						};
+					};
+					nAttributes=4;
 				};
 			};
 			class Item1
@@ -12330,7 +14778,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-10.370605,0.0014390945,-7.390625};
+					position[]={-10.374512,0.0014390945,-7.1948242};
 				};
 				side="Independent";
 				flags=5;
@@ -12403,7 +14851,7 @@ class items
 						headgear="rhsusf_bowman_cap";
 					};
 				};
-				id=314;
+				id=83;
 				type="I_Protagonist_VR_F";
 				class CustomAttributes
 				{
@@ -12445,14 +14893,97 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=3;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="0";
+										};
+									};
+									class Item1
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+									class Item2
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="3";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute3
+					{
+						property="a3aa_insta_zeus_unit_curator";
+						expression="[_this, _value] call a3aa_insta_zeus_fnc_createUnitCurator";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"BOOL"
+									};
+								};
+								value=1;
+							};
+						};
+					};
+					nAttributes=4;
 				};
 			};
 		};
 		class Attributes
 		{
 		};
-		id=312;
+		id=81;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -12477,12 +15008,12 @@ class items
 			nAttributes=1;
 		};
 	};
-	class Item28
+	class Item27
 	{
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={-8.4584961,0,-7.0712891};
+			position[]={-8.4624023,0,-6.8754883};
 		};
 		side="Empty";
 		flags=4;
@@ -12490,7 +15021,7 @@ class items
 		{
 			init="call{[this, 200] call a3aa_fnc_boxGuard}";
 		};
-		id=315;
+		id=84;
 		type="ACE_medicalSupplyCrate";
 		class CustomAttributes
 		{
@@ -12516,7 +15047,7 @@ class items
 			nAttributes=1;
 		};
 	};
-	class Item29
+	class Item28
 	{
 		dataType="Group";
 		side="Independent";
@@ -12528,7 +15059,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={9.5498047,0.0014390945,5.6328125};
+					position[]={9.5458984,0.0014390945,5.8286133};
 				};
 				side="Independent";
 				flags=7;
@@ -12575,7 +15106,7 @@ class items
 							isBackpack=0;
 							class ItemCargo
 							{
-								items=10;
+								items=9;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -12618,12 +15149,7 @@ class items
 								};
 								class Item8
 								{
-									name="ACRE_PRC152";
-									count=1;
-								};
-								class Item9
-								{
-									name="ACRE_PRC148";
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -12722,7 +15248,7 @@ class items
 							};
 							class ItemCargo
 							{
-								items=2;
+								items=4;
 								class Item0
 								{
 									name="ACE_IR_Strobe_Item";
@@ -12731,6 +15257,16 @@ class items
 								class Item1
 								{
 									name="cnto_flecktarn_h_beret";
+									count=1;
+								};
+								class Item2
+								{
+									name="ACRE_PRC152";
+									count=1;
+								};
+								class Item3
+								{
+									name="ACRE_PRC148";
 									count=1;
 								};
 							};
@@ -12742,7 +15278,7 @@ class items
 						headgear="cnto_flecktarn_h_beret";
 					};
 				};
-				id=317;
+				id=86;
 				type="I_officer_F";
 				class CustomAttributes
 				{
@@ -12773,7 +15309,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={11.548828,0.0014390945,5.6337891};
+					position[]={11.544922,0.0014390945,5.8295898};
 				};
 				side="Independent";
 				flags=5;
@@ -12820,7 +15356,7 @@ class items
 							};
 							class ItemCargo
 							{
-								items=6;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -12849,6 +15385,11 @@ class items
 								class Item5
 								{
 									name="ACRE_PRC343";
+									count=1;
+								};
+								class Item6
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -12982,7 +15523,7 @@ class items
 						headgear="LOP_H_Cowboy_hat";
 					};
 				};
-				id=318;
+				id=87;
 				type="I_medic_F";
 				class CustomAttributes
 				{
@@ -13013,7 +15554,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={12.549805,0.0014390945,5.6328125};
+					position[]={12.545898,0.0014390945,5.8286133};
 				};
 				side="Independent";
 				flags=5;
@@ -13060,7 +15601,7 @@ class items
 							};
 							class ItemCargo
 							{
-								items=6;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -13089,6 +15630,11 @@ class items
 								class Item5
 								{
 									name="ACRE_PRC343";
+									count=1;
+								};
+								class Item6
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -13141,7 +15687,7 @@ class items
 						headgear="cnto_flecktarn_h_boo_desert";
 					};
 				};
-				id=319;
+				id=88;
 				type="I_soldier_F";
 				class CustomAttributes
 				{
@@ -13172,7 +15718,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={10.549805,0.0014390945,5.6328125};
+					position[]={10.545898,0.0014390945,5.8286133};
 				};
 				side="Independent";
 				flags=4;
@@ -13305,10 +15851,15 @@ class items
 							};
 							class ItemCargo
 							{
-								items=1;
+								items=2;
 								class Item0
 								{
 									name="ACE_tourniquet";
+									count=1;
+								};
+								class Item1
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -13320,7 +15871,7 @@ class items
 						headgear="cnto_flecktarn_h_s_mediterranean";
 					};
 				};
-				id=320;
+				id=89;
 				type="I_soldier_F";
 				class CustomAttributes
 				{
@@ -13350,7 +15901,7 @@ class items
 		class Attributes
 		{
 		};
-		id=316;
+		id=85;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -13375,7 +15926,7 @@ class items
 			nAttributes=1;
 		};
 	};
-	class Item30
+	class Item29
 	{
 		dataType="Group";
 		side="Independent";
@@ -13387,7 +15938,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={9.4907227,0.0014390945,3.3398438};
+					position[]={9.4868164,0.0014390945,3.5356445};
 				};
 				side="Independent";
 				flags=7;
@@ -13493,7 +16044,7 @@ class items
 								};
 								class Item8
 								{
-									name="ACRE_PRC152";
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -13598,10 +16149,15 @@ class items
 							};
 							class ItemCargo
 							{
-								items=1;
+								items=2;
 								class Item0
 								{
 									name="ACE_IR_Strobe_Item";
+									count=1;
+								};
+								class Item1
+								{
+									name="ACRE_PRC152";
 									count=1;
 								};
 							};
@@ -13613,11 +16169,30 @@ class items
 						headgear="H_Cap_headphones";
 					};
 				};
-				id=322;
+				id=91;
 				type="I_Soldier_SL_F";
 				class CustomAttributes
 				{
 					class Attribute0
+					{
+						property="speaker";
+						expression="_this setspeaker _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="Male04GRE";
+							};
+						};
+					};
+					class Attribute1
 					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
@@ -13636,7 +16211,57 @@ class items
 							};
 						};
 					};
-					nAttributes=1;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=2;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+									class Item1
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=3;
 				};
 			};
 			class Item1
@@ -13644,7 +16269,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={10.491211,0.0014390945,3.3398438};
+					position[]={10.487305,0.0014390945,3.5356445};
 				};
 				side="Independent";
 				flags=5;
@@ -13853,7 +16478,7 @@ class items
 						headgear="LOP_H_Cowboy_hat";
 					};
 				};
-				id=323;
+				id=92;
 				type="I_medic_F";
 				class CustomAttributes
 				{
@@ -13876,7 +16501,43 @@ class items
 							};
 						};
 					};
-					nAttributes=1;
+					class Attribute1
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=2;
 				};
 			};
 			class Item2
@@ -13884,7 +16545,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={9.4912109,0.0014390945,1.3398438};
+					position[]={9.4873047,0.0014390945,1.5356445};
 				};
 				side="Independent";
 				flags=5;
@@ -14024,10 +16685,15 @@ class items
 							};
 							class ItemCargo
 							{
-								items=1;
+								items=2;
 								class Item0
 								{
 									name="ACE_tourniquet";
+									count=1;
+								};
+								class Item1
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -14093,7 +16759,7 @@ class items
 						headgear="rhsusf_bowman_cap";
 					};
 				};
-				id=324;
+				id=93;
 				type="I_Soldier_TL_F";
 				class CustomAttributes
 				{
@@ -14116,7 +16782,43 @@ class items
 							};
 						};
 					};
-					nAttributes=1;
+					class Attribute1
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=2;
 				};
 			};
 			class Item3
@@ -14124,7 +16826,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={10.491211,0.0014390945,1.3398438};
+					position[]={10.487305,0.0014390945,1.5356445};
 				};
 				side="Independent";
 				flags=5;
@@ -14170,7 +16872,7 @@ class items
 							};
 							class ItemCargo
 							{
-								items=6;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -14199,6 +16901,11 @@ class items
 								class Item5
 								{
 									name="ACRE_PRC343";
+									count=1;
+								};
+								class Item6
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -14267,7 +16974,7 @@ class items
 						headgear="H_ShemagOpen_khk";
 					};
 				};
-				id=325;
+				id=94;
 				type="I_Soldier_AR_F";
 				class CustomAttributes
 				{
@@ -14290,7 +16997,43 @@ class items
 							};
 						};
 					};
-					nAttributes=1;
+					class Attribute1
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=2;
 				};
 			};
 			class Item4
@@ -14298,7 +17041,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={11.491211,0.0014390945,1.3398438};
+					position[]={11.487305,0.0014390945,1.5356445};
 				};
 				side="Independent";
 				flags=5;
@@ -14356,7 +17099,7 @@ class items
 							};
 							class ItemCargo
 							{
-								items=8;
+								items=9;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -14395,6 +17138,11 @@ class items
 								class Item7
 								{
 									name="ACE_MapTools";
+									count=1;
+								};
+								class Item8
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -14496,7 +17244,7 @@ class items
 						headgear="H_Booniehat_khk_hs";
 					};
 				};
-				id=326;
+				id=95;
 				type="I_Soldier_AAR_F";
 				class CustomAttributes
 				{
@@ -14519,7 +17267,43 @@ class items
 							};
 						};
 					};
-					nAttributes=1;
+					class Attribute1
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=2;
 				};
 			};
 			class Item5
@@ -14527,7 +17311,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={12.491211,0.0014390945,1.3398438};
+					position[]={12.487305,0.0014390945,1.5356445};
 				};
 				side="Independent";
 				flags=5;
@@ -14578,7 +17362,7 @@ class items
 							};
 							class ItemCargo
 							{
-								items=6;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -14607,6 +17391,11 @@ class items
 								class Item5
 								{
 									name="ACRE_PRC343";
+									count=1;
+								};
+								class Item6
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -14659,7 +17448,7 @@ class items
 						headgear="LOP_H_Beanie_dpmw";
 					};
 				};
-				id=327;
+				id=96;
 				type="I_Soldier_LAT_F";
 				class CustomAttributes
 				{
@@ -14682,7 +17471,43 @@ class items
 							};
 						};
 					};
-					nAttributes=1;
+					class Attribute1
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=2;
 				};
 			};
 			class Item6
@@ -14690,7 +17515,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={9.4907227,0.0014390945,-0.66015625};
+					position[]={9.4868164,0.0014390945,-0.46435547};
 				};
 				side="Independent";
 				flags=5;
@@ -14830,10 +17655,15 @@ class items
 							};
 							class ItemCargo
 							{
-								items=1;
+								items=2;
 								class Item0
 								{
 									name="ACE_tourniquet";
+									count=1;
+								};
+								class Item1
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -14899,7 +17729,7 @@ class items
 						headgear="rhsusf_bowman_cap";
 					};
 				};
-				id=328;
+				id=97;
 				type="I_Soldier_TL_F";
 				class CustomAttributes
 				{
@@ -14922,7 +17752,43 @@ class items
 							};
 						};
 					};
-					nAttributes=1;
+					class Attribute1
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=2;
 				};
 			};
 			class Item7
@@ -14930,7 +17796,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={10.491211,0.0014390945,-0.66015625};
+					position[]={10.487305,0.0014390945,-0.46435547};
 				};
 				side="Independent";
 				flags=5;
@@ -14976,7 +17842,7 @@ class items
 							};
 							class ItemCargo
 							{
-								items=6;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -15005,6 +17871,11 @@ class items
 								class Item5
 								{
 									name="ACRE_PRC343";
+									count=1;
+								};
+								class Item6
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -15073,7 +17944,7 @@ class items
 						headgear="H_ShemagOpen_khk";
 					};
 				};
-				id=329;
+				id=98;
 				type="I_Soldier_AR_F";
 				class CustomAttributes
 				{
@@ -15096,7 +17967,43 @@ class items
 							};
 						};
 					};
-					nAttributes=1;
+					class Attribute1
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=2;
 				};
 			};
 			class Item8
@@ -15104,7 +18011,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={11.491211,0.0014390945,-0.66015625};
+					position[]={11.487305,0.0014390945,-0.46435547};
 				};
 				side="Independent";
 				flags=5;
@@ -15162,7 +18069,7 @@ class items
 							};
 							class ItemCargo
 							{
-								items=8;
+								items=9;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -15201,6 +18108,11 @@ class items
 								class Item7
 								{
 									name="ACE_MapTools";
+									count=1;
+								};
+								class Item8
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -15302,7 +18214,7 @@ class items
 						headgear="H_Booniehat_khk_hs";
 					};
 				};
-				id=330;
+				id=99;
 				type="I_Soldier_AAR_F";
 				class CustomAttributes
 				{
@@ -15325,7 +18237,43 @@ class items
 							};
 						};
 					};
-					nAttributes=1;
+					class Attribute1
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=2;
 				};
 			};
 			class Item9
@@ -15333,7 +18281,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={12.491211,0.0014390945,-0.66015625};
+					position[]={12.487305,0.0014390945,-0.46435547};
 				};
 				side="Independent";
 				flags=5;
@@ -15384,7 +18332,7 @@ class items
 							};
 							class ItemCargo
 							{
-								items=6;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -15413,6 +18361,11 @@ class items
 								class Item5
 								{
 									name="ACRE_PRC343";
+									count=1;
+								};
+								class Item6
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -15465,7 +18418,7 @@ class items
 						headgear="LOP_H_Beanie_dpmw";
 					};
 				};
-				id=331;
+				id=100;
 				type="I_Soldier_LAT_F";
 				class CustomAttributes
 				{
@@ -15488,14 +18441,50 @@ class items
 							};
 						};
 					};
-					nAttributes=1;
+					class Attribute1
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=2;
 				};
 			};
 		};
 		class Attributes
 		{
 		};
-		id=321;
+		id=90;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -15520,7 +18509,7 @@ class items
 			nAttributes=1;
 		};
 	};
-	class Item31
+	class Item30
 	{
 		dataType="Group";
 		side="Independent";
@@ -15532,7 +18521,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={15.053711,0.0014390945,3.2285156};
+					position[]={15.049805,0.0014390945,3.4243164};
 				};
 				side="Independent";
 				flags=7;
@@ -15638,7 +18627,7 @@ class items
 								};
 								class Item8
 								{
-									name="ACRE_PRC152";
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -15743,10 +18732,15 @@ class items
 							};
 							class ItemCargo
 							{
-								items=1;
+								items=2;
 								class Item0
 								{
 									name="ACE_IR_Strobe_Item";
+									count=1;
+								};
+								class Item1
+								{
+									name="ACRE_PRC152";
 									count=1;
 								};
 							};
@@ -15758,7 +18752,7 @@ class items
 						headgear="H_Cap_headphones";
 					};
 				};
-				id=333;
+				id=102;
 				type="I_Soldier_SL_F";
 				class CustomAttributes
 				{
@@ -15781,7 +18775,57 @@ class items
 							};
 						};
 					};
-					nAttributes=1;
+					class Attribute1
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=2;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="2";
+										};
+									};
+									class Item1
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=2;
 				};
 			};
 			class Item1
@@ -15789,7 +18833,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={16.052734,0.0014390945,3.2285156};
+					position[]={16.048828,0.0014390945,3.4243164};
 				};
 				side="Independent";
 				flags=5;
@@ -15998,7 +19042,7 @@ class items
 						headgear="LOP_H_Cowboy_hat";
 					};
 				};
-				id=334;
+				id=103;
 				type="I_medic_F";
 				class CustomAttributes
 				{
@@ -16021,7 +19065,43 @@ class items
 							};
 						};
 					};
-					nAttributes=1;
+					class Attribute1
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="2";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=2;
 				};
 			};
 			class Item2
@@ -16029,7 +19109,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={15.052734,0.0014390945,1.2285156};
+					position[]={15.048828,0.0014390945,1.4243164};
 				};
 				side="Independent";
 				flags=5;
@@ -16169,10 +19249,15 @@ class items
 							};
 							class ItemCargo
 							{
-								items=1;
+								items=2;
 								class Item0
 								{
 									name="ACE_tourniquet";
+									count=1;
+								};
+								class Item1
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -16238,7 +19323,7 @@ class items
 						headgear="rhsusf_bowman_cap";
 					};
 				};
-				id=335;
+				id=104;
 				type="I_Soldier_TL_F";
 				class CustomAttributes
 				{
@@ -16261,7 +19346,43 @@ class items
 							};
 						};
 					};
-					nAttributes=1;
+					class Attribute1
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="2";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=2;
 				};
 			};
 			class Item3
@@ -16269,7 +19390,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={16.052734,0.0014390945,1.2285156};
+					position[]={16.048828,0.0014390945,1.4243164};
 				};
 				side="Independent";
 				flags=5;
@@ -16315,7 +19436,7 @@ class items
 							};
 							class ItemCargo
 							{
-								items=6;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -16344,6 +19465,11 @@ class items
 								class Item5
 								{
 									name="ACRE_PRC343";
+									count=1;
+								};
+								class Item6
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -16412,7 +19538,7 @@ class items
 						headgear="H_ShemagOpen_khk";
 					};
 				};
-				id=336;
+				id=105;
 				type="I_Soldier_AR_F";
 				class CustomAttributes
 				{
@@ -16435,7 +19561,43 @@ class items
 							};
 						};
 					};
-					nAttributes=1;
+					class Attribute1
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="2";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=2;
 				};
 			};
 			class Item4
@@ -16443,7 +19605,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={17.053223,0.0014390945,1.2285156};
+					position[]={17.049316,0.0014390945,1.4243164};
 				};
 				side="Independent";
 				flags=5;
@@ -16501,7 +19663,7 @@ class items
 							};
 							class ItemCargo
 							{
-								items=8;
+								items=9;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -16540,6 +19702,11 @@ class items
 								class Item7
 								{
 									name="ACE_MapTools";
+									count=1;
+								};
+								class Item8
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -16641,7 +19808,7 @@ class items
 						headgear="H_Booniehat_khk_hs";
 					};
 				};
-				id=337;
+				id=106;
 				type="I_Soldier_AAR_F";
 				class CustomAttributes
 				{
@@ -16664,7 +19831,43 @@ class items
 							};
 						};
 					};
-					nAttributes=1;
+					class Attribute1
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="2";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=2;
 				};
 			};
 			class Item5
@@ -16672,7 +19875,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={18.052734,0.0014390945,1.2285156};
+					position[]={18.048828,0.0014390945,1.4243164};
 				};
 				side="Independent";
 				flags=5;
@@ -16723,7 +19926,7 @@ class items
 							};
 							class ItemCargo
 							{
-								items=6;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -16752,6 +19955,11 @@ class items
 								class Item5
 								{
 									name="ACRE_PRC343";
+									count=1;
+								};
+								class Item6
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -16804,7 +20012,7 @@ class items
 						headgear="LOP_H_Beanie_dpmw";
 					};
 				};
-				id=338;
+				id=107;
 				type="I_Soldier_LAT_F";
 				class CustomAttributes
 				{
@@ -16827,7 +20035,43 @@ class items
 							};
 						};
 					};
-					nAttributes=1;
+					class Attribute1
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="2";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=2;
 				};
 			};
 			class Item6
@@ -16835,7 +20079,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={15.052734,0.0014390945,-0.77148438};
+					position[]={15.048828,0.0014390945,-0.57568359};
 				};
 				side="Independent";
 				flags=5;
@@ -16975,10 +20219,15 @@ class items
 							};
 							class ItemCargo
 							{
-								items=1;
+								items=2;
 								class Item0
 								{
 									name="ACE_tourniquet";
+									count=1;
+								};
+								class Item1
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -17044,7 +20293,7 @@ class items
 						headgear="rhsusf_bowman_cap";
 					};
 				};
-				id=339;
+				id=108;
 				type="I_Soldier_TL_F";
 				class CustomAttributes
 				{
@@ -17067,7 +20316,43 @@ class items
 							};
 						};
 					};
-					nAttributes=1;
+					class Attribute1
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="2";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=2;
 				};
 			};
 			class Item7
@@ -17075,7 +20360,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={16.052734,0.0014390945,-0.77148438};
+					position[]={16.048828,0.0014390945,-0.57568359};
 				};
 				side="Independent";
 				flags=5;
@@ -17121,7 +20406,7 @@ class items
 							};
 							class ItemCargo
 							{
-								items=6;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -17150,6 +20435,11 @@ class items
 								class Item5
 								{
 									name="ACRE_PRC343";
+									count=1;
+								};
+								class Item6
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -17218,7 +20508,7 @@ class items
 						headgear="H_ShemagOpen_khk";
 					};
 				};
-				id=340;
+				id=109;
 				type="I_Soldier_AR_F";
 				class CustomAttributes
 				{
@@ -17241,7 +20531,43 @@ class items
 							};
 						};
 					};
-					nAttributes=1;
+					class Attribute1
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="2";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=2;
 				};
 			};
 			class Item8
@@ -17249,7 +20575,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={17.052734,0.0014390945,-0.77148438};
+					position[]={17.048828,0.0014390945,-0.57568359};
 				};
 				side="Independent";
 				flags=5;
@@ -17307,7 +20633,7 @@ class items
 							};
 							class ItemCargo
 							{
-								items=8;
+								items=9;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -17346,6 +20672,11 @@ class items
 								class Item7
 								{
 									name="ACE_MapTools";
+									count=1;
+								};
+								class Item8
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -17447,7 +20778,7 @@ class items
 						headgear="H_Booniehat_khk_hs";
 					};
 				};
-				id=341;
+				id=110;
 				type="I_Soldier_AAR_F";
 				class CustomAttributes
 				{
@@ -17470,7 +20801,43 @@ class items
 							};
 						};
 					};
-					nAttributes=1;
+					class Attribute1
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="2";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=2;
 				};
 			};
 			class Item9
@@ -17478,7 +20845,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={18.052734,0.0014390945,-0.77148438};
+					position[]={18.048828,0.0014390945,-0.57568359};
 				};
 				side="Independent";
 				flags=5;
@@ -17529,7 +20896,7 @@ class items
 							};
 							class ItemCargo
 							{
-								items=6;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -17558,6 +20925,11 @@ class items
 								class Item5
 								{
 									name="ACRE_PRC343";
+									count=1;
+								};
+								class Item6
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -17610,7 +20982,7 @@ class items
 						headgear="LOP_H_Beanie_dpmw";
 					};
 				};
-				id=342;
+				id=111;
 				type="I_Soldier_LAT_F";
 				class CustomAttributes
 				{
@@ -17633,14 +21005,50 @@ class items
 							};
 						};
 					};
-					nAttributes=1;
+					class Attribute1
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="2";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=2;
 				};
 			};
 		};
 		class Attributes
 		{
 		};
-		id=332;
+		id=101;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -17665,7 +21073,7 @@ class items
 			nAttributes=1;
 		};
 	};
-	class Item32
+	class Item31
 	{
 		dataType="Group";
 		side="Independent";
@@ -17677,7 +21085,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={20.101074,0.0014390945,3.1201172};
+					position[]={20.097168,0.0014390945,3.315918};
 				};
 				side="Independent";
 				flags=7;
@@ -17783,7 +21191,7 @@ class items
 								};
 								class Item8
 								{
-									name="ACRE_PRC152";
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -17888,10 +21296,15 @@ class items
 							};
 							class ItemCargo
 							{
-								items=1;
+								items=2;
 								class Item0
 								{
 									name="ACE_IR_Strobe_Item";
+									count=1;
+								};
+								class Item1
+								{
+									name="ACRE_PRC152";
 									count=1;
 								};
 							};
@@ -17903,7 +21316,7 @@ class items
 						headgear="H_Cap_headphones";
 					};
 				};
-				id=344;
+				id=113;
 				type="I_Soldier_SL_F";
 				class CustomAttributes
 				{
@@ -17926,7 +21339,57 @@ class items
 							};
 						};
 					};
-					nAttributes=1;
+					class Attribute1
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=2;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="3";
+										};
+									};
+									class Item1
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=2;
 				};
 			};
 			class Item1
@@ -17934,7 +21397,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={21.101074,0.0014390945,3.1191406};
+					position[]={21.097168,0.0014390945,3.3149414};
 				};
 				side="Independent";
 				flags=5;
@@ -18143,7 +21606,7 @@ class items
 						headgear="LOP_H_Cowboy_hat";
 					};
 				};
-				id=345;
+				id=114;
 				type="I_medic_F";
 				class CustomAttributes
 				{
@@ -18166,7 +21629,43 @@ class items
 							};
 						};
 					};
-					nAttributes=1;
+					class Attribute1
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="3";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=2;
 				};
 			};
 			class Item2
@@ -18174,7 +21673,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={20.101074,0.0014390945,1.1191406};
+					position[]={20.097168,0.0014390945,1.3149414};
 				};
 				side="Independent";
 				flags=5;
@@ -18314,10 +21813,15 @@ class items
 							};
 							class ItemCargo
 							{
-								items=1;
+								items=2;
 								class Item0
 								{
 									name="ACE_tourniquet";
+									count=1;
+								};
+								class Item1
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -18383,7 +21887,7 @@ class items
 						headgear="rhsusf_bowman_cap";
 					};
 				};
-				id=346;
+				id=115;
 				type="I_Soldier_TL_F";
 				class CustomAttributes
 				{
@@ -18406,7 +21910,43 @@ class items
 							};
 						};
 					};
-					nAttributes=1;
+					class Attribute1
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="3";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=2;
 				};
 			};
 			class Item3
@@ -18414,7 +21954,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={21.101074,0.0014390945,1.1191406};
+					position[]={21.097168,0.0014390945,1.3149414};
 				};
 				side="Independent";
 				flags=5;
@@ -18460,7 +22000,7 @@ class items
 							};
 							class ItemCargo
 							{
-								items=6;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -18489,6 +22029,11 @@ class items
 								class Item5
 								{
 									name="ACRE_PRC343";
+									count=1;
+								};
+								class Item6
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -18557,7 +22102,7 @@ class items
 						headgear="H_ShemagOpen_khk";
 					};
 				};
-				id=347;
+				id=116;
 				type="I_Soldier_AR_F";
 				class CustomAttributes
 				{
@@ -18580,7 +22125,43 @@ class items
 							};
 						};
 					};
-					nAttributes=1;
+					class Attribute1
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="3";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=2;
 				};
 			};
 			class Item4
@@ -18588,7 +22169,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={22.101074,0.0014390945,1.1191406};
+					position[]={22.097168,0.0014390945,1.3149414};
 				};
 				side="Independent";
 				flags=5;
@@ -18646,7 +22227,7 @@ class items
 							};
 							class ItemCargo
 							{
-								items=8;
+								items=9;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -18685,6 +22266,11 @@ class items
 								class Item7
 								{
 									name="ACE_MapTools";
+									count=1;
+								};
+								class Item8
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -18786,7 +22372,7 @@ class items
 						headgear="H_Booniehat_khk_hs";
 					};
 				};
-				id=348;
+				id=117;
 				type="I_Soldier_AAR_F";
 				class CustomAttributes
 				{
@@ -18809,7 +22395,43 @@ class items
 							};
 						};
 					};
-					nAttributes=1;
+					class Attribute1
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="3";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=2;
 				};
 			};
 			class Item5
@@ -18817,7 +22439,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={23.101074,0.0014390945,1.1191406};
+					position[]={23.097168,0.0014390945,1.3149414};
 				};
 				side="Independent";
 				flags=5;
@@ -18868,7 +22490,7 @@ class items
 							};
 							class ItemCargo
 							{
-								items=6;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -18897,6 +22519,11 @@ class items
 								class Item5
 								{
 									name="ACRE_PRC343";
+									count=1;
+								};
+								class Item6
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -18949,7 +22576,7 @@ class items
 						headgear="LOP_H_Beanie_dpmw";
 					};
 				};
-				id=349;
+				id=118;
 				type="I_Soldier_LAT_F";
 				class CustomAttributes
 				{
@@ -18972,7 +22599,43 @@ class items
 							};
 						};
 					};
-					nAttributes=1;
+					class Attribute1
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="3";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=2;
 				};
 			};
 			class Item6
@@ -18980,7 +22643,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={20.101074,0.0014390945,-0.88085938};
+					position[]={20.097168,0.0014390945,-0.68505859};
 				};
 				side="Independent";
 				flags=5;
@@ -19120,10 +22783,15 @@ class items
 							};
 							class ItemCargo
 							{
-								items=1;
+								items=2;
 								class Item0
 								{
 									name="ACE_tourniquet";
+									count=1;
+								};
+								class Item1
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -19189,7 +22857,7 @@ class items
 						headgear="rhsusf_bowman_cap";
 					};
 				};
-				id=350;
+				id=119;
 				type="I_Soldier_TL_F";
 				class CustomAttributes
 				{
@@ -19212,7 +22880,43 @@ class items
 							};
 						};
 					};
-					nAttributes=1;
+					class Attribute1
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="3";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=2;
 				};
 			};
 			class Item7
@@ -19220,7 +22924,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={21.101074,0.0014390945,-0.88085938};
+					position[]={21.097168,0.0014390945,-0.68505859};
 				};
 				side="Independent";
 				flags=5;
@@ -19266,7 +22970,7 @@ class items
 							};
 							class ItemCargo
 							{
-								items=6;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -19295,6 +22999,11 @@ class items
 								class Item5
 								{
 									name="ACRE_PRC343";
+									count=1;
+								};
+								class Item6
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -19363,7 +23072,7 @@ class items
 						headgear="H_ShemagOpen_khk";
 					};
 				};
-				id=351;
+				id=120;
 				type="I_Soldier_AR_F";
 				class CustomAttributes
 				{
@@ -19386,7 +23095,43 @@ class items
 							};
 						};
 					};
-					nAttributes=1;
+					class Attribute1
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="3";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=2;
 				};
 			};
 			class Item8
@@ -19394,7 +23139,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={22.101074,0.0014390945,-0.88085938};
+					position[]={22.097168,0.0014390945,-0.68505859};
 				};
 				side="Independent";
 				flags=5;
@@ -19452,7 +23197,7 @@ class items
 							};
 							class ItemCargo
 							{
-								items=8;
+								items=9;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -19491,6 +23236,11 @@ class items
 								class Item7
 								{
 									name="ACE_MapTools";
+									count=1;
+								};
+								class Item8
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -19592,7 +23342,7 @@ class items
 						headgear="H_Booniehat_khk_hs";
 					};
 				};
-				id=352;
+				id=121;
 				type="I_Soldier_AAR_F";
 				class CustomAttributes
 				{
@@ -19615,7 +23365,43 @@ class items
 							};
 						};
 					};
-					nAttributes=1;
+					class Attribute1
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="3";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=2;
 				};
 			};
 			class Item9
@@ -19623,7 +23409,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={23.101074,0.0014390945,-0.88085938};
+					position[]={23.097168,0.0014390945,-0.68505859};
 				};
 				side="Independent";
 				flags=5;
@@ -19674,7 +23460,7 @@ class items
 							};
 							class ItemCargo
 							{
-								items=6;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -19703,6 +23489,11 @@ class items
 								class Item5
 								{
 									name="ACRE_PRC343";
+									count=1;
+								};
+								class Item6
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -19755,7 +23546,7 @@ class items
 						headgear="LOP_H_Beanie_dpmw";
 					};
 				};
-				id=353;
+				id=122;
 				type="I_Soldier_LAT_F";
 				class CustomAttributes
 				{
@@ -19778,14 +23569,50 @@ class items
 							};
 						};
 					};
-					nAttributes=1;
+					class Attribute1
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="3";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=2;
 				};
 			};
 		};
 		class Attributes
 		{
 		};
-		id=343;
+		id=112;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -19810,7 +23637,7 @@ class items
 			nAttributes=1;
 		};
 	};
-	class Item33
+	class Item32
 	{
 		dataType="Group";
 		side="Independent";
@@ -19822,7 +23649,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={9.4912109,0.0014390945,-4.6601563};
+					position[]={9.4873047,0.0014390945,-4.4643555};
 				};
 				side="Independent";
 				flags=7;
@@ -19922,7 +23749,7 @@ class items
 								};
 								class Item8
 								{
-									name="ACRE_PRC152";
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -20027,10 +23854,15 @@ class items
 							};
 							class ItemCargo
 							{
-								items=1;
+								items=2;
 								class Item0
 								{
 									name="ACE_IR_Strobe_Item";
+									count=1;
+								};
+								class Item1
+								{
+									name="ACRE_PRC152";
 									count=1;
 								};
 							};
@@ -20042,7 +23874,7 @@ class items
 						headgear="LOP_H_Beanie_dpmw";
 					};
 				};
-				id=355;
+				id=124;
 				type="I_Soldier_TL_F";
 				class CustomAttributes
 				{
@@ -20084,7 +23916,57 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=2;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="5";
+										};
+									};
+									class Item1
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=3;
 				};
 			};
 			class Item1
@@ -20092,7 +23974,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={10.491211,0.0014390945,-4.6611328};
+					position[]={10.487305,0.0014390945,-4.465332};
 				};
 				side="Independent";
 				flags=5;
@@ -20138,7 +24020,7 @@ class items
 							};
 							class ItemCargo
 							{
-								items=6;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -20167,6 +24049,11 @@ class items
 								class Item5
 								{
 									name="ACRE_PRC343";
+									count=1;
+								};
+								class Item6
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -20228,7 +24115,7 @@ class items
 						headgear="LOP_H_Cowboy_hat";
 					};
 				};
-				id=356;
+				id=125;
 				type="I_Soldier_AR_F";
 				class CustomAttributes
 				{
@@ -20270,7 +24157,43 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="5";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=3;
 				};
 			};
 			class Item2
@@ -20278,7 +24201,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={11.491211,0.0014390945,-4.6611328};
+					position[]={11.487305,0.0014390945,-4.465332};
 				};
 				side="Independent";
 				flags=5;
@@ -20331,7 +24254,7 @@ class items
 							};
 							class ItemCargo
 							{
-								items=6;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -20360,6 +24283,11 @@ class items
 								class Item5
 								{
 									name="ACRE_PRC343";
+									count=1;
+								};
+								class Item6
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -20433,7 +24361,7 @@ class items
 						headgear="LOP_H_Beanie_dpmw";
 					};
 				};
-				id=357;
+				id=126;
 				type="I_Soldier_AAR_F";
 				class CustomAttributes
 				{
@@ -20475,14 +24403,50 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="5";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=3;
 				};
 			};
 		};
 		class Attributes
 		{
 		};
-		id=354;
+		id=123;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -20507,7 +24471,7 @@ class items
 			nAttributes=1;
 		};
 	};
-	class Item34
+	class Item33
 	{
 		dataType="Group";
 		side="Independent";
@@ -20519,7 +24483,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={15.734375,0.0014390945,-4.6953125};
+					position[]={15.730469,0.0014390945,-4.4995117};
 				};
 				side="Independent";
 				flags=7;
@@ -20619,7 +24583,7 @@ class items
 								};
 								class Item8
 								{
-									name="ACRE_PRC152";
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -20724,10 +24688,15 @@ class items
 							};
 							class ItemCargo
 							{
-								items=1;
+								items=2;
 								class Item0
 								{
 									name="ACE_IR_Strobe_Item";
+									count=1;
+								};
+								class Item1
+								{
+									name="ACRE_PRC152";
 									count=1;
 								};
 							};
@@ -20739,7 +24708,7 @@ class items
 						headgear="H_ShemagOpen_khk";
 					};
 				};
-				id=359;
+				id=128;
 				type="I_Soldier_TL_F";
 				class CustomAttributes
 				{
@@ -20781,7 +24750,57 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=2;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="6";
+										};
+									};
+									class Item1
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=3;
 				};
 			};
 			class Item1
@@ -20789,7 +24808,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={16.73291,0.0014390945,-4.6933594};
+					position[]={16.729004,0.0014390945,-4.4975586};
 				};
 				side="Independent";
 				flags=5;
@@ -20846,7 +24865,7 @@ class items
 							};
 							class ItemCargo
 							{
-								items=6;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -20875,6 +24894,11 @@ class items
 								class Item5
 								{
 									name="ACRE_PRC343";
+									count=1;
+								};
+								class Item6
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -20942,7 +24966,7 @@ class items
 						headgear="LOP_H_Cowboy_hat";
 					};
 				};
-				id=360;
+				id=129;
 				type="I_Soldier_AT_F";
 				class CustomAttributes
 				{
@@ -20984,7 +25008,43 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="6";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=3;
 				};
 			};
 			class Item2
@@ -20992,7 +25052,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={17.73291,0.0014390945,-4.6933594};
+					position[]={17.729004,0.0014390945,-4.4975586};
 				};
 				side="Independent";
 				flags=5;
@@ -21039,7 +25099,7 @@ class items
 							};
 							class ItemCargo
 							{
-								items=6;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -21068,6 +25128,11 @@ class items
 								class Item5
 								{
 									name="ACRE_PRC343";
+									count=1;
+								};
+								class Item6
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -21135,7 +25200,7 @@ class items
 						headgear="LOP_H_Beanie_dpmw";
 					};
 				};
-				id=361;
+				id=130;
 				type="I_Soldier_AAT_F";
 				class CustomAttributes
 				{
@@ -21177,14 +25242,50 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="6";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=3;
 				};
 			};
 		};
 		class Attributes
 		{
 		};
-		id=358;
+		id=127;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -21209,7 +25310,7 @@ class items
 			nAttributes=1;
 		};
 	};
-	class Item35
+	class Item34
 	{
 		dataType="Group";
 		side="Independent";
@@ -21221,7 +25322,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={9.2304688,0.0014390945,-7.3291016};
+					position[]={9.2265625,0.0014390945,-7.1333008};
 				};
 				side="Independent";
 				flags=7;
@@ -21284,7 +25385,7 @@ class items
 							};
 							class ItemCargo
 							{
-								items=9;
+								items=10;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -21328,6 +25429,11 @@ class items
 								class Item8
 								{
 									name="ACRE_PRC152";
+									count=1;
+								};
+								class Item9
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -21402,7 +25508,7 @@ class items
 						headgear="H_Booniehat_khk_hs";
 					};
 				};
-				id=363;
+				id=132;
 				type="I_Spotter_F";
 				class CustomAttributes
 				{
@@ -21444,7 +25550,57 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=2;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="8";
+										};
+									};
+									class Item1
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=3;
 				};
 			};
 			class Item1
@@ -21452,7 +25608,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={10.22998,0.0014390945,-7.3300781};
+					position[]={10.226074,0.0014390945,-7.1342773};
 				};
 				side="Independent";
 				flags=4;
@@ -21588,7 +25744,7 @@ class items
 							};
 							class ItemCargo
 							{
-								items=3;
+								items=4;
 								class Item0
 								{
 									name="ACE_IR_Strobe_Item";
@@ -21604,6 +25760,11 @@ class items
 									name="rhsusf_acc_anpvs27";
 									count=1;
 								};
+								class Item3
+								{
+									name="ACE_epinephrine";
+									count=1;
+								};
 							};
 						};
 						map="ItemMap";
@@ -21613,7 +25774,7 @@ class items
 						headgear="LOP_H_Beanie_dpmw";
 					};
 				};
-				id=364;
+				id=133;
 				type="I_Sniper_F";
 				class CustomAttributes
 				{
@@ -21655,14 +25816,50 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="8";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=3;
 				};
 			};
 		};
 		class Attributes
 		{
 		};
-		id=362;
+		id=131;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -21687,7 +25884,7 @@ class items
 			nAttributes=1;
 		};
 	};
-	class Item36
+	class Item35
 	{
 		dataType="Group";
 		side="Independent";
@@ -21699,7 +25896,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={15.361328,0.0014390945,-7.390625};
+					position[]={15.357422,0.0014390945,-7.1948242};
 				};
 				side="Independent";
 				flags=7;
@@ -21751,7 +25948,7 @@ class items
 							};
 							class ItemCargo
 							{
-								items=9;
+								items=10;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -21795,6 +25992,11 @@ class items
 								class Item8
 								{
 									name="ACRE_PRC152";
+									count=1;
+								};
+								class Item9
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -21865,7 +26067,7 @@ class items
 						headgear="H_ShemagOpen_khk";
 					};
 				};
-				id=366;
+				id=135;
 				type="I_support_AMort_F";
 				class CustomAttributes
 				{
@@ -21915,7 +26117,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={16.362305,0.0014390945,-7.390625};
+					position[]={16.358398,0.0014390945,-7.1948242};
 				};
 				side="Independent";
 				flags=5;
@@ -21962,7 +26164,7 @@ class items
 							};
 							class ItemCargo
 							{
-								items=8;
+								items=9;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -22001,6 +26203,11 @@ class items
 								class Item7
 								{
 									name="ACE_RangeTable_82mm";
+									count=1;
+								};
+								class Item8
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -22058,7 +26265,7 @@ class items
 						headgear="H_Booniehat_khk_hs";
 					};
 				};
-				id=367;
+				id=136;
 				type="I_support_Mort_F";
 				class CustomAttributes
 				{
@@ -22107,7 +26314,7 @@ class items
 		class Attributes
 		{
 		};
-		id=365;
+		id=134;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -22132,7 +26339,7 @@ class items
 			nAttributes=1;
 		};
 	};
-	class Item37
+	class Item36
 	{
 		dataType="Group";
 		side="Independent";
@@ -22144,7 +26351,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={20.629395,0.0014390945,-4.65625};
+					position[]={20.625488,0.0014390945,-4.4604492};
 				};
 				side="Independent";
 				flags=7;
@@ -22184,16 +26391,6 @@ class items
 						{
 							typeName="LOP_U_PMC_Fatigue_03";
 							isBackpack=0;
-							class MagazineCargo
-							{
-								items=1;
-								class Item0
-								{
-									name="rhs_30Rnd_545x39_7N22_AK";
-									count=2;
-									ammoLeft=30;
-								};
-							};
 							class ItemCargo
 							{
 								items=8;
@@ -22234,7 +26431,7 @@ class items
 								};
 								class Item7
 								{
-									name="ACRE_PRC152";
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -22305,22 +26502,17 @@ class items
 						{
 							typeName="cnto_flecktarn_b_ca_grassland";
 							isBackpack=1;
-							class MagazineCargo
-							{
-								items=1;
-								class Item0
-								{
-									name="rhs_30Rnd_545x39_AK_plum_green";
-									count=1;
-									ammoLeft=30;
-								};
-							};
 							class ItemCargo
 							{
-								items=1;
+								items=2;
 								class Item0
 								{
 									name="ToolKit";
+									count=1;
+								};
+								class Item1
+								{
+									name="ACRE_PRC152";
 									count=1;
 								};
 							};
@@ -22332,7 +26524,7 @@ class items
 						headgear="LOP_H_Beanie_dpmw";
 					};
 				};
-				id=369;
+				id=138;
 				type="I_engineer_F";
 				class CustomAttributes
 				{
@@ -22374,7 +26566,57 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=2;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="7";
+										};
+									};
+									class Item1
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=3;
 				};
 			};
 			class Item1
@@ -22382,7 +26624,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={21.629395,0.0014390945,-4.65625};
+					position[]={21.625488,0.0014390945,-4.4604492};
 				};
 				side="Independent";
 				flags=5;
@@ -22421,19 +26663,9 @@ class items
 						{
 							typeName="cnto_flecktarn_u_t_urban";
 							isBackpack=0;
-							class MagazineCargo
-							{
-								items=1;
-								class Item0
-								{
-									name="rhs_30Rnd_545x39_7N22_AK";
-									count=1;
-									ammoLeft=30;
-								};
-							};
 							class ItemCargo
 							{
-								items=7;
+								items=8;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -22469,6 +26701,11 @@ class items
 									name="ACRE_PRC343";
 									count=1;
 								};
+								class Item7
+								{
+									name="ACE_epinephrine";
+									count=1;
+								};
 							};
 						};
 						class vest
@@ -22493,13 +26730,13 @@ class items
 								class Item2
 								{
 									name="rhs_30Rnd_545x39_AK_plum_green";
-									count=2;
+									count=1;
 									ammoLeft=30;
 								};
 								class Item3
 								{
 									name="rhs_30Rnd_545x39_7N22_AK";
-									count=7;
+									count=5;
 									ammoLeft=30;
 								};
 							};
@@ -22537,16 +26774,6 @@ class items
 						{
 							typeName="cnto_flecktarn_b_ca_grassland";
 							isBackpack=1;
-							class MagazineCargo
-							{
-								items=1;
-								class Item0
-								{
-									name="rhs_30Rnd_545x39_AK_plum_green";
-									count=1;
-									ammoLeft=30;
-								};
-							};
 							class ItemCargo
 							{
 								items=1;
@@ -22564,7 +26791,7 @@ class items
 						headgear="H_ShemagOpen_khk";
 					};
 				};
-				id=370;
+				id=139;
 				type="I_engineer_F";
 				class CustomAttributes
 				{
@@ -22606,7 +26833,43 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="7";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=3;
 				};
 			};
 			class Item2
@@ -22614,7 +26877,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={22.629395,0.0014390945,-4.65625};
+					position[]={22.625488,0.0014390945,-4.4604492};
 				};
 				side="Independent";
 				flags=5;
@@ -22653,19 +26916,9 @@ class items
 						{
 							typeName="NatoU_CCE_Combo_rs";
 							isBackpack=0;
-							class MagazineCargo
-							{
-								items=1;
-								class Item0
-								{
-									name="rhs_30Rnd_545x39_7N22_AK";
-									count=1;
-									ammoLeft=30;
-								};
-							};
 							class ItemCargo
 							{
-								items=7;
+								items=8;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -22701,6 +26954,11 @@ class items
 									name="ACRE_PRC343";
 									count=1;
 								};
+								class Item7
+								{
+									name="ACE_epinephrine";
+									count=1;
+								};
 							};
 						};
 						class vest
@@ -22725,13 +26983,13 @@ class items
 								class Item2
 								{
 									name="rhs_30Rnd_545x39_AK_plum_green";
-									count=2;
+									count=1;
 									ammoLeft=30;
 								};
 								class Item3
 								{
 									name="rhs_30Rnd_545x39_7N22_AK";
-									count=7;
+									count=5;
 									ammoLeft=30;
 								};
 							};
@@ -22769,16 +27027,6 @@ class items
 						{
 							typeName="cnto_flecktarn_b_ca_grassland";
 							isBackpack=1;
-							class MagazineCargo
-							{
-								items=1;
-								class Item0
-								{
-									name="rhs_30Rnd_545x39_AK_plum_green";
-									count=1;
-									ammoLeft=30;
-								};
-							};
 							class ItemCargo
 							{
 								items=1;
@@ -22796,7 +27044,7 @@ class items
 						headgear="H_Booniehat_khk_hs";
 					};
 				};
-				id=371;
+				id=140;
 				type="I_engineer_F";
 				class CustomAttributes
 				{
@@ -22838,7 +27086,43 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="7";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=3;
 				};
 			};
 			class Item3
@@ -22846,7 +27130,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={23.629395,0.0014390945,-4.65625};
+					position[]={23.625488,0.0014390945,-4.4604492};
 				};
 				side="Independent";
 				flags=5;
@@ -22891,19 +27175,19 @@ class items
 								class Item0
 								{
 									name="rhs_30Rnd_545x39_AK_plum_green";
-									count=2;
+									count=1;
 									ammoLeft=30;
 								};
 								class Item1
 								{
 									name="rhs_30Rnd_545x39_7N22_AK";
-									count=8;
+									count=5;
 									ammoLeft=30;
 								};
 							};
 							class ItemCargo
 							{
-								items=7;
+								items=8;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -22939,6 +27223,11 @@ class items
 									name="ACRE_PRC343";
 									count=1;
 								};
+								class Item7
+								{
+									name="ACE_epinephrine";
+									count=1;
+								};
 							};
 						};
 						class vest
@@ -22947,7 +27236,7 @@ class items
 							isBackpack=0;
 							class MagazineCargo
 							{
-								items=3;
+								items=2;
 								class Item0
 								{
 									name="SmokeShell";
@@ -22959,12 +27248,6 @@ class items
 									name="HandGrenade";
 									count=2;
 									ammoLeft=1;
-								};
-								class Item2
-								{
-									name="rhs_30Rnd_545x39_AK_plum_green";
-									count=1;
-									ammoLeft=30;
 								};
 							};
 							class ItemCargo
@@ -23018,7 +27301,7 @@ class items
 						headgear="LOP_H_Cowboy_hat";
 					};
 				};
-				id=372;
+				id=141;
 				type="I_engineer_F";
 				class CustomAttributes
 				{
@@ -23060,14 +27343,50 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="7";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=3;
 				};
 			};
 		};
 		class Attributes
 		{
 		};
-		id=368;
+		id=137;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -23092,7 +27411,7 @@ class items
 			nAttributes=1;
 		};
 	};
-	class Item38
+	class Item37
 	{
 		dataType="Group";
 		side="Independent";
@@ -23104,7 +27423,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={8.9614258,0.0014390945,-10.007813};
+					position[]={8.9575195,0.0014390945,-9.8120117};
 				};
 				side="Independent";
 				flags=7;
@@ -23146,7 +27465,7 @@ class items
 							isBackpack=0;
 							class ItemCargo
 							{
-								items=8;
+								items=9;
 								class Item0
 								{
 									name="ACE_quikclot";
@@ -23185,6 +27504,11 @@ class items
 								class Item7
 								{
 									name="ACRE_PRC148";
+									count=1;
+								};
+								class Item8
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -23251,7 +27575,7 @@ class items
 						headgear="H_Booniehat_khk_hs";
 					};
 				};
-				id=374;
+				id=143;
 				type="I_crew_F";
 				class CustomAttributes
 				{
@@ -23293,7 +27617,71 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=3;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="0";
+										};
+									};
+									class Item1
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+									class Item2
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="2";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=3;
 				};
 			};
 			class Item1
@@ -23301,7 +27689,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={9.9614258,0.0014390945,-10.007813};
+					position[]={9.9575195,0.0014390945,-9.8120117};
 				};
 				side="Independent";
 				flags=5;
@@ -23348,7 +27736,7 @@ class items
 							};
 							class ItemCargo
 							{
-								items=5;
+								items=6;
 								class Item0
 								{
 									name="ACE_quikclot";
@@ -23372,6 +27760,11 @@ class items
 								class Item4
 								{
 									name="ACE_tourniquet";
+									count=1;
+								};
+								class Item5
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -23452,7 +27845,7 @@ class items
 						headgear="rhsusf_bowman_cap";
 					};
 				};
-				id=375;
+				id=144;
 				type="I_crew_F";
 				class CustomAttributes
 				{
@@ -23521,7 +27914,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={10.961426,0.0014390945,-10.007813};
+					position[]={10.95752,0.0014390945,-9.8120117};
 				};
 				side="Independent";
 				flags=5;
@@ -23643,10 +28036,15 @@ class items
 							};
 							class ItemCargo
 							{
-								items=1;
+								items=2;
 								class Item0
 								{
 									name="ACE_tourniquet";
+									count=1;
+								};
+								class Item1
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -23658,7 +28056,7 @@ class items
 						headgear="LOP_H_Beanie_dpmw";
 					};
 				};
-				id=376;
+				id=145;
 				type="I_crew_F";
 				class CustomAttributes
 				{
@@ -23726,7 +28124,7 @@ class items
 		class Attributes
 		{
 		};
-		id=373;
+		id=142;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -23751,7 +28149,7 @@ class items
 			nAttributes=1;
 		};
 	};
-	class Item39
+	class Item38
 	{
 		dataType="Group";
 		side="Independent";
@@ -23763,7 +28161,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={15.241211,0.0014390945,-10.196289};
+					position[]={15.237305,0.0014390945,-10.000488};
 				};
 				side="Independent";
 				flags=7;
@@ -23805,7 +28203,7 @@ class items
 							isBackpack=0;
 							class ItemCargo
 							{
-								items=8;
+								items=9;
 								class Item0
 								{
 									name="ACE_quikclot";
@@ -23844,6 +28242,11 @@ class items
 								class Item7
 								{
 									name="ACE_tourniquet";
+									count=1;
+								};
+								class Item8
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -23910,7 +28313,7 @@ class items
 						headgear="H_ShemagOpen_khk";
 					};
 				};
-				id=378;
+				id=147;
 				type="I_pilot_F";
 				class CustomAttributes
 				{
@@ -23971,7 +28374,71 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					class Attribute3
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=3;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="0";
+										};
+									};
+									class Item1
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+									class Item2
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="3";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=4;
 				};
 			};
 			class Item1
@@ -23979,7 +28446,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={16.241211,0.0014390945,-10.195313};
+					position[]={16.237305,0.0014390945,-9.9995117};
 				};
 				side="Independent";
 				flags=5;
@@ -24030,7 +28497,7 @@ class items
 							};
 							class ItemCargo
 							{
-								items=8;
+								items=9;
 								class Item0
 								{
 									name="ACE_quikclot";
@@ -24069,6 +28536,11 @@ class items
 								class Item7
 								{
 									name="ACE_tourniquet";
+									count=1;
+								};
+								class Item8
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -24159,7 +28631,7 @@ class items
 						headgear="LOP_H_Cowboy_hat";
 					};
 				};
-				id=379;
+				id=148;
 				type="I_pilot_F";
 				class CustomAttributes
 				{
@@ -24220,14 +28692,78 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					class Attribute3
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=3;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="0";
+										};
+									};
+									class Item1
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+									class Item2
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="3";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=4;
 				};
 			};
 		};
 		class Attributes
 		{
 		};
-		id=377;
+		id=146;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -24252,7 +28788,7 @@ class items
 			nAttributes=1;
 		};
 	};
-	class Item40
+	class Item39
 	{
 		dataType="Group";
 		side="Independent";
@@ -24264,7 +28800,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={18.977539,0.0014390945,-10.325195};
+					position[]={18.973633,0.0014390945,-10.129395};
 				};
 				side="Independent";
 				flags=7;
@@ -24305,7 +28841,7 @@ class items
 							isBackpack=0;
 							class ItemCargo
 							{
-								items=8;
+								items=9;
 								class Item0
 								{
 									name="ACE_quikclot";
@@ -24344,6 +28880,11 @@ class items
 								class Item7
 								{
 									name="ACE_tourniquet";
+									count=1;
+								};
+								class Item8
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -24408,7 +28949,7 @@ class items
 						headgear="H_PilotHelmetFighter_I";
 					};
 				};
-				id=381;
+				id=150;
 				type="I_pilot_F";
 				class CustomAttributes
 				{
@@ -24469,14 +29010,78 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					class Attribute3
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=3;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="0";
+										};
+									};
+									class Item1
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+									class Item2
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="3";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=4;
 				};
 			};
 		};
 		class Attributes
 		{
 		};
-		id=380;
+		id=149;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -24501,12 +29106,12 @@ class items
 			nAttributes=1;
 		};
 	};
-	class Item41
+	class Item40
 	{
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={23.108887,0.28405476,-8.7460938};
+			position[]={23.10498,0.28405476,-8.550293};
 		};
 		side="Empty";
 		flags=4;
@@ -24514,7 +29119,7 @@ class items
 		{
 			init="call{[this, 200] call a3aa_fnc_boxGuard}";
 		};
-		id=382;
+		id=151;
 		type="Box_IND_Ammo_F";
 		class CustomAttributes
 		{
@@ -24540,12 +29145,12 @@ class items
 			nAttributes=1;
 		};
 	};
-	class Item42
+	class Item41
 	{
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={23.161621,0.89242268,-11.12793};
+			position[]={23.157715,0.89242268,-10.932129};
 		};
 		side="Empty";
 		flags=4;
@@ -24553,7 +29158,7 @@ class items
 		{
 			init="call{[this, 200] call a3aa_fnc_boxGuard}";
 		};
-		id=383;
+		id=152;
 		type="I_supplyCrate_F";
 		class CustomAttributes
 		{
@@ -24579,18 +29184,18 @@ class items
 			nAttributes=1;
 		};
 	};
-	class Item43
+	class Item42
 	{
 		dataType="Comment";
 		class PositionInfo
 		{
-			position[]={18.903809,0,-8.1455078};
+			position[]={18.900146,0,-7.9494629};
 		};
-		title="v1.14.1";
-		description="-v1.14.1" \n " - A3EE box guard updated to A3AA." \n " - Custom location re-added." \n "" \n "- v1.14.0 " \n "PL: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Boonie Hat"" for more visual diversity in the platoon and to bring PL headgear in line with RU and US Standard Factions. " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n "  - Removed CNTO ""Beret"" from Backpack gear due to old logo texture. " \n " " \n "Platoon Sergeant: " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n "  - Backpack added 3CB ""Radio Backpack MR3000"" and filled it with the ACRE2 ""AN/PRC-117F"" backpack radio. This gives more incentive to bring the PLT Sgt along since he is the only one who can act as a max range radio man for the platoon. " \n " " \n "Platoon Medic: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n " " \n "Platoon Rifleman: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n " " \n "Squad Medic: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n " " \n "FTL: " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n " " \n "AR: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n "  - Added muzzle attachment RHS ""SF3P-556 1/2-28"". " \n " " \n "AAR: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n " " \n "LAT: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n " " \n "MMG Teamleader: " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n " " \n "MMG Gunner: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n "  - Unfortunately no muzzle attachments available for the MG-3! " \n " " \n "MMG Asst. Gunner: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n " " \n "MAT Teamleader: " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n " " \n "MAT Gunner: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n " " \n "MAT Asst. Gunner: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n " " \n "ENG Leader: " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Heavy"" to differentiate ENG from the rest of the platoon. " \n " " \n "ENG Rifleman: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Heavy"" to differentiate ENG from the rest of the platoon. " \n " " \n "Mortar Leader: " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Special"" to visually differentiate the Mortar Team from the rest of the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n "  - Reduced STANAG mags from 10 to 5 to match the ENG ammo count. " \n " " \n "Mortar Gunner: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Special"" to visually differentiate the Mortar Team from the rest of the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n "  - Reduced STANAG mags from 10 to 5 to match the ENG ammo count. " \n " " \n "DMT Leader " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n " " \n "DMT Marksman " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n "  - Added NVG scope RHS ""AN/PVS-27"" to the vest gear. " \n " " \n "Zeus & Co-Zeus " \n "  - Uniform changed from vanilla ""VR Suit Indie"" to CNTO ""Flecktarn Recon"" to make Zeus look a bit more like an HQ commander than a Tron character. " \n "  - Facewear changed from vanilla ""VR Goggles"" to vanilla ""Aviator Glasses"". " \n "  - Insignia added ""Zeus"". " \n " " \n "All Units: " \n "  - Disabled LAMBS AI " \n " " \n "Alpha SL: " \n "  - Enabled ""is Player"". This makes it easier for Mission Makers to quickly test a mission in the editor by just hitting ""play"" instead of having to select a specific unit every time beforehand to avoid ending up in spectator mode by default. " \n " " \n "Crates: " \n "  - Added an ACE3 medical crate with our usual base script. " \n " " \n " " \n "- v1.13.6 " \n "  - ALL Added persistent Call-Signs for all GM's (where not included in v1.13.4) " \n "  - ALL Added the code `this disableAI ""MOVE""; this setSpeaker ""NoVoice""; enableRadio false;` to all playable units to prevent them from running off and spamming the vanilla-radio during local testing. " \n "  - ALL Changed persistent call-signs (map markers) to a consistent formula: ≤ 2 syllables = written out call-sing. ≥ 3 syllables = abbreviated call-sign. " \n "  - ALL Added full changelog to all factions for quick in-game reference " \n "  - TFN Added new yellow owl insignia patches to all uniforms " \n " " \n " " \n "- v1.13.5 " \n "  - ALL Added respective GM's to Standard Faction Compositions for convenience / time saving  " \n "  - ALL Added base clean-up module to Standard Faction Compositions to ensure Mission Makers don't forget it in the future - radius set to 200x200 meters " \n " " \n " " \n "- v1.13.4  " \n "  - ALL Added @ Squad/Team names to leaders so that Team name appears in role select " \n "  - TFN Changed M249 to the FN MINIMI " \n " " \n " " \n "- v1.13.3 " \n "  - US Added Improved Bipod/SAW Grip to AR M249 " \n "  - US Removed M14 Mags " \n "  - TFN Added Bipod to M249 " \n " " \n " " \n "- v1.13.2 " \n "  - ALL Added 1 Extra Tourniquet to every Unit " \n "  - TFN DMT Lead Rifle Changed to D10 Version " \n "  - TFN DMT given extra pistol mag to bring in line with other units " \n "  - TFN AAR Weapon changed to HK416 D14.5 " \n "  - TFN Lead Elements Given AN/PEQ-16A's " \n "  - US Alpha Fireteam 2 AAR vest changed to ALT variant to match rest of faction " \n "  - US Lead Elements Given AN/PEQ-16A's " \n "  - US DMT given extra pistol mag to bring in line with other units " \n "  - US DMT Sniper Rifle Given SU-260/P (MDO) to bring zoom level to the same as Russian and TFN factions " \n "  - US DMT Bipod Changed to Harris Bipod " \n "  - US DMT Marksman Rifle changed to black version of same rifle " \n "  - US DMT Marksman Magazines changed to SR-25 version, as RHS hotfix made M14 mags incompatible with MK11 " \n "  - RUS DMT given extra pistol mag to bring in line with other units " \n "  - RUS DGR Helmets changed to TSH-4 to make distinct from US Helmets " \n "  - RUS NB Helmets changed to ZSH-7A to make distinct from US and TFN helmets " \n "  - RUS Removed RIS Rail adaptors from AK rifles " \n "  - RUS Added PG-7V rocket to MAT ammo crate. This rocket is lighter and packs less payload than the PG-7VL. This gives it an  increased effective range but is less powerful due to decreased payload " \n " " \n " " \n "- v1.12.2 " \n "  - Hotfixed US Vests across the Squads to match V.12 changes. Whoops. " \n "  - Added Angled Grip to TFN HK416s where possible.  " \n " " \n " " \n "- v1.12 " \n "  - Fixed TFN MMG Ammo preloaded into Rifle to 100RND mag from 50rnd. " \n "  - Fixed TFN DMT Marksman Ammo loaded into Rifle to correct SBLR mag. " \n "  - Changed TFN DMT Lead Suppressor to QDSS NT4 Black from Rotex-5 Grey " \n "  - Changed TFN Dagger Uniforms from Gorka R Green to FFCP Green Fatigues [RS] " \n "  - Changed US PLT Commander + Squad Leader Vest from SPCS Rifleman/OEF- CP to SPCS Squad Lead/OEF-CP " \n "  - Changed US Medic Vest from SPCS Rifleman/OEF-CP to SPCS Medic/OEF-CP " \n "  - Changed US PLT Rifleman Vest from SPCS OEF-CP to SPCS Rifleman Alt/OEF-CP " \n "  - Changed US FTL Vest from SPCS Rifleman/OEF-CP to SPCS Team Leader Alt/OEF-CP " \n "  - Changed US AR Vest from SPCS Rifleman/OEF-CP to SPCS SAW/OEF-CP " \n "  - Changed US AAR Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP " \n "  - Changed US Rifleman AT Vest from SPCS OEF-CP to SPCS Rifleman Alt/OEF-CP " \n "  - Changed US MAT/MMG/DMT/ENG/MTR Lead Vest from SPCS Rifleman/OEF-CP to SPCS Team Leader Alt/OEF-CP " \n "  - Changed US MMG Gunner Vest from SPCS Rifleman/OEF-CP to SPCS Machinegunner/OEF-CP " \n "  - Changed US MMG/MAT Ammo Bearer Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP " \n "  - Changed US MAT Gunner Vest from SPCS OEF-CP to SPCS Rifleman Alt/OEF-CP " \n "  - Changed US DMT Marksman vest from SPCS OEF-CP to SPCS Sniper/OEF-CP " \n "  - Fixed US DMT Marksman Rifle Loaded Mag to correct varient. " \n "  - Changed US Engineer Rifleman Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP. " \n "  - Changed US MTR Gunner Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP. " \n "  - Changed US DGR Uniforms from FFCP ACU Fatigues to FFCP ACU Fatigues [RS] " \n "  - Changed US DGR Driver Backpack from Assault Pack Green to Assault Pack Black " \n "  - Changed US Heli Pilot/Copilot Uniforms from Heli pilot Coveralls to FFCP Nomad Fatigues [RS] " \n "  - Fixed US Heli/Jet Pilot Vest White Smoke grenade count to 2. " \n "  - Changed US Heli Pilot/Copilot Helmet from Heli Pilot NATO to HGU-56/P (Black/Visor) " \n "  - Changed US Jet Pilot Uniform from Pilot Coveralls NATO to  FFCP Nomad Fatigues " \n "  - Changed RUS Vic/Heli/Jet Crew Weapons to PP-2000 " \n "  - Upped RUS PP-2000 Ammo counts to 6x Mag to bring in line with ammo counts for TFN and US. " \n "  - Changed RUS Heli Pilot Uniforms from Pilot Coveralls CSAT to FFCP-Fatigues EMR [RS] " \n "  - Changed RUS Heli Pilot Vest from 6B23 (6Sh116) to FFCP Tactical Vest TigerVRS " \n "  - Changed RUS Jet Pilot Uniforms from Pilot Coveralls CSAT to FFCP-Fatigues EMR [RS] " \n "  - Changed RUS Jet Pilot Vest from 6B23 (6Sh116) to FFCP Tactical Vest TigerVRS " \n " " \n " " \n "- v1.11 " \n "  - changed m40 mini grenades to m67 fragmentation " \n "  - replaced mp7 weapons with mp5k-pdw " \n "  - changed ak105 to ak74m (plum)  " \n "  - changed PKM to PKP " \n "  - changed RUS PKM ammo boxes. MMG now loads with 7TZ (AP rounds) " \n "  - added vert grip to us weapons " \n "  - replaced m14 with HK PSG1A1 " \n "  - replaced m260e4 with mg3 " \n "  - updated all ammo boxes respectively.  " \n " " \n " " \n "- v1.10 " \n "  - changed Medic loadouts from 6 x 1000ml blood bags to 2 x 1000ml and 8 x 500ml. " \n " " \n " " \n "- v1.09 " \n "  - updated Fireteam colours A1 Red A2 Yellow, B1 Green B2 Blue, C1 Red C2 Yellow. " \n " " \n " " \n "- v1.08 " \n "  - changed ""Reaper"" to ""Nightbird"", ""RPR"" to ""NB"" " \n "  - changed ""Paladin"" to ""Falcon"", ""PAL"" to ""FC"" " \n "  - changed ""DAGGER"" to ""DGR"" " \n " " \n " " \n "- v1.07 " \n "  - US and RU faction bumped to v1.07 to avoid confusion regarding version numbers (US and RU was 1.05, TFN was 1.06) " \n "  - overhauled the RU faction: updated helmets, uniforms, weapons to a more modern look " \n "  - overhauled the US faction: updated helmets and vests to armour rating of IV " \n "  - corrected some mistakes in all factions (grenade ammount of MMG gunner, ENG not having tourniquetes, DGR not having GPS-s) " \n "  - overhauled the medics of all factions to reflect recent cahnges to ACE medical (less QuikClots, more Elastic Bandages, etc.) " \n " " \n " " \n "- v1.05 " \n "  - Added a MAT ammo box on spawn. " \n " " \n " " \n "- v1.04 " \n "  - All MAT Teams carrying RPG's got the ver3 scopes with ranges for all types " \n "    of ammo. " \n "  - All Callsigns were changed to be uniformed throught no matter the faction. " \n " " \n " " \n "- v1.03 " \n "  - set crew driver/gunner and pilot/copilot/jetpilot as Engineers through the " \n "    Object: ACE Options menu in unit attributes " \n "  - overhauled the TFN faction (weapons, helmets, etc.), changes not applicable " \n "    to derived factions " \n " " \n " " \n "- v1.02 " \n "  - loadout overhaul for DMT, made them lighter + gave them tools for recon " \n "  - specified preset ACRE2 radio channels for most units " \n " " \n " " \n "- v1.01 " \n "  - updated team colors func to `a3ee_team_colors_fnc_setColor`, just load+save " \n "    the composition in editor, this fixes it " \n "  - changed RPG-7 using MAT teams to carry Kitbags " \n "  - removed one PKM ammo box from AAR, MMG gunner, MMG bearer (fixes overload) " \n "  - moved 1-2 AR boxes from AAR to AR, gave AR an Assaultpack " \n "  - added 1-2 more AR boxes to AR's Assaultpack (if enough space) " \n "  - changed HEDP to HE rockets for Carl Gustav (M3MAAWS) " \n "  - changed US crew uniform and helmet to match grey color scheme of US pilots " \n "  - changed backpacks of driver/copilot to use less contrasting colors compared " \n "    to their respective uniform/vest colors " \n "  - changed Carryall backpacks of TFN Engineers to use custom Flecktarn Carryall " \n "  - changed all (GP-25 and normal) AK74m rifles to be the non-NPZ variants " \n "  - removed secondary long-range (PRC148) from Engineers " \n " " \n " " \n "- v1.00 (and before) " \n "  - added a Comment object with version number (`v1.00`) " \n "  - added `respawn_west`, `respawn_east`, `respawn_guerrila` markers " \n "  - added `[this, 200] call a3ee_fnc_boxGuard` to init lines of resupply boxes " \n "  - added `Resupply` green triangle markers on the position of resupply boxes";
-		id=384;
+		title="v1.14.2";
+		description="-v1.14.2 " \n "-GM: Fixed ""assign zeus to this unit"" not being present " \n "-All Groups: Fixed radio channel presets " \n "-Gave every unit 1 epi in Uniform, or Vest if uniform was full (medic not included) " \n "-Moved element lead LR radio to backpack " \n "-Added mortar supply crate " \n "-DMT: Removed NVG scope, and replaced main scope with one that can be used with goggles. " \n "-Gave engineers more ammo (1 tracer + 1 for members, 2 tracer for leader)" \n "" \n "-v1.14.1" \n " - A3EE box guard updated to A3AA." \n " - Custom location re-added." \n "" \n "- v1.14.0 " \n "PL: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Boonie Hat"" for more visual diversity in the platoon and to bring PL headgear in line with RU and US Standard Factions. " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n "  - Removed CNTO ""Beret"" from Backpack gear due to old logo texture. " \n " " \n "Platoon Sergeant: " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n "  - Backpack added 3CB ""Radio Backpack MR3000"" and filled it with the ACRE2 ""AN/PRC-117F"" backpack radio. This gives more incentive to bring the PLT Sgt along since he is the only one who can act as a max range radio man for the platoon. " \n " " \n "Platoon Medic: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n " " \n "Platoon Rifleman: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n " " \n "Squad Medic: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n " " \n "FTL: " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n " " \n "AR: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n "  - Added muzzle attachment RHS ""SF3P-556 1/2-28"". " \n " " \n "AAR: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n " " \n "LAT: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n " " \n "MMG Teamleader: " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n " " \n "MMG Gunner: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n "  - Unfortunately no muzzle attachments available for the MG-3! " \n " " \n "MMG Asst. Gunner: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n " " \n "MAT Teamleader: " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n " " \n "MAT Gunner: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n " " \n "MAT Asst. Gunner: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n " " \n "ENG Leader: " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Heavy"" to differentiate ENG from the rest of the platoon. " \n " " \n "ENG Rifleman: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Heavy"" to differentiate ENG from the rest of the platoon. " \n " " \n "Mortar Leader: " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Special"" to visually differentiate the Mortar Team from the rest of the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n "  - Reduced STANAG mags from 10 to 5 to match the ENG ammo count. " \n " " \n "Mortar Gunner: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Special"" to visually differentiate the Mortar Team from the rest of the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n "  - Reduced STANAG mags from 10 to 5 to match the ENG ammo count. " \n " " \n "DMT Leader " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n " " \n "DMT Marksman " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n "  - Added NVG scope RHS ""AN/PVS-27"" to the vest gear. " \n " " \n "Zeus & Co-Zeus " \n "  - Uniform changed from vanilla ""VR Suit Indie"" to CNTO ""Flecktarn Recon"" to make Zeus look a bit more like an HQ commander than a Tron character. " \n "  - Facewear changed from vanilla ""VR Goggles"" to vanilla ""Aviator Glasses"". " \n "  - Insignia added ""Zeus"". " \n " " \n "All Units: " \n "  - Disabled LAMBS AI " \n " " \n "Alpha SL: " \n "  - Enabled ""is Player"". This makes it easier for Mission Makers to quickly test a mission in the editor by just hitting ""play"" instead of having to select a specific unit every time beforehand to avoid ending up in spectator mode by default. " \n " " \n "Crates: " \n "  - Added an ACE3 medical crate with our usual base script. " \n " " \n " " \n "- v1.13.6 " \n "  - ALL Added persistent Call-Signs for all GM's (where not included in v1.13.4) " \n "  - ALL Added the code `this disableAI ""MOVE""; this setSpeaker ""NoVoice""; enableRadio false;` to all playable units to prevent them from running off and spamming the vanilla-radio during local testing. " \n "  - ALL Changed persistent call-signs (map markers) to a consistent formula: ≤ 2 syllables = written out call-sing. ≥ 3 syllables = abbreviated call-sign. " \n "  - ALL Added full changelog to all factions for quick in-game reference " \n "  - TFN Added new yellow owl insignia patches to all uniforms " \n " " \n " " \n "- v1.13.5 " \n "  - ALL Added respective GM's to Standard Faction Compositions for convenience / time saving  " \n "  - ALL Added base clean-up module to Standard Faction Compositions to ensure Mission Makers don't forget it in the future - radius set to 200x200 meters " \n " " \n " " \n "- v1.13.4  " \n "  - ALL Added @ Squad/Team names to leaders so that Team name appears in role select " \n "  - TFN Changed M249 to the FN MINIMI " \n " " \n " " \n "- v1.13.3 " \n "  - US Added Improved Bipod/SAW Grip to AR M249 " \n "  - US Removed M14 Mags " \n "  - TFN Added Bipod to M249 " \n " " \n " " \n "- v1.13.2 " \n "  - ALL Added 1 Extra Tourniquet to every Unit " \n "  - TFN DMT Lead Rifle Changed to D10 Version " \n "  - TFN DMT given extra pistol mag to bring in line with other units " \n "  - TFN AAR Weapon changed to HK416 D14.5 " \n "  - TFN Lead Elements Given AN/PEQ-16A's " \n "  - US Alpha Fireteam 2 AAR vest changed to ALT variant to match rest of faction " \n "  - US Lead Elements Given AN/PEQ-16A's " \n "  - US DMT given extra pistol mag to bring in line with other units " \n "  - US DMT Sniper Rifle Given SU-260/P (MDO) to bring zoom level to the same as Russian and TFN factions " \n "  - US DMT Bipod Changed to Harris Bipod " \n "  - US DMT Marksman Rifle changed to black version of same rifle " \n "  - US DMT Marksman Magazines changed to SR-25 version, as RHS hotfix made M14 mags incompatible with MK11 " \n "  - RUS DMT given extra pistol mag to bring in line with other units " \n "  - RUS DGR Helmets changed to TSH-4 to make distinct from US Helmets " \n "  - RUS NB Helmets changed to ZSH-7A to make distinct from US and TFN helmets " \n "  - RUS Removed RIS Rail adaptors from AK rifles " \n "  - RUS Added PG-7V rocket to MAT ammo crate. This rocket is lighter and packs less payload than the PG-7VL. This gives it an  increased effective range but is less powerful due to decreased payload " \n " " \n " " \n "- v1.12.2 " \n "  - Hotfixed US Vests across the Squads to match V.12 changes. Whoops. " \n "  - Added Angled Grip to TFN HK416s where possible.  " \n " " \n " " \n "- v1.12 " \n "  - Fixed TFN MMG Ammo preloaded into Rifle to 100RND mag from 50rnd. " \n "  - Fixed TFN DMT Marksman Ammo loaded into Rifle to correct SBLR mag. " \n "  - Changed TFN DMT Lead Suppressor to QDSS NT4 Black from Rotex-5 Grey " \n "  - Changed TFN Dagger Uniforms from Gorka R Green to FFCP Green Fatigues [RS] " \n "  - Changed US PLT Commander + Squad Leader Vest from SPCS Rifleman/OEF- CP to SPCS Squad Lead/OEF-CP " \n "  - Changed US Medic Vest from SPCS Rifleman/OEF-CP to SPCS Medic/OEF-CP " \n "  - Changed US PLT Rifleman Vest from SPCS OEF-CP to SPCS Rifleman Alt/OEF-CP " \n "  - Changed US FTL Vest from SPCS Rifleman/OEF-CP to SPCS Team Leader Alt/OEF-CP " \n "  - Changed US AR Vest from SPCS Rifleman/OEF-CP to SPCS SAW/OEF-CP " \n "  - Changed US AAR Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP " \n "  - Changed US Rifleman AT Vest from SPCS OEF-CP to SPCS Rifleman Alt/OEF-CP " \n "  - Changed US MAT/MMG/DMT/ENG/MTR Lead Vest from SPCS Rifleman/OEF-CP to SPCS Team Leader Alt/OEF-CP " \n "  - Changed US MMG Gunner Vest from SPCS Rifleman/OEF-CP to SPCS Machinegunner/OEF-CP " \n "  - Changed US MMG/MAT Ammo Bearer Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP " \n "  - Changed US MAT Gunner Vest from SPCS OEF-CP to SPCS Rifleman Alt/OEF-CP " \n "  - Changed US DMT Marksman vest from SPCS OEF-CP to SPCS Sniper/OEF-CP " \n "  - Fixed US DMT Marksman Rifle Loaded Mag to correct varient. " \n "  - Changed US Engineer Rifleman Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP. " \n "  - Changed US MTR Gunner Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP. " \n "  - Changed US DGR Uniforms from FFCP ACU Fatigues to FFCP ACU Fatigues [RS] " \n "  - Changed US DGR Driver Backpack from Assault Pack Green to Assault Pack Black " \n "  - Changed US Heli Pilot/Copilot Uniforms from Heli pilot Coveralls to FFCP Nomad Fatigues [RS] " \n "  - Fixed US Heli/Jet Pilot Vest White Smoke grenade count to 2. " \n "  - Changed US Heli Pilot/Copilot Helmet from Heli Pilot NATO to HGU-56/P (Black/Visor) " \n "  - Changed US Jet Pilot Uniform from Pilot Coveralls NATO to  FFCP Nomad Fatigues " \n "  - Changed RUS Vic/Heli/Jet Crew Weapons to PP-2000 " \n "  - Upped RUS PP-2000 Ammo counts to 6x Mag to bring in line with ammo counts for TFN and US. " \n "  - Changed RUS Heli Pilot Uniforms from Pilot Coveralls CSAT to FFCP-Fatigues EMR [RS] " \n "  - Changed RUS Heli Pilot Vest from 6B23 (6Sh116) to FFCP Tactical Vest TigerVRS " \n "  - Changed RUS Jet Pilot Uniforms from Pilot Coveralls CSAT to FFCP-Fatigues EMR [RS] " \n "  - Changed RUS Jet Pilot Vest from 6B23 (6Sh116) to FFCP Tactical Vest TigerVRS " \n " " \n " " \n "- v1.11 " \n "  - changed m40 mini grenades to m67 fragmentation " \n "  - replaced mp7 weapons with mp5k-pdw " \n "  - changed ak105 to ak74m (plum)  " \n "  - changed PKM to PKP " \n "  - changed RUS PKM ammo boxes. MMG now loads with 7TZ (AP rounds) " \n "  - added vert grip to us weapons " \n "  - replaced m14 with HK PSG1A1 " \n "  - replaced m260e4 with mg3 " \n "  - updated all ammo boxes respectively.  " \n " " \n " " \n "- v1.10 " \n "  - changed Medic loadouts from 6 x 1000ml blood bags to 2 x 1000ml and 8 x 500ml. " \n " " \n " " \n "- v1.09 " \n "  - updated Fireteam colours A1 Red A2 Yellow, B1 Green B2 Blue, C1 Red C2 Yellow. " \n " " \n " " \n "- v1.08 " \n "  - changed ""Reaper"" to ""Nightbird"", ""RPR"" to ""NB"" " \n "  - changed ""Paladin"" to ""Falcon"", ""PAL"" to ""FC"" " \n "  - changed ""DAGGER"" to ""DGR"" " \n " " \n " " \n "- v1.07 " \n "  - US and RU faction bumped to v1.07 to avoid confusion regarding version numbers (US and RU was 1.05, TFN was 1.06) " \n "  - overhauled the RU faction: updated helmets, uniforms, weapons to a more modern look " \n "  - overhauled the US faction: updated helmets and vests to armour rating of IV " \n "  - corrected some mistakes in all factions (grenade ammount of MMG gunner, ENG not having tourniquetes, DGR not having GPS-s) " \n "  - overhauled the medics of all factions to reflect recent cahnges to ACE medical (less QuikClots, more Elastic Bandages, etc.) " \n " " \n " " \n "- v1.05 " \n "  - Added a MAT ammo box on spawn. " \n " " \n " " \n "- v1.04 " \n "  - All MAT Teams carrying RPG's got the ver3 scopes with ranges for all types " \n "    of ammo. " \n "  - All Callsigns were changed to be uniformed throught no matter the faction. " \n " " \n " " \n "- v1.03 " \n "  - set crew driver/gunner and pilot/copilot/jetpilot as Engineers through the " \n "    Object: ACE Options menu in unit attributes " \n "  - overhauled the TFN faction (weapons, helmets, etc.), changes not applicable " \n "    to derived factions " \n " " \n " " \n "- v1.02 " \n "  - loadout overhaul for DMT, made them lighter + gave them tools for recon " \n "  - specified preset ACRE2 radio channels for most units " \n " " \n " " \n "- v1.01 " \n "  - updated team colors func to `a3ee_team_colors_fnc_setColor`, just load+save " \n "    the composition in editor, this fixes it " \n "  - changed RPG-7 using MAT teams to carry Kitbags " \n "  - removed one PKM ammo box from AAR, MMG gunner, MMG bearer (fixes overload) " \n "  - moved 1-2 AR boxes from AAR to AR, gave AR an Assaultpack " \n "  - added 1-2 more AR boxes to AR's Assaultpack (if enough space) " \n "  - changed HEDP to HE rockets for Carl Gustav (M3MAAWS) " \n "  - changed US crew uniform and helmet to match grey color scheme of US pilots " \n "  - changed backpacks of driver/copilot to use less contrasting colors compared " \n "    to their respective uniform/vest colors " \n "  - changed Carryall backpacks of TFN Engineers to use custom Flecktarn Carryall " \n "  - changed all (GP-25 and normal) AK74m rifles to be the non-NPZ variants " \n "  - removed secondary long-range (PRC148) from Engineers " \n " " \n " " \n "- v1.00 (and before) " \n "  - added a Comment object with version number (`v1.00`) " \n "  - added `respawn_west`, `respawn_east`, `respawn_guerrila` markers " \n "  - added `[this, 200] call a3ee_fnc_boxGuard` to init lines of resupply boxes " \n "  - added `Resupply` green triangle markers on the position of resupply boxes";
+		id=153;
 	};
-	class Item44
+	class Item43
 	{
 		dataType="Group";
 		side="Independent";
@@ -24602,7 +29207,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={20.629395,0.0014390945,-7.390625};
+					position[]={20.625488,0.0014390945,-7.1948242};
 				};
 				side="Independent";
 				flags=7;
@@ -24675,7 +29280,7 @@ class items
 						headgear="H_ShemagOpen_khk";
 					};
 				};
-				id=386;
+				id=155;
 				type="I_Protagonist_VR_F";
 				class CustomAttributes
 				{
@@ -24717,7 +29322,90 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=3;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="0";
+										};
+									};
+									class Item1
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+									class Item2
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="3";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute3
+					{
+						property="a3aa_insta_zeus_unit_curator";
+						expression="[_this, _value] call a3aa_insta_zeus_fnc_createUnitCurator";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"BOOL"
+									};
+								};
+								value=1;
+							};
+						};
+					};
+					nAttributes=4;
 				};
 			};
 			class Item1
@@ -24725,7 +29413,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={21.629395,0.0014390945,-7.390625};
+					position[]={21.625488,0.0014390945,-7.1948242};
 				};
 				side="Independent";
 				flags=5;
@@ -24798,7 +29486,7 @@ class items
 						headgear="rhsusf_bowman_cap";
 					};
 				};
-				id=387;
+				id=156;
 				type="I_Protagonist_VR_F";
 				class CustomAttributes
 				{
@@ -24840,14 +29528,97 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=3;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="0";
+										};
+									};
+									class Item1
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+									class Item2
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="3";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute3
+					{
+						property="a3aa_insta_zeus_unit_curator";
+						expression="[_this, _value] call a3aa_insta_zeus_fnc_createUnitCurator";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"BOOL"
+									};
+								};
+								value=1;
+							};
+						};
+					};
+					nAttributes=4;
 				};
 			};
 		};
 		class Attributes
 		{
 		};
-		id=385;
+		id=154;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -24872,12 +29643,12 @@ class items
 			nAttributes=1;
 		};
 	};
-	class Item45
+	class Item44
 	{
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={23.540527,0,-7.0712891};
+			position[]={23.536621,0,-6.8754883};
 		};
 		side="Empty";
 		flags=4;
@@ -24885,7 +29656,7 @@ class items
 		{
 			init="call{[this, 200] call a3aa_fnc_boxGuard}";
 		};
-		id=388;
+		id=157;
 		type="ACE_medicalSupplyCrate";
 		class CustomAttributes
 		{
@@ -24911,32 +29682,48 @@ class items
 			nAttributes=1;
 		};
 	};
+	class Item45
+	{
+		dataType="Comment";
+		class PositionInfo
+		{
+			position[]={-15.454102,0,6.7783203};
+		};
+		title="WESTERN PMC";
+		id=158;
+	};
 	class Item46
 	{
 		dataType="Comment";
 		class PositionInfo
 		{
-			position[]={-15.450195,0,6.5825195};
+			position[]={16.545898,0,6.7783203};
 		};
-		title="WESTERN PMC";
-		id=389;
+		title="EASTERN PMC";
+		id=159;
 	};
 	class Item47
 	{
-		dataType="Comment";
+		dataType="Object";
 		class PositionInfo
 		{
-			position[]={16.549805,0,6.5825195};
+			position[]={9.5458984,0.79142618,16.778809};
 		};
-		title="EASTERN PMC";
-		id=390;
+		side="Empty";
+		flags=4;
+		class Attributes
+		{
+			disableSimulation=1;
+		};
+		id=160;
+		type="Land_Noticeboard_F";
 	};
 	class Item48
 	{
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={9.5498047,0.79142618,16.583008};
+			position[]={16.545898,0.79142618,16.778809};
 		};
 		side="Empty";
 		flags=4;
@@ -24944,61 +29731,45 @@ class items
 		{
 			disableSimulation=1;
 		};
-		id=391;
+		id=161;
 		type="Land_Noticeboard_F";
 	};
 	class Item49
 	{
-		dataType="Object";
+		dataType="Comment";
 		class PositionInfo
 		{
-			position[]={16.549805,0.79142618,16.583008};
+			position[]={9.5458984,0,17.778809};
 		};
-		side="Empty";
-		flags=4;
-		class Attributes
-		{
-			disableSimulation=1;
-		};
-		id=392;
-		type="Land_Noticeboard_F";
+		title="Standard Rifles";
+		id=162;
 	};
 	class Item50
 	{
 		dataType="Comment";
 		class PositionInfo
 		{
-			position[]={9.5498047,0,17.583008};
+			position[]={16.545898,0,17.778809};
 		};
-		title="Standard Rifles";
-		id=393;
+		title="SL & FTLS";
+		id=163;
 	};
 	class Item51
 	{
 		dataType="Comment";
 		class PositionInfo
 		{
-			position[]={16.549805,0,17.583008};
-		};
-		title="SL & FTLS";
-		id=394;
-	};
-	class Item52
-	{
-		dataType="Comment";
-		class PositionInfo
-		{
-			position[]={23.549316,0,17.583008};
+			position[]={23.54541,0,17.778809};
 		};
 		title="DMT";
-		id=395;
+		id=164;
 	};
-	class Item53
+	class Item52
 	{
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={23.549316,0.79142618,16.583008};
+			position[]={23.54541,0.79142618,16.778809};
 		};
 		side="Empty";
 		flags=4;
@@ -25006,48 +29777,48 @@ class items
 		{
 			disableSimulation=1;
 		};
-		id=396;
+		id=165;
 		type="Land_Noticeboard_F";
 	};
-	class Item54
+	class Item53
 	{
 		dataType="Marker";
-		position[]={9.5498047,0.29708433,15.583008};
+		position[]={9.5458984,0.29708433,15.778809};
 		name="Rifles_9";
 		text="Rifles";
 		type="mil_triangle";
 		colorName="ColorGreen";
 		angle=2.177;
-		id=397;
+		id=166;
 	};
-	class Item55
+	class Item54
 	{
 		dataType="Marker";
-		position[]={16.549805,0.29708433,15.583008};
+		position[]={16.545898,0.29708433,15.778809};
 		name="Rifles_10";
 		text="SL & FTLS";
 		type="mil_triangle";
 		colorName="ColorGreen";
 		angle=2.177;
-		id=398;
+		id=167;
 	};
-	class Item56
+	class Item55
 	{
 		dataType="Marker";
-		position[]={23.549316,0.29708433,15.583008};
+		position[]={23.54541,0.29708433,15.778809};
 		name="Rifles_11";
 		text="DMT";
 		type="mil_triangle";
 		colorName="ColorGreen";
 		angle=2.177;
-		id=399;
+		id=168;
 	};
-	class Item57
+	class Item56
 	{
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={21.549805,0.14963102,-9.4169922};
+			position[]={21.545898,0.14963102,-9.2211914};
 			angles[]={-0,1.5418237,0};
 		};
 		side="Empty";
@@ -25055,7 +29826,7 @@ class items
 		class Attributes
 		{
 		};
-		id=400;
+		id=169;
 		type="Box_East_WpsLaunch_F";
 		class CustomAttributes
 		{
@@ -25081,23 +29852,23 @@ class items
 			nAttributes=1;
 		};
 	};
-	class Item58
+	class Item57
 	{
 		dataType="Marker";
-		position[]={22.549316,0.036262512,-9.4169922};
+		position[]={22.54541,0.035955906,-9.2211914};
 		name="resupply_marker_3";
 		text="Resupply";
 		type="mil_triangle";
 		colorName="ColorGreen";
-		id=401;
+		id=170;
 		atlOffset=0.00015306473;
 	};
-	class Item59
+	class Item58
 	{
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={-8.4506836,0.1566577,15.583008};
+			position[]={-8.4545898,0.1566577,15.778809};
 			angles[]={-0,4.7261076,0};
 		};
 		side="Empty";
@@ -25107,7 +29878,48 @@ class items
 			init="call{{    " \n "    _x params [""_classname"", ""_text""];    " \n "    this addAction [    " \n "        _text,    " \n "  {if (count ((player weaponAccessories primaryWeapon player)-[""""]) != 0) then {hint ""Remove weapon attachments before changing weapon""} else {player addWeapon (_this select 3), player addItemToVest ""20Rnd_762x51_Mag""}; " \n "  },    " \n "  _classname, 0.1, true, true, """", ""typeOf _this in ['I_Sniper_F']"",3   " \n "    ];    " \n "} forEach [    " \n "   " \n "[""srifle_EBR_F"",""<t color='#e6e600'>M18 ABR</t>""],   " \n "[""arifle_SPAR_03_blk_F"",""<t color='#ff0000'>SPAR 7.62 DMR Black</t>""],     " \n "[""arifle_SPAR_03_khk_F"",""<t color='#009933'>SPAR 7.62 DMR Woodland</t>""],    " \n "[""arifle_SPAR_03_snd_F"",""<t color='e6e600'>SPAR 7.62 DMR Sand</t>""],    " \n "[""srifle_DMR_06_olive_F"",""<t color='#e6e600'>Mk14 DMR Woodland</t>""],    " \n "[""srifle_DMR_06_camo_F"",""<t color='#e6e600'>Mk14 DMR Sand</t>""],    " \n "[""srifle_DMR_03_tan_F"",""<t color='#e6e600'>Mk1 EMR Sand""],    " \n "[""srifle_DMR_03_khaki_F"",""<t color='#009933'>Mk1 EMR Woodland</t>""],    " \n "[""srifle_DMR_03_multicam_F"",""<t color='#ff0000'>Mk1 EMR Camo 1</t>""],   " \n "[""srifle_DMR_03_multicam_F"",""<t color='#ff0000'>Mk1 EMR Camo 2</t>""],   " \n "[""hlc_rifle_M14dmr_Rail"",""<t color='#ff0000'>M14 DMR Black</t>""]   " \n "   " \n "];}";
 			disableSimulation=1;
 		};
-		id=402;
+		id=171;
+		type="Land_PlasticCase_01_small_F";
+		class CustomAttributes
+		{
+			class Attribute0
+			{
+				property="ammoBox";
+				expression="[_this,_value] call bis_fnc_initAmmoBox;";
+				class Value
+				{
+					class data
+					{
+						class type
+						{
+							type[]=
+							{
+								"STRING"
+							};
+						};
+						value="[[[[],[]],[[],[]],[[],[]],[[],[]]],false]";
+					};
+				};
+			};
+			nAttributes=1;
+		};
+	};
+	class Item59
+	{
+		dataType="Object";
+		class PositionInfo
+		{
+			position[]={9.5454102,0.1566577,15.778809};
+			angles[]={-0,4.7261076,0};
+		};
+		side="Empty";
+		flags=4;
+		class Attributes
+		{
+			init="call{{   " \n "    _x params [""_classname"", ""_text""];   " \n "    this addAction [   " \n "        _text,   " \n "  {player addWeapon (_this select 3), player addItemToVest ""rhs_30Rnd_545x39_7N22_AK"", player addPrimaryWeaponItem ""rhs_acc_dtk""},   " \n "  _classname, 0.1, true, true, """", ""typeOf _this in ['I_medic_F', 'I_soldier_F', 'I_Soldier_AAR_F', 'I_Soldier_LAT_F', 'I_Soldier_AT_F', 'I_Soldier_AAT_F', 'I_engineer_F', 'I_crew_F', 'I_support_MORT_F', 'I_support_AMORT_F']"",3    " \n "    ];   " \n "} forEach [   " \n "  " \n "[""rhs_weap_ak105"",""<t color='#ff0000'>AK 105</t>""],     " \n "[""rhs_weap_ak105_npz"",""<t color='#009933'>AK 105 - Rail mod</t>""],    " \n "[""rhs_weap_ak105_zenitco01"",""<t color='#009933'>AK 105 Zentico</t>""],    " \n "[""rhs_weap_ak105_zenitco01_b33"",""<t color='#e6e600'>AK 105 Zentico - Rail mod</t>""],    " \n "[""rhs_weap_ak74"",""<t color='#e6e600'>AK 74</t>""],    " \n "[""rhs_weap_ak74m_camo"",""<t color='#e6e600'>AK74M Camo</t>""],    " \n "[""rhs_weap_ak74m_desert_npz"",""<t color='#009933'>AK74M Desert - Rail mod</t>""],    " \n "[""rhs_weap_ak74mr"",""<t color='#e6e600'>AK74MR</t>""],    " \n "[""hlc_rifle_ak12"",""<t color='#009933'>AK12</t>""],    " \n "[""hlc_rifle_aku12"",""<t color='#ff0000'>AK12U</t>""],    " \n "[""hlc_rifle_ak74m"",""<t color='#ff0000'>AK74M</t>""],    " \n "[""hlc_rifle_aks74"",""<t color='#ff0000'>AKS74</t>""],      " \n "[""hlc_rifle_aek971_mtk"",""<t color='#e6e600'>AEK971</t>""]  " \n "  " \n "]; " \n "}";
+			disableSimulation=1;
+		};
+		id=172;
 		type="Land_PlasticCase_01_small_F";
 		class CustomAttributes
 		{
@@ -25138,17 +29950,17 @@ class items
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={9.5493164,0.1566577,15.583008};
+			position[]={16.54541,0.1566577,15.778809};
 			angles[]={-0,4.7261076,0};
 		};
 		side="Empty";
 		flags=4;
 		class Attributes
 		{
-			init="call{{   " \n "    _x params [""_classname"", ""_text""];   " \n "    this addAction [   " \n "        _text,   " \n "  {player addWeapon (_this select 3), player addItemToVest ""rhs_30Rnd_545x39_7N22_AK"", player addPrimaryWeaponItem ""rhs_acc_dtk""},   " \n "  _classname, 0.1, true, true, """", ""typeOf _this in ['I_medic_F', 'I_soldier_F', 'I_Soldier_AAR_F', 'I_Soldier_LAT_F', 'I_Soldier_AT_F', 'I_Soldier_AAT_F', 'I_engineer_F', 'I_crew_F', 'I_support_MORT_F', 'I_support_AMORT_F']"",3    " \n "    ];   " \n "} forEach [   " \n "  " \n "[""rhs_weap_ak105"",""<t color='#ff0000'>AK 105</t>""],     " \n "[""rhs_weap_ak105_npz"",""<t color='#009933'>AK 105 - Rail mod</t>""],    " \n "[""rhs_weap_ak105_zenitco01"",""<t color='#009933'>AK 105 Zentico</t>""],    " \n "[""rhs_weap_ak105_zenitco01_b33"",""<t color='#e6e600'>AK 105 Zentico - Rail mod</t>""],    " \n "[""rhs_weap_ak74"",""<t color='#e6e600'>AK 74</t>""],    " \n "[""rhs_weap_ak74m_camo"",""<t color='#e6e600'>AK74M Camo</t>""],    " \n "[""rhs_weap_ak74m_desert_npz"",""<t color='#009933'>AK74M Desert - Rail mod</t>""],    " \n "[""rhs_weap_ak74mr"",""<t color='#e6e600'>AK74MR</t>""],    " \n "[""hlc_rifle_ak12"",""<t color='#009933'>AK12</t>""],    " \n "[""hlc_rifle_aku12"",""<t color='#ff0000'>AK12U</t>""],    " \n "[""hlc_rifle_ak74m"",""<t color='#ff0000'>AK74M</t>""],    " \n "[""hlc_rifle_aks74"",""<t color='#ff0000'>AKS74</t>""],      " \n "[""hlc_rifle_aek971_mtk"",""<t color='#e6e600'>AEK971</t>""]  " \n "  " \n "]; " \n "}";
+			init="call{{   " \n "    _x params [""_classname"", ""_text""];   " \n "    this addAction [   " \n "        _text,   " \n "  {player addWeapon (_this select 3), player addItemToVest ""rhs_30Rnd_545x39_7N22_AK"", player addItemToBackpack ""rhs_VOG25"", player addPrimaryWeaponItem ""rhs_acc_dtk""},  " \n "  _classname, 0.1, true, true, """", ""typeOf _this in ['I_officer_F', 'I_Soldier_SL_F', 'I_Soldier_TL_F', 'I_Spotter_F']"",3 " \n "    ];   " \n "} forEach [   " \n "  " \n "[""rhs_weap_ak74_gp25"",""<t color='#ff0000'>AK74 GL</t>""],    " \n "[""rhs_weap_ak74mr_gp25"",""<t color='#009933'>AK74MR 21 GL</t>""],   " \n "[""hlc_rifle_ak12GL"",""<t color='#009933'>AK12 GL</t>""],   " \n "[""hlc_rifle_ak74m_gl"",""<t color='#e6e600'>AK74M GL</t>""],  " \n "[""hlc_rifle_aks74_GL"",""<t color='#e6e600'>AKS74 GL</t>""]  " \n "  " \n "];}";
 			disableSimulation=1;
 		};
-		id=403;
+		id=173;
 		type="Land_PlasticCase_01_small_F";
 		class CustomAttributes
 		{
@@ -25179,17 +29991,17 @@ class items
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={16.549316,0.1566577,15.583008};
+			position[]={-22.454834,0.1566577,15.778564};
 			angles[]={-0,4.7261076,0};
 		};
 		side="Empty";
 		flags=4;
 		class Attributes
 		{
-			init="call{{   " \n "    _x params [""_classname"", ""_text""];   " \n "    this addAction [   " \n "        _text,   " \n "  {player addWeapon (_this select 3), player addItemToVest ""rhs_30Rnd_545x39_7N22_AK"", player addItemToBackpack ""rhs_VOG25"", player addPrimaryWeaponItem ""rhs_acc_dtk""},  " \n "  _classname, 0.1, true, true, """", ""typeOf _this in ['I_officer_F', 'I_Soldier_SL_F', 'I_Soldier_TL_F', 'I_Spotter_F']"",3 " \n "    ];   " \n "} forEach [   " \n "  " \n "[""rhs_weap_ak74_gp25"",""<t color='#ff0000'>AK74 GL</t>""],    " \n "[""rhs_weap_ak74mr_gp25"",""<t color='#009933'>AK74MR 21 GL</t>""],   " \n "[""hlc_rifle_ak12GL"",""<t color='#009933'>AK12 GL</t>""],   " \n "[""hlc_rifle_ak74m_gl"",""<t color='#e6e600'>AK74M GL</t>""],  " \n "[""hlc_rifle_aks74_GL"",""<t color='#e6e600'>AKS74 GL</t>""]  " \n "  " \n "];}";
+			init="call{{  " \n "    _x params [""_classname"", ""_text""];    " \n "    this addAction [    " \n "        _text,    " \n "  {player addWeapon (_this select 3), player addItemToVest ""rhs_mag_30Rnd_556x45_M855A1_Stanag"", player addPrimaryWeaponItem ""rhsusf_acc_M952V""},    " \n "  _classname, 0.1, true, true, """", ""typeOf _this in ['I_medic_F', 'I_soldier_F', 'I_Soldier_AAR_F', 'I_Soldier_LAT_F', 'I_Soldier_AT_F', 'I_Soldier_AAT_F', 'I_engineer_F', 'I_crew_F', 'I_support_MORT_F', 'I_support_AMORT_F']"",3  " \n "    ];    " \n "} forEach [    " \n "   " \n "[""arifle_Mk20C_plain_F"",""<t color='#ff0000'>Mk20 Carbine</t>""],      " \n "[""arifle_TRG21_F"",""<t color='#009933'>TRG 21</t>""],     " \n "[""arifle_SPAR_01_khk_F"",""<t color='#009933'>SPAR Woodland</t>""],     " \n "[""arifle_SPAR_01_snd_F"",""<t color='#e6e600'>SPAR Sand</t>""],     " \n "[""rhs_weap_hk416d145_d"",""<t color='#e6e600'>HK416 Sand</t>""],     " \n "[""rhs_weap_m4a1_blockII_d"",""<t color='#e6e600'>M4A1 Sand</t>""],     " \n "[""rhs_weap_m4a1_blockII_wd"",""<t color='#009933'>M4A1 Woodland</t>""],     " \n "[""rhs_weap_mk18_KAC_d"",""<t color='#e6e600'>Mk18 Sand</t>""],     " \n "[""rhs_weap_mk18_KAC_wd"",""<t color='#009933'>Mk18 Woodland</t>""],     " \n "[""hlc_rifle_RU5562"",""<t color='#ff0000'>Sanitiser</t>""],     " \n "[""hlc_rifle_RU556"",""<t color='#ff0000'>Liquidator</t>""],     " \n "[""hlc_rifle_bcmjack"",""<t color='#ff0000'>Jack</t>""],     " \n "[""hlc_rifle_ACR_SBR_green"",""<t color='#009933'>ACR Woodland</t>""],     " \n "[""hlc_rifle_ACR_SBR_tan"",""<t color='#e6e600'>ACR Sand</t>""]   " \n "   " \n "];}";
 			disableSimulation=1;
 		};
-		id=404;
+		id=174;
 		type="Land_PlasticCase_01_small_F";
 		class CustomAttributes
 		{
@@ -25220,17 +30032,17 @@ class items
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={-22.450684,0.1566577,15.583008};
+			position[]={23.54541,0.1566577,15.778809};
 			angles[]={-0,4.7261076,0};
 		};
 		side="Empty";
 		flags=4;
 		class Attributes
 		{
-			init="call{{  " \n "    _x params [""_classname"", ""_text""];    " \n "    this addAction [    " \n "        _text,    " \n "  {player addWeapon (_this select 3), player addItemToVest ""rhs_mag_30Rnd_556x45_M855A1_Stanag"", player addPrimaryWeaponItem ""rhsusf_acc_M952V""},    " \n "  _classname, 0.1, true, true, """", ""typeOf _this in ['I_medic_F', 'I_soldier_F', 'I_Soldier_AAR_F', 'I_Soldier_LAT_F', 'I_Soldier_AT_F', 'I_Soldier_AAT_F', 'I_engineer_F', 'I_crew_F', 'I_support_MORT_F', 'I_support_AMORT_F']"",3  " \n "    ];    " \n "} forEach [    " \n "   " \n "[""arifle_Mk20C_plain_F"",""<t color='#ff0000'>Mk20 Carbine</t>""],      " \n "[""arifle_TRG21_F"",""<t color='#009933'>TRG 21</t>""],     " \n "[""arifle_SPAR_01_khk_F"",""<t color='#009933'>SPAR Woodland</t>""],     " \n "[""arifle_SPAR_01_snd_F"",""<t color='#e6e600'>SPAR Sand</t>""],     " \n "[""rhs_weap_hk416d145_d"",""<t color='#e6e600'>HK416 Sand</t>""],     " \n "[""rhs_weap_m4a1_blockII_d"",""<t color='#e6e600'>M4A1 Sand</t>""],     " \n "[""rhs_weap_m4a1_blockII_wd"",""<t color='#009933'>M4A1 Woodland</t>""],     " \n "[""rhs_weap_mk18_KAC_d"",""<t color='#e6e600'>Mk18 Sand</t>""],     " \n "[""rhs_weap_mk18_KAC_wd"",""<t color='#009933'>Mk18 Woodland</t>""],     " \n "[""hlc_rifle_RU5562"",""<t color='#ff0000'>Sanitiser</t>""],     " \n "[""hlc_rifle_RU556"",""<t color='#ff0000'>Liquidator</t>""],     " \n "[""hlc_rifle_bcmjack"",""<t color='#ff0000'>Jack</t>""],     " \n "[""hlc_rifle_ACR_SBR_green"",""<t color='#009933'>ACR Woodland</t>""],     " \n "[""hlc_rifle_ACR_SBR_tan"",""<t color='#e6e600'>ACR Sand</t>""]   " \n "   " \n "];}";
+			init="call{{   " \n "    _x params [""_classname"", ""_text""];   " \n "    this addAction [   " \n "        _text,   " \n "  {if (count ((player weaponAccessories primaryWeapon player)-[""""]) != 0) then {hint ""Remove weapon attachments before changing weapon""} else {player addWeapon (_this select 3), player addItemToVest ""10Rnd_762x54_Mag""}; " \n "  },   " \n "  _classname, 0.1, true, true, """", ""typeOf _this in ['I_Sniper_F']"",3 " \n "    ];   " \n "} forEach [   " \n "  " \n "[""rhs_weap_svdp_wd"",""<t color='#e6e600'>SVD Camo</t>""],  " \n "[""rhs_weap_svds_npz"",""<t color='#ff0000'>SVD Blk - Rail mod</t>""],  " \n "[""UK3CB_SVD_OLD"",""<t color='#ff0000'>Dragunov</t>""]  " \n "  " \n "];}";
 			disableSimulation=1;
 		};
-		id=405;
+		id=175;
 		type="Land_PlasticCase_01_small_F";
 		class CustomAttributes
 		{
@@ -25261,17 +30073,17 @@ class items
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={23.549316,0.1566577,15.583008};
+			position[]={-15.45459,0.1566577,15.778809};
 			angles[]={-0,4.7261076,0};
 		};
 		side="Empty";
 		flags=4;
 		class Attributes
 		{
-			init="call{{   " \n "    _x params [""_classname"", ""_text""];   " \n "    this addAction [   " \n "        _text,   " \n "  {if (count ((player weaponAccessories primaryWeapon player)-[""""]) != 0) then {hint ""Remove weapon attachments before changing weapon""} else {player addWeapon (_this select 3), player addItemToVest ""10Rnd_762x54_Mag""}; " \n "  },   " \n "  _classname, 0.1, true, true, """", ""typeOf _this in ['I_Sniper_F']"",3 " \n "    ];   " \n "} forEach [   " \n "  " \n "[""rhs_weap_svdp_wd"",""<t color='#e6e600'>SVD Camo</t>""],  " \n "[""rhs_weap_svds_npz"",""<t color='#ff0000'>SVD Blk - Rail mod</t>""],  " \n "[""UK3CB_SVD_OLD"",""<t color='#ff0000'>Dragunov</t>""]  " \n "  " \n "];}";
+			init="call{{    " \n "    _x params [""_classname"", ""_text""];    " \n "    this addAction [    " \n "    _text,    " \n "     {player addWeapon (_this select 3), player addItemToVest ""rhs_mag_30Rnd_556x45_M855A1_Stanag"", player addItemToBackpack ""1Rnd_HE_Grenade_shell"", player addPrimaryWeaponItem ""rhsusf_acc_M952V""},    " \n "     _classname, 0.1, true, true, """", ""typeOf _this in ['I_officer_F', 'I_Soldier_SL_F', 'I_Soldier_TL_F', 'I_Spotter_F']"",  3  " \n "  ];    " \n "} forEach [    " \n "   " \n "[""arifle_Mk20_GL_plain_F"",""<t color='#ff0000'>Mk20 Carbine GL</t>""],     " \n "[""arifle_TRG21_GL_F"",""<t color='#009933'>TRG 21 GL</t>""],    " \n "[""arifle_SPAR_01_GL_khk_F"",""<t color='#009933'>SPAR Woodland GL</t>""],    " \n "[""arifle_SPAR_01_GL_snd_F"",""<t color='#e6e600'>SPAR Sand GL</t>""],    " \n "[""rhs_weap_m4a1_blockII_M203_d"",""<t color='#e6e600'>M4A1 Sand GL</t>""],    " \n "[""rhs_weap_m4a1_blockII_M203_wd"",""<t color='#009933'>M4A1 Woodland GL""],    " \n "[""hlc_rifle_ACR_GL_SBR_green"",""<t color='#009933'>ACR Woodland GL</t>""],    " \n "[""hlc_rifle_ACR_GL_SBR_tan"",""<t color='#e6e600'>ACR Sand GL</t>""]   " \n "   " \n "];  " \n "}";
 			disableSimulation=1;
 		};
-		id=406;
+		id=176;
 		type="Land_PlasticCase_01_small_F";
 		class CustomAttributes
 		{
@@ -25299,27 +30111,41 @@ class items
 	};
 	class Item64
 	{
-		dataType="Object";
+		dataType="Logic";
 		class PositionInfo
 		{
-			position[]={-15.450684,0.1566577,15.583008};
-			angles[]={-0,4.7261076,0};
+			position[]={16.546143,0,-2.2214355};
 		};
-		side="Empty";
-		flags=4;
-		class Attributes
-		{
-			init="call{{    " \n "    _x params [""_classname"", ""_text""];    " \n "    this addAction [    " \n "    _text,    " \n "     {player addWeapon (_this select 3), player addItemToVest ""rhs_mag_30Rnd_556x45_M855A1_Stanag"", player addItemToBackpack ""1Rnd_HE_Grenade_shell"", player addPrimaryWeaponItem ""rhsusf_acc_M952V""},    " \n "     _classname, 0.1, true, true, """", ""typeOf _this in ['I_officer_F', 'I_Soldier_SL_F', 'I_Soldier_TL_F', 'I_Spotter_F']"",  3  " \n "  ];    " \n "} forEach [    " \n "   " \n "[""arifle_Mk20_GL_plain_F"",""<t color='#ff0000'>Mk20 Carbine GL</t>""],     " \n "[""arifle_TRG21_GL_F"",""<t color='#009933'>TRG 21 GL</t>""],    " \n "[""arifle_SPAR_01_GL_khk_F"",""<t color='#009933'>SPAR Woodland GL</t>""],    " \n "[""arifle_SPAR_01_GL_snd_F"",""<t color='#e6e600'>SPAR Sand GL</t>""],    " \n "[""rhs_weap_m4a1_blockII_M203_d"",""<t color='#e6e600'>M4A1 Sand GL</t>""],    " \n "[""rhs_weap_m4a1_blockII_M203_wd"",""<t color='#009933'>M4A1 Woodland GL""],    " \n "[""hlc_rifle_ACR_GL_SBR_green"",""<t color='#009933'>ACR Woodland GL</t>""],    " \n "[""hlc_rifle_ACR_GL_SBR_tan"",""<t color='#e6e600'>ACR Sand GL</t>""]   " \n "   " \n "];  " \n "}";
-			disableSimulation=1;
-		};
-		id=407;
-		type="Land_PlasticCase_01_small_F";
+		areaSize[]={200,0,200};
+		areaIsRectangle=1;
+		flags=1;
+		id=177;
+		type="a3aa_ee_custom_location";
 		class CustomAttributes
 		{
 			class Attribute0
 			{
-				property="ammoBox";
-				expression="[_this,_value] call bis_fnc_initAmmoBox;";
+				property="a3aa_ee_custom_location_delcorpse";
+				expression="_this setVariable [""a3aa_ee_custom_location_delcorpse"",_value]";
+				class Value
+				{
+					class data
+					{
+						class type
+						{
+							type[]=
+							{
+								"BOOL"
+							};
+						};
+						value=1;
+					};
+				};
+			};
+			class Attribute1
+			{
+				property="a3aa_ee_custom_location_locname";
+				expression="_this setVariable [""a3aa_ee_custom_location_locname"",_value]";
 				class Value
 				{
 					class data
@@ -25331,11 +30157,30 @@ class items
 								"STRING"
 							};
 						};
-						value="[[[[],[]],[[],[]],[[],[]],[[],[]]],false]";
+						value="";
 					};
 				};
 			};
-			nAttributes=1;
+			class Attribute2
+			{
+				property="a3aa_ee_custom_location_loctype";
+				expression="_this setVariable [""a3aa_ee_custom_location_loctype"",_value]";
+				class Value
+				{
+					class data
+					{
+						class type
+						{
+							type[]=
+							{
+								"STRING"
+							};
+						};
+						value="NameVillage";
+					};
+				};
+			};
+			nAttributes=3;
 		};
 	};
 	class Item65
@@ -25343,12 +30188,12 @@ class items
 		dataType="Logic";
 		class PositionInfo
 		{
-			position[]={16.549805,0,-2.4169922};
+			position[]={-15.454102,0,-2.2211914};
 		};
-		areaSize[]={40,-1,20};
+		areaSize[]={200,-1,200};
 		areaIsRectangle=1;
 		flags=1;
-		id=408;
+		id=178;
 		type="a3aa_ee_custom_location";
 		class CustomAttributes
 		{
@@ -25414,41 +30259,24 @@ class items
 	};
 	class Item66
 	{
-		dataType="Logic";
+		dataType="Object";
 		class PositionInfo
 		{
-			position[]={-15.450195,0,-2.4169922};
+			position[]={23.418213,0.18872452,-13.004395};
 		};
-		areaSize[]={200,-1,200};
-		areaIsRectangle=1;
-		flags=1;
-		id=409;
-		type="a3aa_ee_custom_location";
+		side="Empty";
+		flags=4;
+		class Attributes
+		{
+		};
+		id=257;
+		type="Box_IND_Wps_F";
 		class CustomAttributes
 		{
 			class Attribute0
 			{
-				property="a3aa_ee_custom_location_delcorpse";
-				expression="_this setVariable [""a3aa_ee_custom_location_delcorpse"",_value]";
-				class Value
-				{
-					class data
-					{
-						class type
-						{
-							type[]=
-							{
-								"BOOL"
-							};
-						};
-						value=1;
-					};
-				};
-			};
-			class Attribute1
-			{
-				property="a3aa_ee_custom_location_locname";
-				expression="_this setVariable [""a3aa_ee_custom_location_locname"",_value]";
+				property="ammoBox";
+				expression="[_this,_value] call bis_fnc_initAmmoBox;";
 				class Value
 				{
 					class data
@@ -25460,30 +30288,60 @@ class items
 								"STRING"
 							};
 						};
-						value="";
+						value="[[[[""arifle_Mk20C_F"",""arifle_Mk20_F"",""arifle_Mk20_GL_F"",""LMG_Mk200_F"",""hgun_PDW2000_F"",""hgun_ACPC2_F""],[2,4,2,2,1,1]],[[""30Rnd_556x45_Stanag"",""9Rnd_45ACP_Mag"",""30Rnd_9x21_Mag"",""200Rnd_65x39_cased_Box"",""ACE_30Rnd_556x45_Stanag_M995_AP_mag"",""ACE_30Rnd_556x45_Stanag_Mk262_mag"",""ACE_30Rnd_556x45_Stanag_Mk318_mag""],[8,1,1,2,4,4,4]],[[""ACE_MapTools"",""ACE_RangeTable_82mm""],[2,2]],[[""I_Mortar_01_support_F"",""I_Mortar_01_weapon_F""],[2,2]]],false]";
 					};
 				};
 			};
-			class Attribute2
-			{
-				property="a3aa_ee_custom_location_loctype";
-				expression="_this setVariable [""a3aa_ee_custom_location_loctype"",_value]";
-				class Value
-				{
-					class data
-					{
-						class type
-						{
-							type[]=
-							{
-								"STRING"
-							};
-						};
-						value="NameVillage";
-					};
-				};
-			};
-			nAttributes=3;
+			nAttributes=1;
 		};
+	};
+	class Item67
+	{
+		dataType="Object";
+		class PositionInfo
+		{
+			position[]={-8.6479492,0.18872452,-13.056885};
+		};
+		side="Empty";
+		flags=4;
+		class Attributes
+		{
+		};
+		id=258;
+		type="Box_IND_Wps_F";
+		class CustomAttributes
+		{
+			class Attribute0
+			{
+				property="ammoBox";
+				expression="[_this,_value] call bis_fnc_initAmmoBox;";
+				class Value
+				{
+					class data
+					{
+						class type
+						{
+							type[]=
+							{
+								"STRING"
+							};
+						};
+						value="[[[[""arifle_Mk20C_F"",""arifle_Mk20_F"",""arifle_Mk20_GL_F"",""LMG_Mk200_F"",""hgun_PDW2000_F"",""hgun_ACPC2_F""],[2,4,2,2,1,1]],[[""30Rnd_556x45_Stanag"",""9Rnd_45ACP_Mag"",""30Rnd_9x21_Mag"",""200Rnd_65x39_cased_Box"",""ACE_30Rnd_556x45_Stanag_M995_AP_mag"",""ACE_30Rnd_556x45_Stanag_Mk262_mag"",""ACE_30Rnd_556x45_Stanag_Mk318_mag""],[8,1,1,2,4,4,4]],[[""ACE_MapTools"",""ACE_RangeTable_82mm""],[2,2]],[[""I_Mortar_01_support_F"",""I_Mortar_01_weapon_F""],[2,2]]],false]";
+					};
+				};
+			};
+			nAttributes=1;
+		};
+	};
+	class Item68
+	{
+		dataType="Comment";
+		class PositionInfo
+		{
+			position[]={-12.731689,0,-8.1850586};
+		};
+		title="v1.14.2";
+		description="-v1.14.2 " \n "-GM: Fixed ""assign zeus to this unit"" not being present " \n "-All Groups: Fixed radio channel presets " \n "-Gave every unit 1 epi in Uniform, or Vest if uniform was full (medic not included) " \n "-Moved element lead LR radio to backpack " \n "-Added mortar supply crate " \n "-DMT: Removed NVG scope, and replaced main scope with one that can be used with goggles. " \n "-Gave engineers more ammo (1 tracer + 1 for members, 2 tracer for leader)" \n "" \n "-v1.14.1" \n " - A3EE box guard updated to A3AA." \n " - Custom location re-added." \n "" \n "- v1.14.0 " \n "PL: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Boonie Hat"" for more visual diversity in the platoon and to bring PL headgear in line with RU and US Standard Factions. " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n "  - Removed CNTO ""Beret"" from Backpack gear due to old logo texture. " \n " " \n "Platoon Sergeant: " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n "  - Backpack added 3CB ""Radio Backpack MR3000"" and filled it with the ACRE2 ""AN/PRC-117F"" backpack radio. This gives more incentive to bring the PLT Sgt along since he is the only one who can act as a max range radio man for the platoon. " \n " " \n "Platoon Medic: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n " " \n "Platoon Rifleman: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n " " \n "Squad Medic: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n " " \n "FTL: " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n " " \n "AR: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n "  - Added muzzle attachment RHS ""SF3P-556 1/2-28"". " \n " " \n "AAR: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n " " \n "LAT: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n " " \n "MMG Teamleader: " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n " " \n "MMG Gunner: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n "  - Unfortunately no muzzle attachments available for the MG-3! " \n " " \n "MMG Asst. Gunner: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n " " \n "MAT Teamleader: " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n " " \n "MAT Gunner: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n " " \n "MAT Asst. Gunner: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n " " \n "ENG Leader: " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Heavy"" to differentiate ENG from the rest of the platoon. " \n " " \n "ENG Rifleman: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Heavy"" to differentiate ENG from the rest of the platoon. " \n " " \n "Mortar Leader: " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Special"" to visually differentiate the Mortar Team from the rest of the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n "  - Reduced STANAG mags from 10 to 5 to match the ENG ammo count. " \n " " \n "Mortar Gunner: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Special"" to visually differentiate the Mortar Team from the rest of the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n "  - Reduced STANAG mags from 10 to 5 to match the ENG ammo count. " \n " " \n "DMT Leader " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n " " \n "DMT Marksman " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n "  - Added NVG scope RHS ""AN/PVS-27"" to the vest gear. " \n " " \n "Zeus & Co-Zeus " \n "  - Uniform changed from vanilla ""VR Suit Indie"" to CNTO ""Flecktarn Recon"" to make Zeus look a bit more like an HQ commander than a Tron character. " \n "  - Facewear changed from vanilla ""VR Goggles"" to vanilla ""Aviator Glasses"". " \n "  - Insignia added ""Zeus"". " \n " " \n "All Units: " \n "  - Disabled LAMBS AI " \n " " \n "Alpha SL: " \n "  - Enabled ""is Player"". This makes it easier for Mission Makers to quickly test a mission in the editor by just hitting ""play"" instead of having to select a specific unit every time beforehand to avoid ending up in spectator mode by default. " \n " " \n "Crates: " \n "  - Added an ACE3 medical crate with our usual base script. " \n " " \n " " \n "- v1.13.6 " \n "  - ALL Added persistent Call-Signs for all GM's (where not included in v1.13.4) " \n "  - ALL Added the code `this disableAI ""MOVE""; this setSpeaker ""NoVoice""; enableRadio false;` to all playable units to prevent them from running off and spamming the vanilla-radio during local testing. " \n "  - ALL Changed persistent call-signs (map markers) to a consistent formula: ≤ 2 syllables = written out call-sing. ≥ 3 syllables = abbreviated call-sign. " \n "  - ALL Added full changelog to all factions for quick in-game reference " \n "  - TFN Added new yellow owl insignia patches to all uniforms " \n " " \n " " \n "- v1.13.5 " \n "  - ALL Added respective GM's to Standard Faction Compositions for convenience / time saving  " \n "  - ALL Added base clean-up module to Standard Faction Compositions to ensure Mission Makers don't forget it in the future - radius set to 200x200 meters " \n " " \n " " \n "- v1.13.4  " \n "  - ALL Added @ Squad/Team names to leaders so that Team name appears in role select " \n "  - TFN Changed M249 to the FN MINIMI " \n " " \n " " \n "- v1.13.3 " \n "  - US Added Improved Bipod/SAW Grip to AR M249 " \n "  - US Removed M14 Mags " \n "  - TFN Added Bipod to M249 " \n " " \n " " \n "- v1.13.2 " \n "  - ALL Added 1 Extra Tourniquet to every Unit " \n "  - TFN DMT Lead Rifle Changed to D10 Version " \n "  - TFN DMT given extra pistol mag to bring in line with other units " \n "  - TFN AAR Weapon changed to HK416 D14.5 " \n "  - TFN Lead Elements Given AN/PEQ-16A's " \n "  - US Alpha Fireteam 2 AAR vest changed to ALT variant to match rest of faction " \n "  - US Lead Elements Given AN/PEQ-16A's " \n "  - US DMT given extra pistol mag to bring in line with other units " \n "  - US DMT Sniper Rifle Given SU-260/P (MDO) to bring zoom level to the same as Russian and TFN factions " \n "  - US DMT Bipod Changed to Harris Bipod " \n "  - US DMT Marksman Rifle changed to black version of same rifle " \n "  - US DMT Marksman Magazines changed to SR-25 version, as RHS hotfix made M14 mags incompatible with MK11 " \n "  - RUS DMT given extra pistol mag to bring in line with other units " \n "  - RUS DGR Helmets changed to TSH-4 to make distinct from US Helmets " \n "  - RUS NB Helmets changed to ZSH-7A to make distinct from US and TFN helmets " \n "  - RUS Removed RIS Rail adaptors from AK rifles " \n "  - RUS Added PG-7V rocket to MAT ammo crate. This rocket is lighter and packs less payload than the PG-7VL. This gives it an  increased effective range but is less powerful due to decreased payload " \n " " \n " " \n "- v1.12.2 " \n "  - Hotfixed US Vests across the Squads to match V.12 changes. Whoops. " \n "  - Added Angled Grip to TFN HK416s where possible.  " \n " " \n " " \n "- v1.12 " \n "  - Fixed TFN MMG Ammo preloaded into Rifle to 100RND mag from 50rnd. " \n "  - Fixed TFN DMT Marksman Ammo loaded into Rifle to correct SBLR mag. " \n "  - Changed TFN DMT Lead Suppressor to QDSS NT4 Black from Rotex-5 Grey " \n "  - Changed TFN Dagger Uniforms from Gorka R Green to FFCP Green Fatigues [RS] " \n "  - Changed US PLT Commander + Squad Leader Vest from SPCS Rifleman/OEF- CP to SPCS Squad Lead/OEF-CP " \n "  - Changed US Medic Vest from SPCS Rifleman/OEF-CP to SPCS Medic/OEF-CP " \n "  - Changed US PLT Rifleman Vest from SPCS OEF-CP to SPCS Rifleman Alt/OEF-CP " \n "  - Changed US FTL Vest from SPCS Rifleman/OEF-CP to SPCS Team Leader Alt/OEF-CP " \n "  - Changed US AR Vest from SPCS Rifleman/OEF-CP to SPCS SAW/OEF-CP " \n "  - Changed US AAR Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP " \n "  - Changed US Rifleman AT Vest from SPCS OEF-CP to SPCS Rifleman Alt/OEF-CP " \n "  - Changed US MAT/MMG/DMT/ENG/MTR Lead Vest from SPCS Rifleman/OEF-CP to SPCS Team Leader Alt/OEF-CP " \n "  - Changed US MMG Gunner Vest from SPCS Rifleman/OEF-CP to SPCS Machinegunner/OEF-CP " \n "  - Changed US MMG/MAT Ammo Bearer Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP " \n "  - Changed US MAT Gunner Vest from SPCS OEF-CP to SPCS Rifleman Alt/OEF-CP " \n "  - Changed US DMT Marksman vest from SPCS OEF-CP to SPCS Sniper/OEF-CP " \n "  - Fixed US DMT Marksman Rifle Loaded Mag to correct varient. " \n "  - Changed US Engineer Rifleman Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP. " \n "  - Changed US MTR Gunner Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP. " \n "  - Changed US DGR Uniforms from FFCP ACU Fatigues to FFCP ACU Fatigues [RS] " \n "  - Changed US DGR Driver Backpack from Assault Pack Green to Assault Pack Black " \n "  - Changed US Heli Pilot/Copilot Uniforms from Heli pilot Coveralls to FFCP Nomad Fatigues [RS] " \n "  - Fixed US Heli/Jet Pilot Vest White Smoke grenade count to 2. " \n "  - Changed US Heli Pilot/Copilot Helmet from Heli Pilot NATO to HGU-56/P (Black/Visor) " \n "  - Changed US Jet Pilot Uniform from Pilot Coveralls NATO to  FFCP Nomad Fatigues " \n "  - Changed RUS Vic/Heli/Jet Crew Weapons to PP-2000 " \n "  - Upped RUS PP-2000 Ammo counts to 6x Mag to bring in line with ammo counts for TFN and US. " \n "  - Changed RUS Heli Pilot Uniforms from Pilot Coveralls CSAT to FFCP-Fatigues EMR [RS] " \n "  - Changed RUS Heli Pilot Vest from 6B23 (6Sh116) to FFCP Tactical Vest TigerVRS " \n "  - Changed RUS Jet Pilot Uniforms from Pilot Coveralls CSAT to FFCP-Fatigues EMR [RS] " \n "  - Changed RUS Jet Pilot Vest from 6B23 (6Sh116) to FFCP Tactical Vest TigerVRS " \n " " \n " " \n "- v1.11 " \n "  - changed m40 mini grenades to m67 fragmentation " \n "  - replaced mp7 weapons with mp5k-pdw " \n "  - changed ak105 to ak74m (plum)  " \n "  - changed PKM to PKP " \n "  - changed RUS PKM ammo boxes. MMG now loads with 7TZ (AP rounds) " \n "  - added vert grip to us weapons " \n "  - replaced m14 with HK PSG1A1 " \n "  - replaced m260e4 with mg3 " \n "  - updated all ammo boxes respectively.  " \n " " \n " " \n "- v1.10 " \n "  - changed Medic loadouts from 6 x 1000ml blood bags to 2 x 1000ml and 8 x 500ml. " \n " " \n " " \n "- v1.09 " \n "  - updated Fireteam colours A1 Red A2 Yellow, B1 Green B2 Blue, C1 Red C2 Yellow. " \n " " \n " " \n "- v1.08 " \n "  - changed ""Reaper"" to ""Nightbird"", ""RPR"" to ""NB"" " \n "  - changed ""Paladin"" to ""Falcon"", ""PAL"" to ""FC"" " \n "  - changed ""DAGGER"" to ""DGR"" " \n " " \n " " \n "- v1.07 " \n "  - US and RU faction bumped to v1.07 to avoid confusion regarding version numbers (US and RU was 1.05, TFN was 1.06) " \n "  - overhauled the RU faction: updated helmets, uniforms, weapons to a more modern look " \n "  - overhauled the US faction: updated helmets and vests to armour rating of IV " \n "  - corrected some mistakes in all factions (grenade ammount of MMG gunner, ENG not having tourniquetes, DGR not having GPS-s) " \n "  - overhauled the medics of all factions to reflect recent cahnges to ACE medical (less QuikClots, more Elastic Bandages, etc.) " \n " " \n " " \n "- v1.05 " \n "  - Added a MAT ammo box on spawn. " \n " " \n " " \n "- v1.04 " \n "  - All MAT Teams carrying RPG's got the ver3 scopes with ranges for all types " \n "    of ammo. " \n "  - All Callsigns were changed to be uniformed throught no matter the faction. " \n " " \n " " \n "- v1.03 " \n "  - set crew driver/gunner and pilot/copilot/jetpilot as Engineers through the " \n "    Object: ACE Options menu in unit attributes " \n "  - overhauled the TFN faction (weapons, helmets, etc.), changes not applicable " \n "    to derived factions " \n " " \n " " \n "- v1.02 " \n "  - loadout overhaul for DMT, made them lighter + gave them tools for recon " \n "  - specified preset ACRE2 radio channels for most units " \n " " \n " " \n "- v1.01 " \n "  - updated team colors func to `a3ee_team_colors_fnc_setColor`, just load+save " \n "    the composition in editor, this fixes it " \n "  - changed RPG-7 using MAT teams to carry Kitbags " \n "  - removed one PKM ammo box from AAR, MMG gunner, MMG bearer (fixes overload) " \n "  - moved 1-2 AR boxes from AAR to AR, gave AR an Assaultpack " \n "  - added 1-2 more AR boxes to AR's Assaultpack (if enough space) " \n "  - changed HEDP to HE rockets for Carl Gustav (M3MAAWS) " \n "  - changed US crew uniform and helmet to match grey color scheme of US pilots " \n "  - changed backpacks of driver/copilot to use less contrasting colors compared " \n "    to their respective uniform/vest colors " \n "  - changed Carryall backpacks of TFN Engineers to use custom Flecktarn Carryall " \n "  - changed all (GP-25 and normal) AK74m rifles to be the non-NPZ variants " \n "  - removed secondary long-range (PRC148) from Engineers " \n " " \n " " \n "- v1.00 (and before) " \n "  - added a Comment object with version number (`v1.00`) " \n "  - added `respawn_west`, `respawn_east`, `respawn_guerrila` markers " \n "  - added `[this, 200] call a3ee_fnc_boxGuard` to init lines of resupply boxes " \n "  - added `Resupply` green triangle markers on the position of resupply boxes";
+		id=259;
 	};
 };

--- a/reference/Task%20Force%20Noctem/composition.sqe
+++ b/reference/Task%20Force%20Noctem/composition.sqe
@@ -1,8 +1,8 @@
 version=53;
-center[]={5963.0205,5,5291.7188};
+center[]={3279.947,5,3728.8118};
 class items
 {
-	items=21;
+	items=22;
 	class Item0
 	{
 		dataType="Group";
@@ -15,7 +15,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-6.1591797,0.0014390945,7.6572266};
+					position[]={-6.1660156,0.0014390945,7.9711914};
 				};
 				side="Independent";
 				flags=7;
@@ -62,7 +62,7 @@ class items
 							isBackpack=0;
 							class ItemCargo
 							{
-								items=10;
+								items=8;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -101,16 +101,6 @@ class items
 								class Item7
 								{
 									name="ACE_MapTools";
-									count=1;
-								};
-								class Item8
-								{
-									name="ACRE_PRC152";
-									count=1;
-								};
-								class Item9
-								{
-									name="ACRE_PRC148";
 									count=1;
 								};
 							};
@@ -155,10 +145,15 @@ class items
 							};
 							class ItemCargo
 							{
-								items=1;
+								items=2;
 								class Item0
 								{
 									name="ACE_tourniquet";
+									count=1;
+								};
+								class Item1
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -209,10 +204,20 @@ class items
 							};
 							class ItemCargo
 							{
-								items=1;
+								items=3;
 								class Item0
 								{
 									name="ACE_IR_Strobe_Item";
+									count=1;
+								};
+								class Item1
+								{
+									name="ACRE_PRC152";
+									count=1;
+								};
+								class Item2
+								{
+									name="ACRE_PRC148";
 									count=1;
 								};
 							};
@@ -221,10 +226,10 @@ class items
 						compass="ItemCompass";
 						watch="ItemWatch";
 						gps="ItemGPS";
-						headgear="cnto_flecktarn_h_boo_grassland";
+						headgear="cnto_flecktarn_h_s_grassland";
 					};
 				};
-				id=78;
+				id=1;
 				type="I_officer_F";
 				class CustomAttributes
 				{
@@ -266,7 +271,109 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=3;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="4";
+										};
+									};
+									class Item1
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+									class Item2
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="5";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute3
+					{
+						property="speaker";
+						expression="_this setspeaker _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="Male01GRE";
+							};
+						};
+					};
+					class Attribute4
+					{
+						property="pitch";
+						expression="_this setpitch _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"SCALAR"
+									};
+								};
+								value=1.03;
+							};
+						};
+					};
+					nAttributes=5;
 				};
 			};
 			class Item1
@@ -274,7 +381,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-5.1601563,0.0014390945,7.6582031};
+					position[]={-5.1669922,0.0014390945,7.972168};
 				};
 				side="Independent";
 				flags=5;
@@ -409,10 +516,15 @@ class items
 							};
 							class ItemCargo
 							{
-								items=1;
+								items=2;
 								class Item0
 								{
 									name="ACE_tourniquet";
+									count=1;
+								};
+								class Item1
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -438,7 +550,7 @@ class items
 						headgear="cnto_flecktarn_h_s_grassland";
 					};
 				};
-				id=79;
+				id=2;
 				type="I_Soldier_TL_F";
 				class CustomAttributes
 				{
@@ -480,7 +592,109 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=3;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="4";
+										};
+									};
+									class Item1
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+									class Item2
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="3";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute3
+					{
+						property="speaker";
+						expression="_this setspeaker _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="Male06GRE";
+							};
+						};
+					};
+					class Attribute4
+					{
+						property="pitch";
+						expression="_this setpitch _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"SCALAR"
+									};
+								};
+								value=0.98000002;
+							};
+						};
+					};
+					nAttributes=5;
 				};
 			};
 			class Item2
@@ -488,7 +702,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-4.1601563,0.0014390945,7.6582031};
+					position[]={-4.166748,0.0014390945,7.9724121};
 				};
 				side="Independent";
 				flags=5;
@@ -697,7 +911,7 @@ class items
 						headgear="cnto_flecktarn_h_c_grassland";
 					};
 				};
-				id=80;
+				id=3;
 				type="I_medic_F";
 				class CustomAttributes
 				{
@@ -739,7 +953,43 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="4";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=3;
 				};
 			};
 			class Item3
@@ -747,7 +997,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-3.1601563,0.0014390945,7.6582031};
+					position[]={-3.166748,0.0014390945,7.9724121};
 				};
 				side="Independent";
 				flags=5;
@@ -794,7 +1044,7 @@ class items
 							};
 							class ItemCargo
 							{
-								items=6;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -823,6 +1073,11 @@ class items
 								class Item5
 								{
 									name="ACRE_PRC343";
+									count=1;
+								};
+								class Item6
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -875,7 +1130,7 @@ class items
 						headgear="cnto_flecktarn_h_c_grassland";
 					};
 				};
-				id=81;
+				id=4;
 				type="I_soldier_F";
 				class CustomAttributes
 				{
@@ -917,14 +1172,50 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="4";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=3;
 				};
 			};
 		};
 		class Attributes
 		{
 		};
-		id=77;
+		id=0;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -961,7 +1252,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-6.2177734,0.0014390945,5.3632813};
+					position[]={-6.2241211,0.0014390945,5.6772461};
 				};
 				side="Independent";
 				flags=7;
@@ -1019,7 +1310,7 @@ class items
 							};
 							class ItemCargo
 							{
-								items=9;
+								items=8;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -1058,11 +1349,6 @@ class items
 								class Item7
 								{
 									name="ACE_MapTools";
-									count=1;
-								};
-								class Item8
-								{
-									name="ACRE_PRC152";
 									count=1;
 								};
 							};
@@ -1107,10 +1393,15 @@ class items
 							};
 							class ItemCargo
 							{
-								items=1;
+								items=2;
 								class Item0
 								{
 									name="ACE_tourniquet";
+									count=1;
+								};
+								class Item1
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -1167,10 +1458,15 @@ class items
 							};
 							class ItemCargo
 							{
-								items=1;
+								items=2;
 								class Item0
 								{
 									name="ACE_IR_Strobe_Item";
+									count=1;
+								};
+								class Item1
+								{
+									name="ACRE_PRC152";
 									count=1;
 								};
 							};
@@ -1182,7 +1478,7 @@ class items
 						headgear="cnto_flecktarn_h_s_grassland";
 					};
 				};
-				id=83;
+				id=6;
 				type="I_Soldier_SL_F";
 				class CustomAttributes
 				{
@@ -1224,7 +1520,95 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=2;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+									class Item1
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute3
+					{
+						property="speaker";
+						expression="_this setspeaker _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="Male03GRE";
+							};
+						};
+					};
+					class Attribute4
+					{
+						property="pitch";
+						expression="_this setpitch _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"SCALAR"
+									};
+								};
+								value=1.01;
+							};
+						};
+					};
+					nAttributes=5;
 				};
 			};
 			class Item1
@@ -1232,7 +1616,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-5.2177734,0.0014390945,5.3642578};
+					position[]={-5.2243652,0.0014390945,5.6784668};
 				};
 				side="Independent";
 				flags=5;
@@ -1441,7 +1825,7 @@ class items
 						headgear="cnto_flecktarn_h_c_grassland";
 					};
 				};
-				id=84;
+				id=7;
 				type="I_medic_F";
 				class CustomAttributes
 				{
@@ -1483,7 +1867,43 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=3;
 				};
 			};
 			class Item2
@@ -1491,7 +1911,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-6.2177734,0.0014390945,3.3642578};
+					position[]={-6.2243652,0.0014390945,3.6784668};
 				};
 				side="Independent";
 				flags=5;
@@ -1625,10 +2045,15 @@ class items
 							};
 							class ItemCargo
 							{
-								items=1;
+								items=2;
 								class Item0
 								{
 									name="ACE_tourniquet";
+									count=1;
+								};
+								class Item1
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -1694,7 +2119,7 @@ class items
 						headgear="cnto_flecktarn_h_s_grassland";
 					};
 				};
-				id=85;
+				id=8;
 				type="I_Soldier_TL_F";
 				class CustomAttributes
 				{
@@ -1736,7 +2161,43 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=3;
 				};
 			};
 			class Item3
@@ -1744,7 +2205,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-5.2177734,0.0014390945,3.3642578};
+					position[]={-5.2243652,0.0014390945,3.6784668};
 				};
 				side="Independent";
 				flags=5;
@@ -1792,7 +2253,7 @@ class items
 							};
 							class ItemCargo
 							{
-								items=6;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -1821,6 +2282,11 @@ class items
 								class Item5
 								{
 									name="ACRE_PRC343";
+									count=1;
+								};
+								class Item6
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -1882,7 +2348,7 @@ class items
 						headgear="cnto_flecktarn_h_c_grassland";
 					};
 				};
-				id=86;
+				id=9;
 				type="I_Soldier_AR_F";
 				class CustomAttributes
 				{
@@ -1924,7 +2390,43 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=3;
 				};
 			};
 			class Item4
@@ -1932,7 +2434,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-4.2177734,0.0014390945,3.3642578};
+					position[]={-4.2243652,0.0014390945,3.6784668};
 				};
 				side="Independent";
 				flags=5;
@@ -2061,10 +2563,15 @@ class items
 							};
 							class ItemCargo
 							{
-								items=1;
+								items=2;
 								class Item0
 								{
 									name="ACE_tourniquet";
+									count=1;
+								};
+								class Item1
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -2130,7 +2637,7 @@ class items
 						headgear="cnto_flecktarn_h_c_grassland";
 					};
 				};
-				id=87;
+				id=10;
 				type="I_Soldier_AAR_F";
 				class CustomAttributes
 				{
@@ -2172,7 +2679,43 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=3;
 				};
 			};
 			class Item5
@@ -2180,7 +2723,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-3.2177734,0.0014390945,3.3642578};
+					position[]={-3.2243652,0.0014390945,3.6784668};
 				};
 				side="Independent";
 				flags=5;
@@ -2231,7 +2774,7 @@ class items
 							};
 							class ItemCargo
 							{
-								items=6;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -2260,6 +2803,11 @@ class items
 								class Item5
 								{
 									name="ACRE_PRC343";
+									count=1;
+								};
+								class Item6
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -2312,7 +2860,7 @@ class items
 						headgear="cnto_flecktarn_h_c_grassland";
 					};
 				};
-				id=88;
+				id=11;
 				type="I_Soldier_LAT_F";
 				class CustomAttributes
 				{
@@ -2354,7 +2902,43 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=3;
 				};
 			};
 			class Item6
@@ -2362,7 +2946,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-6.2177734,0.0014390945,1.3642578};
+					position[]={-6.2243652,0.0014390945,1.6784668};
 				};
 				side="Independent";
 				flags=5;
@@ -2496,10 +3080,15 @@ class items
 							};
 							class ItemCargo
 							{
-								items=1;
+								items=2;
 								class Item0
 								{
 									name="ACE_tourniquet";
+									count=1;
+								};
+								class Item1
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -2565,7 +3154,7 @@ class items
 						headgear="cnto_flecktarn_h_s_grassland";
 					};
 				};
-				id=89;
+				id=12;
 				type="I_Soldier_TL_F";
 				class CustomAttributes
 				{
@@ -2607,7 +3196,43 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=3;
 				};
 			};
 			class Item7
@@ -2615,7 +3240,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-5.2177734,0.0014390945,1.3642578};
+					position[]={-5.2243652,0.0014390945,1.6784668};
 				};
 				side="Independent";
 				flags=5;
@@ -2663,7 +3288,7 @@ class items
 							};
 							class ItemCargo
 							{
-								items=6;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -2692,6 +3317,11 @@ class items
 								class Item5
 								{
 									name="ACRE_PRC343";
+									count=1;
+								};
+								class Item6
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -2753,7 +3383,7 @@ class items
 						headgear="cnto_flecktarn_h_c_grassland";
 					};
 				};
-				id=90;
+				id=13;
 				type="I_Soldier_AR_F";
 				class CustomAttributes
 				{
@@ -2795,7 +3425,43 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=3;
 				};
 			};
 			class Item8
@@ -2803,7 +3469,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-4.2177734,0.0014390945,1.3642578};
+					position[]={-4.2243652,0.0014390945,1.6784668};
 				};
 				side="Independent";
 				flags=5;
@@ -2932,10 +3598,15 @@ class items
 							};
 							class ItemCargo
 							{
-								items=1;
+								items=2;
 								class Item0
 								{
 									name="ACE_tourniquet";
+									count=1;
+								};
+								class Item1
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -3001,7 +3672,7 @@ class items
 						headgear="cnto_flecktarn_h_c_grassland";
 					};
 				};
-				id=91;
+				id=14;
 				type="I_Soldier_AAR_F";
 				class CustomAttributes
 				{
@@ -3043,7 +3714,43 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=3;
 				};
 			};
 			class Item9
@@ -3051,7 +3758,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-3.2177734,0.0014390945,1.3642578};
+					position[]={-3.2243652,0.0014390945,1.6784668};
 				};
 				side="Independent";
 				flags=5;
@@ -3102,7 +3809,7 @@ class items
 							};
 							class ItemCargo
 							{
-								items=6;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -3131,6 +3838,11 @@ class items
 								class Item5
 								{
 									name="ACRE_PRC343";
+									count=1;
+								};
+								class Item6
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -3183,7 +3895,7 @@ class items
 						headgear="cnto_flecktarn_h_c_grassland";
 					};
 				};
-				id=92;
+				id=15;
 				type="I_Soldier_LAT_F";
 				class CustomAttributes
 				{
@@ -3225,14 +3937,50 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=3;
 				};
 			};
 		};
 		class Attributes
 		{
 		};
-		id=82;
+		id=5;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -3269,7 +4017,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-0.65527344,0.0014390945,5.2519531};
+					position[]={-0.66210938,0.0014390945,5.5661621};
 				};
 				side="Independent";
 				flags=7;
@@ -3326,7 +4074,7 @@ class items
 							};
 							class ItemCargo
 							{
-								items=9;
+								items=8;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -3365,11 +4113,6 @@ class items
 								class Item7
 								{
 									name="ACE_MapTools";
-									count=1;
-								};
-								class Item8
-								{
-									name="ACRE_PRC152";
 									count=1;
 								};
 							};
@@ -3414,10 +4157,15 @@ class items
 							};
 							class ItemCargo
 							{
-								items=1;
+								items=2;
 								class Item0
 								{
 									name="ACE_tourniquet";
+									count=1;
+								};
+								class Item1
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -3474,10 +4222,15 @@ class items
 							};
 							class ItemCargo
 							{
-								items=1;
+								items=2;
 								class Item0
 								{
 									name="ACE_IR_Strobe_Item";
+									count=1;
+								};
+								class Item1
+								{
+									name="ACRE_PRC152";
 									count=1;
 								};
 							};
@@ -3489,7 +4242,7 @@ class items
 						headgear="cnto_flecktarn_h_s_grassland";
 					};
 				};
-				id=94;
+				id=17;
 				type="I_Soldier_SL_F";
 				class CustomAttributes
 				{
@@ -3531,7 +4284,95 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=2;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="2";
+										};
+									};
+									class Item1
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute3
+					{
+						property="speaker";
+						expression="_this setspeaker _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="Male03GRE";
+							};
+						};
+					};
+					class Attribute4
+					{
+						property="pitch";
+						expression="_this setpitch _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"SCALAR"
+									};
+								};
+								value=1.03;
+							};
+						};
+					};
+					nAttributes=5;
 				};
 			};
 			class Item1
@@ -3539,7 +4380,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={0.34375,0.0014390945,5.2519531};
+					position[]={0.3371582,0.0014390945,5.5661621};
 				};
 				side="Independent";
 				flags=5;
@@ -3748,7 +4589,7 @@ class items
 						headgear="cnto_flecktarn_h_c_grassland";
 					};
 				};
-				id=95;
+				id=18;
 				type="I_medic_F";
 				class CustomAttributes
 				{
@@ -3790,7 +4631,43 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="2";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=3;
 				};
 			};
 			class Item2
@@ -3798,7 +4675,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-0.65625,0.0014390945,3.2519531};
+					position[]={-0.73339844,0.0014390945,3.5930176};
 				};
 				side="Independent";
 				flags=5;
@@ -3932,10 +4809,15 @@ class items
 							};
 							class ItemCargo
 							{
-								items=1;
+								items=2;
 								class Item0
 								{
 									name="ACE_tourniquet";
+									count=1;
+								};
+								class Item1
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -4001,7 +4883,7 @@ class items
 						headgear="cnto_flecktarn_h_s_grassland";
 					};
 				};
-				id=96;
+				id=19;
 				type="I_Soldier_TL_F";
 				class CustomAttributes
 				{
@@ -4043,7 +4925,43 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="2";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=3;
 				};
 			};
 			class Item3
@@ -4051,7 +4969,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={0.34375,0.0014390945,3.2519531};
+					position[]={0.3371582,0.0014390945,3.5661621};
 				};
 				side="Independent";
 				flags=5;
@@ -4099,7 +5017,7 @@ class items
 							};
 							class ItemCargo
 							{
-								items=6;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -4128,6 +5046,11 @@ class items
 								class Item5
 								{
 									name="ACRE_PRC343";
+									count=1;
+								};
+								class Item6
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -4189,7 +5112,7 @@ class items
 						headgear="cnto_flecktarn_h_c_grassland";
 					};
 				};
-				id=97;
+				id=20;
 				type="I_Soldier_AR_F";
 				class CustomAttributes
 				{
@@ -4231,7 +5154,43 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="2";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=3;
 				};
 			};
 			class Item4
@@ -4239,7 +5198,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={1.34375,0.0014390945,3.2519531};
+					position[]={1.3371582,0.0014390945,3.5661621};
 				};
 				side="Independent";
 				flags=5;
@@ -4368,10 +5327,15 @@ class items
 							};
 							class ItemCargo
 							{
-								items=1;
+								items=2;
 								class Item0
 								{
 									name="ACE_tourniquet";
+									count=1;
+								};
+								class Item1
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -4437,7 +5401,7 @@ class items
 						headgear="cnto_flecktarn_h_c_grassland";
 					};
 				};
-				id=98;
+				id=21;
 				type="I_Soldier_AAR_F";
 				class CustomAttributes
 				{
@@ -4479,7 +5443,43 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="2";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=3;
 				};
 			};
 			class Item5
@@ -4487,7 +5487,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={2.34375,0.0014390945,3.2519531};
+					position[]={2.3371582,0.0014390945,3.5661621};
 				};
 				side="Independent";
 				flags=5;
@@ -4538,7 +5538,7 @@ class items
 							};
 							class ItemCargo
 							{
-								items=6;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -4567,6 +5567,11 @@ class items
 								class Item5
 								{
 									name="ACRE_PRC343";
+									count=1;
+								};
+								class Item6
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -4619,7 +5624,7 @@ class items
 						headgear="cnto_flecktarn_h_c_grassland";
 					};
 				};
-				id=99;
+				id=22;
 				type="I_Soldier_LAT_F";
 				class CustomAttributes
 				{
@@ -4661,7 +5666,43 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="2";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=3;
 				};
 			};
 			class Item6
@@ -4669,7 +5710,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-0.65625,0.0014390945,1.2519531};
+					position[]={-0.6628418,0.0014390945,1.5661621};
 				};
 				side="Independent";
 				flags=5;
@@ -4803,10 +5844,15 @@ class items
 							};
 							class ItemCargo
 							{
-								items=1;
+								items=2;
 								class Item0
 								{
 									name="ACE_tourniquet";
+									count=1;
+								};
+								class Item1
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -4872,7 +5918,7 @@ class items
 						headgear="cnto_flecktarn_h_s_grassland";
 					};
 				};
-				id=100;
+				id=23;
 				type="I_Soldier_TL_F";
 				class CustomAttributes
 				{
@@ -4914,7 +5960,43 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="2";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=3;
 				};
 			};
 			class Item7
@@ -4922,7 +6004,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={0.34375,0.0014390945,1.2519531};
+					position[]={0.3371582,0.0014390945,1.5661621};
 				};
 				side="Independent";
 				flags=5;
@@ -4970,7 +6052,7 @@ class items
 							};
 							class ItemCargo
 							{
-								items=6;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -4999,6 +6081,11 @@ class items
 								class Item5
 								{
 									name="ACRE_PRC343";
+									count=1;
+								};
+								class Item6
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -5060,7 +6147,7 @@ class items
 						headgear="cnto_flecktarn_h_c_grassland";
 					};
 				};
-				id=101;
+				id=24;
 				type="I_Soldier_AR_F";
 				class CustomAttributes
 				{
@@ -5102,7 +6189,43 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="2";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=3;
 				};
 			};
 			class Item8
@@ -5110,7 +6233,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={1.34375,0.0014390945,1.2519531};
+					position[]={1.3371582,0.0014390945,1.5661621};
 				};
 				side="Independent";
 				flags=5;
@@ -5239,10 +6362,15 @@ class items
 							};
 							class ItemCargo
 							{
-								items=1;
+								items=2;
 								class Item0
 								{
 									name="ACE_tourniquet";
+									count=1;
+								};
+								class Item1
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -5308,7 +6436,7 @@ class items
 						headgear="cnto_flecktarn_h_c_grassland";
 					};
 				};
-				id=102;
+				id=25;
 				type="I_Soldier_AAR_F";
 				class CustomAttributes
 				{
@@ -5350,7 +6478,43 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="2";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=3;
 				};
 			};
 			class Item9
@@ -5358,7 +6522,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={2.34375,0.0014390945,1.2519531};
+					position[]={2.3371582,0.0014390945,1.5661621};
 				};
 				side="Independent";
 				flags=5;
@@ -5409,7 +6573,7 @@ class items
 							};
 							class ItemCargo
 							{
-								items=6;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -5438,6 +6602,11 @@ class items
 								class Item5
 								{
 									name="ACRE_PRC343";
+									count=1;
+								};
+								class Item6
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -5490,7 +6659,7 @@ class items
 						headgear="cnto_flecktarn_h_c_grassland";
 					};
 				};
-				id=103;
+				id=26;
 				type="I_Soldier_LAT_F";
 				class CustomAttributes
 				{
@@ -5532,14 +6701,50 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="2";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=3;
 				};
 			};
 		};
 		class Attributes
 		{
 		};
-		id=93;
+		id=16;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -5576,7 +6781,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={4.3920898,0.0014390945,5.1445313};
+					position[]={4.3859863,0.0014390945,5.458252};
 				};
 				side="Independent";
 				flags=7;
@@ -5633,7 +6838,7 @@ class items
 							};
 							class ItemCargo
 							{
-								items=9;
+								items=8;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -5672,11 +6877,6 @@ class items
 								class Item7
 								{
 									name="ACE_MapTools";
-									count=1;
-								};
-								class Item8
-								{
-									name="ACRE_PRC152";
 									count=1;
 								};
 							};
@@ -5721,10 +6921,15 @@ class items
 							};
 							class ItemCargo
 							{
-								items=1;
+								items=2;
 								class Item0
 								{
 									name="ACE_tourniquet";
+									count=1;
+								};
+								class Item1
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -5781,10 +6986,15 @@ class items
 							};
 							class ItemCargo
 							{
-								items=1;
+								items=2;
 								class Item0
 								{
 									name="ACE_IR_Strobe_Item";
+									count=1;
+								};
+								class Item1
+								{
+									name="ACRE_PRC152";
 									count=1;
 								};
 							};
@@ -5796,7 +7006,7 @@ class items
 						headgear="cnto_flecktarn_h_s_grassland";
 					};
 				};
-				id=105;
+				id=28;
 				type="I_Soldier_SL_F";
 				class CustomAttributes
 				{
@@ -5838,7 +7048,95 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=2;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="3";
+										};
+									};
+									class Item1
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute3
+					{
+						property="speaker";
+						expression="_this setspeaker _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="Male01GRE";
+							};
+						};
+					};
+					class Attribute4
+					{
+						property="pitch";
+						expression="_this setpitch _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"SCALAR"
+									};
+								};
+								value=0.95999998;
+							};
+						};
+					};
+					nAttributes=5;
 				};
 			};
 			class Item1
@@ -5846,7 +7144,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={5.3920898,0.0014390945,5.1435547};
+					position[]={5.385498,0.0014390945,5.4577637};
 				};
 				side="Independent";
 				flags=5;
@@ -6055,7 +7353,7 @@ class items
 						headgear="cnto_flecktarn_h_c_grassland";
 					};
 				};
-				id=106;
+				id=29;
 				type="I_medic_F";
 				class CustomAttributes
 				{
@@ -6097,7 +7395,43 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="3";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=3;
 				};
 			};
 			class Item2
@@ -6105,7 +7439,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={4.3920898,0.0014390945,3.1435547};
+					position[]={4.385498,0.0014390945,3.4577637};
 				};
 				side="Independent";
 				flags=5;
@@ -6239,10 +7573,15 @@ class items
 							};
 							class ItemCargo
 							{
-								items=1;
+								items=2;
 								class Item0
 								{
 									name="ACE_tourniquet";
+									count=1;
+								};
+								class Item1
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -6308,7 +7647,7 @@ class items
 						headgear="cnto_flecktarn_h_s_grassland";
 					};
 				};
-				id=107;
+				id=30;
 				type="I_Soldier_TL_F";
 				class CustomAttributes
 				{
@@ -6350,7 +7689,43 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="3";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=3;
 				};
 			};
 			class Item3
@@ -6358,7 +7733,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={5.3920898,0.0014390945,3.1435547};
+					position[]={5.385498,0.0014390945,3.4577637};
 				};
 				side="Independent";
 				flags=5;
@@ -6406,7 +7781,7 @@ class items
 							};
 							class ItemCargo
 							{
-								items=6;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -6435,6 +7810,11 @@ class items
 								class Item5
 								{
 									name="ACRE_PRC343";
+									count=1;
+								};
+								class Item6
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -6496,7 +7876,7 @@ class items
 						headgear="cnto_flecktarn_h_c_grassland";
 					};
 				};
-				id=108;
+				id=31;
 				type="I_Soldier_AR_F";
 				class CustomAttributes
 				{
@@ -6538,7 +7918,43 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="3";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=3;
 				};
 			};
 			class Item4
@@ -6546,7 +7962,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={6.3920898,0.0014390945,3.1435547};
+					position[]={6.385498,0.0014390945,3.4577637};
 				};
 				side="Independent";
 				flags=5;
@@ -6675,10 +8091,15 @@ class items
 							};
 							class ItemCargo
 							{
-								items=1;
+								items=2;
 								class Item0
 								{
 									name="ACE_tourniquet";
+									count=1;
+								};
+								class Item1
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -6744,7 +8165,7 @@ class items
 						headgear="cnto_flecktarn_h_c_grassland";
 					};
 				};
-				id=109;
+				id=32;
 				type="I_Soldier_AAR_F";
 				class CustomAttributes
 				{
@@ -6786,7 +8207,43 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="3";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=3;
 				};
 			};
 			class Item5
@@ -6794,7 +8251,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={7.3920898,0.0014390945,3.1435547};
+					position[]={7.385498,0.0014390945,3.4577637};
 				};
 				side="Independent";
 				flags=5;
@@ -6845,7 +8302,7 @@ class items
 							};
 							class ItemCargo
 							{
-								items=6;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -6874,6 +8331,11 @@ class items
 								class Item5
 								{
 									name="ACRE_PRC343";
+									count=1;
+								};
+								class Item6
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -6926,7 +8388,7 @@ class items
 						headgear="cnto_flecktarn_h_c_grassland";
 					};
 				};
-				id=110;
+				id=33;
 				type="I_Soldier_LAT_F";
 				class CustomAttributes
 				{
@@ -6968,7 +8430,43 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="3";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=3;
 				};
 			};
 			class Item6
@@ -6976,7 +8474,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={4.3920898,0.0014390945,1.1435547};
+					position[]={4.385498,0.0014390945,1.4577637};
 				};
 				side="Independent";
 				flags=5;
@@ -7110,10 +8608,15 @@ class items
 							};
 							class ItemCargo
 							{
-								items=1;
+								items=2;
 								class Item0
 								{
 									name="ACE_tourniquet";
+									count=1;
+								};
+								class Item1
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -7179,7 +8682,7 @@ class items
 						headgear="cnto_flecktarn_h_s_grassland";
 					};
 				};
-				id=111;
+				id=34;
 				type="I_Soldier_TL_F";
 				class CustomAttributes
 				{
@@ -7221,7 +8724,43 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="3";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=3;
 				};
 			};
 			class Item7
@@ -7229,7 +8768,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={5.3920898,0.0014390945,1.1435547};
+					position[]={5.385498,0.0014390945,1.4577637};
 				};
 				side="Independent";
 				flags=5;
@@ -7277,7 +8816,7 @@ class items
 							};
 							class ItemCargo
 							{
-								items=6;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -7306,6 +8845,11 @@ class items
 								class Item5
 								{
 									name="ACRE_PRC343";
+									count=1;
+								};
+								class Item6
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -7367,7 +8911,7 @@ class items
 						headgear="cnto_flecktarn_h_c_grassland";
 					};
 				};
-				id=112;
+				id=35;
 				type="I_Soldier_AR_F";
 				class CustomAttributes
 				{
@@ -7409,7 +8953,43 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="3";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=3;
 				};
 			};
 			class Item8
@@ -7417,7 +8997,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={6.3920898,0.0014390945,1.1435547};
+					position[]={6.385498,0.0014390945,1.4577637};
 				};
 				side="Independent";
 				flags=5;
@@ -7546,10 +9126,15 @@ class items
 							};
 							class ItemCargo
 							{
-								items=1;
+								items=2;
 								class Item0
 								{
 									name="ACE_tourniquet";
+									count=1;
+								};
+								class Item1
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -7615,7 +9200,7 @@ class items
 						headgear="cnto_flecktarn_h_c_grassland";
 					};
 				};
-				id=113;
+				id=36;
 				type="I_Soldier_AAR_F";
 				class CustomAttributes
 				{
@@ -7657,7 +9242,43 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="3";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=3;
 				};
 			};
 			class Item9
@@ -7665,7 +9286,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={7.3920898,0.0014390945,1.1435547};
+					position[]={7.385498,0.0014390945,1.4577637};
 				};
 				side="Independent";
 				flags=5;
@@ -7716,7 +9337,7 @@ class items
 							};
 							class ItemCargo
 							{
-								items=6;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -7745,6 +9366,11 @@ class items
 								class Item5
 								{
 									name="ACRE_PRC343";
+									count=1;
+								};
+								class Item6
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -7797,7 +9423,7 @@ class items
 						headgear="cnto_flecktarn_h_c_grassland";
 					};
 				};
-				id=114;
+				id=37;
 				type="I_Soldier_LAT_F";
 				class CustomAttributes
 				{
@@ -7839,14 +9465,50 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="3";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=3;
 				};
 			};
 		};
 		class Attributes
 		{
 		};
-		id=104;
+		id=27;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -7883,7 +9545,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-6.605957,0.0014390945,-1.5185547};
+					position[]={-6.6130371,0.0014390945,-1.204834};
 				};
 				side="Independent";
 				flags=7;
@@ -7940,7 +9602,7 @@ class items
 							};
 							class ItemCargo
 							{
-								items=9;
+								items=8;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -7979,11 +9641,6 @@ class items
 								class Item7
 								{
 									name="ACE_MapTools";
-									count=1;
-								};
-								class Item8
-								{
-									name="ACRE_PRC152";
 									count=1;
 								};
 							};
@@ -8028,10 +9685,15 @@ class items
 							};
 							class ItemCargo
 							{
-								items=1;
+								items=2;
 								class Item0
 								{
 									name="ACE_tourniquet";
+									count=1;
+								};
+								class Item1
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -8088,10 +9750,15 @@ class items
 							};
 							class ItemCargo
 							{
-								items=1;
+								items=2;
 								class Item0
 								{
 									name="ACE_IR_Strobe_Item";
+									count=1;
+								};
+								class Item1
+								{
+									name="ACRE_PRC152";
 									count=1;
 								};
 							};
@@ -8103,7 +9770,7 @@ class items
 						headgear="cnto_flecktarn_h_s_grassland";
 					};
 				};
-				id=116;
+				id=39;
 				type="I_Soldier_TL_F";
 				class CustomAttributes
 				{
@@ -8145,7 +9812,95 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=2;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="5";
+										};
+									};
+									class Item1
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute3
+					{
+						property="speaker";
+						expression="_this setspeaker _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="Male05GRE";
+							};
+						};
+					};
+					class Attribute4
+					{
+						property="pitch";
+						expression="_this setpitch _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"SCALAR"
+									};
+								};
+								value=0.98000002;
+							};
+						};
+					};
+					nAttributes=5;
 				};
 			};
 			class Item1
@@ -8153,7 +9908,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-5.605957,0.0014390945,-1.5195313};
+					position[]={-5.6125488,0.0014390945,-1.2053223};
 				};
 				side="Independent";
 				flags=5;
@@ -8166,11 +9921,11 @@ class items
 					{
 						class primaryWeapon
 						{
-							name="hlc_lmg_MG3KWS_b";
+							name="BWA3_MG5";
 							class primaryMuzzleMag
 							{
-								name="hlc_100Rnd_762x51_M_M60E4";
-								ammoLeft=100;
+								name="BWA3_120Rnd_762x51_soft";
+								ammoLeft=120;
 							};
 						};
 						class handgun
@@ -8199,7 +9954,7 @@ class items
 							};
 							class ItemCargo
 							{
-								items=6;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -8228,6 +9983,11 @@ class items
 								class Item5
 								{
 									name="ACRE_PRC343";
+									count=1;
+								};
+								class Item6
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -8271,9 +10031,9 @@ class items
 								items=1;
 								class Item0
 								{
-									name="hlc_100Rnd_762x51_M_M60E4";
+									name="BWA3_120Rnd_762x51_soft";
 									count=4;
-									ammoLeft=100;
+									ammoLeft=120;
 								};
 							};
 						};
@@ -8283,7 +10043,7 @@ class items
 						headgear="cnto_flecktarn_h_c_grassland";
 					};
 				};
-				id=117;
+				id=40;
 				type="I_Soldier_AR_F";
 				class CustomAttributes
 				{
@@ -8325,7 +10085,43 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="5";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=3;
 				};
 			};
 			class Item2
@@ -8333,7 +10129,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-4.605957,0.0014390945,-1.5195313};
+					position[]={-4.6125488,0.0014390945,-1.2053223};
 				};
 				side="Independent";
 				flags=5;
@@ -8380,7 +10176,7 @@ class items
 							};
 							class ItemCargo
 							{
-								items=6;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -8409,6 +10205,11 @@ class items
 								class Item5
 								{
 									name="ACRE_PRC343";
+									count=1;
+								};
+								class Item6
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -8464,9 +10265,9 @@ class items
 								items=1;
 								class Item0
 								{
-									name="hlc_100Rnd_762x51_M_M60E4";
+									name="BWA3_120Rnd_762x51_soft";
 									count=4;
-									ammoLeft=100;
+									ammoLeft=120;
 								};
 							};
 						};
@@ -8476,7 +10277,7 @@ class items
 						headgear="cnto_flecktarn_h_c_grassland";
 					};
 				};
-				id=118;
+				id=41;
 				type="I_Soldier_AAR_F";
 				class CustomAttributes
 				{
@@ -8518,14 +10319,50 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="5";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=3;
 				};
 			};
 		};
 		class Attributes
 		{
 		};
-		id=115;
+		id=38;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -8562,7 +10399,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-0.36279297,0.0014390945,-1.5537109};
+					position[]={-0.65283203,0.0014390945,-1.262207};
 				};
 				side="Independent";
 				flags=7;
@@ -8619,7 +10456,7 @@ class items
 							};
 							class ItemCargo
 							{
-								items=9;
+								items=8;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -8658,11 +10495,6 @@ class items
 								class Item7
 								{
 									name="ACE_MapTools";
-									count=1;
-								};
-								class Item8
-								{
-									name="ACRE_PRC152";
 									count=1;
 								};
 							};
@@ -8707,10 +10539,15 @@ class items
 							};
 							class ItemCargo
 							{
-								items=1;
+								items=2;
 								class Item0
 								{
 									name="ACE_tourniquet";
+									count=1;
+								};
+								class Item1
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -8767,10 +10604,15 @@ class items
 							};
 							class ItemCargo
 							{
-								items=1;
+								items=2;
 								class Item0
 								{
 									name="ACE_IR_Strobe_Item";
+									count=1;
+								};
+								class Item1
+								{
+									name="ACRE_PRC152";
 									count=1;
 								};
 							};
@@ -8782,7 +10624,7 @@ class items
 						headgear="cnto_flecktarn_h_s_grassland";
 					};
 				};
-				id=120;
+				id=43;
 				type="I_Soldier_TL_F";
 				class CustomAttributes
 				{
@@ -8843,7 +10685,76 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					class Attribute3
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=2;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="6";
+										};
+									};
+									class Item1
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute4
+					{
+						property="pitch";
+						expression="_this setpitch _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"SCALAR"
+									};
+								};
+								value=1.02;
+							};
+						};
+					};
+					nAttributes=5;
 				};
 			};
 			class Item1
@@ -8851,7 +10762,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={0.63574219,0.0014390945,-1.5517578};
+					position[]={0.62915039,0.0014390945,-1.2375488};
 				};
 				side="Independent";
 				flags=5;
@@ -8907,7 +10818,7 @@ class items
 							};
 							class ItemCargo
 							{
-								items=6;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -8936,6 +10847,11 @@ class items
 								class Item5
 								{
 									name="ACRE_PRC343";
+									count=1;
+								};
+								class Item6
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -9009,7 +10925,7 @@ class items
 						headgear="cnto_flecktarn_h_c_grassland";
 					};
 				};
-				id=121;
+				id=44;
 				type="I_Soldier_AT_F";
 				class CustomAttributes
 				{
@@ -9070,7 +10986,43 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					class Attribute3
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="6";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=4;
 				};
 			};
 			class Item2
@@ -9078,7 +11030,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={1.6357422,0.0014390945,-1.5517578};
+					position[]={1.6291504,0.0014390945,-1.2375488};
 				};
 				side="Independent";
 				flags=5;
@@ -9125,7 +11077,7 @@ class items
 							};
 							class ItemCargo
 							{
-								items=6;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -9154,6 +11106,11 @@ class items
 								class Item5
 								{
 									name="ACRE_PRC343";
+									count=1;
+								};
+								class Item6
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -9227,7 +11184,7 @@ class items
 						headgear="cnto_flecktarn_h_c_grassland";
 					};
 				};
-				id=122;
+				id=45;
 				type="I_Soldier_AAT_F";
 				class CustomAttributes
 				{
@@ -9288,14 +11245,50 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					class Attribute3
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="6";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=4;
 				};
 			};
 		};
 		class Attributes
 		{
 		};
-		id=119;
+		id=42;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -9332,10 +11325,257 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-6.8666992,0.0014390945,-4.1875};
+					position[]={-5.8737793,0.0014390945,-3.8742676};
 				};
 				side="Independent";
-				flags=7;
+				flags=5;
+				class Attributes
+				{
+					init="call{this disableAI ""MOVE"";" \n "this setSpeaker ""NoVoice"";" \n "enableRadio false;}";
+					description="DMT Marksman";
+					isPlayable=1;
+					class Inventory
+					{
+						class primaryWeapon
+						{
+							name="hlc_rifle_PSG1A1_RIS";
+							optics="rhsusf_acc_ACOG3_USMC";
+							class primaryMuzzleMag
+							{
+								name="hlc_20rnd_762x51_Mk316_G3";
+								ammoLeft=20;
+							};
+						};
+						class handgun
+						{
+							name="hlc_pistol_P226R_357Elite";
+							optics="HLC_optic_VTAC";
+							class primaryMuzzleMag
+							{
+								name="hlc_12Rnd_357SIG_B_P226";
+								ammoLeft=12;
+							};
+						};
+						class binocular
+						{
+							name="Laserdesignator_03";
+							class primaryMuzzleMag
+							{
+								name="Laserbatteries";
+								ammoLeft=1;
+							};
+						};
+						class uniform
+						{
+							typeName="cnto_flecktarn_u_t_grassland";
+							isBackpack=0;
+							class MagazineCargo
+							{
+								items=1;
+								class Item0
+								{
+									name="SmokeShell";
+									count=2;
+									ammoLeft=1;
+								};
+							};
+							class ItemCargo
+							{
+								items=12;
+								class Item0
+								{
+									name="ACE_fieldDressing";
+									count=4;
+								};
+								class Item1
+								{
+									name="ACE_quikclot";
+									count=6;
+								};
+								class Item2
+								{
+									name="ACE_morphine";
+									count=1;
+								};
+								class Item3
+								{
+									name="ACE_tourniquet";
+									count=1;
+								};
+								class Item4
+								{
+									name="rhsusf_acc_M952V";
+									count=1;
+								};
+								class Item5
+								{
+									name="ACE_CableTie";
+									count=2;
+								};
+								class Item6
+								{
+									name="ACE_MapTools";
+									count=1;
+								};
+								class Item7
+								{
+									name="ACE_Kestrel4500";
+									count=1;
+								};
+								class Item8
+								{
+									name="ACE_RangeCard";
+									count=1;
+								};
+								class Item9
+								{
+									name="ACE_microDAGR";
+									count=1;
+								};
+								class Item10
+								{
+									name="ACRE_PRC343";
+									count=1;
+								};
+								class Item11
+								{
+									name="ACE_epinephrine";
+									count=1;
+								};
+							};
+						};
+						class vest
+						{
+							typeName="cnto_flecktarn_v_l_grassland";
+							isBackpack=0;
+							class MagazineCargo
+							{
+								items=2;
+								class Item0
+								{
+									name="hlc_20rnd_762x51_Mk316_G3";
+									count=4;
+									ammoLeft=20;
+								};
+								class Item1
+								{
+									name="hlc_12Rnd_357SIG_B_P226";
+									count=1;
+									ammoLeft=12;
+								};
+							};
+							class ItemCargo
+							{
+								items=2;
+								class Item0
+								{
+									name="ACE_IR_Strobe_Item";
+									count=1;
+								};
+								class Item1
+								{
+									name="ACE_tourniquet";
+									count=1;
+								};
+							};
+						};
+						map="ItemMap";
+						compass="ItemCompass";
+						watch="ItemWatch";
+						gps="ItemGPS";
+						headgear="cnto_flecktarn_h_boo_grassland";
+					};
+				};
+				id=48;
+				type="I_Spotter_F";
+				class CustomAttributes
+				{
+					class Attribute0
+					{
+						property="lambs_danger_disableAI";
+						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"BOOL"
+									};
+								};
+								value=1;
+							};
+						};
+					};
+					class Attribute1
+					{
+						property="a3aa_ee_extended_gear_insignia";
+						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="CNTOpatchAlt";
+							};
+						};
+					};
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="8";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=3;
+				};
+			};
+			class Item1
+			{
+				dataType="Object";
+				class PositionInfo
+				{
+					position[]={-6.8730469,0.0014390945,-3.8737793};
+				};
+				side="Independent";
+				flags=6;
 				class Attributes
 				{
 					rank="SERGEANT";
@@ -9490,7 +11730,7 @@ class items
 							};
 							class ItemCargo
 							{
-								items=4;
+								items=5;
 								class Item0
 								{
 									name="ACE_IR_Strobe_Item";
@@ -9511,215 +11751,9 @@ class items
 									name="ACE_tourniquet";
 									count=1;
 								};
-							};
-						};
-						map="ItemMap";
-						compass="ItemCompass";
-						watch="ItemWatch";
-						gps="ItemGPS";
-						headgear="cnto_flecktarn_h_boo_grassland";
-					};
-				};
-				id=124;
-				type="I_Spotter_F";
-				class CustomAttributes
-				{
-					class Attribute0
-					{
-						property="lambs_danger_disableAI";
-						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
-						class Value
-						{
-							class data
-							{
-								class type
-								{
-									type[]=
-									{
-										"BOOL"
-									};
-								};
-								value=1;
-							};
-						};
-					};
-					class Attribute1
-					{
-						property="a3aa_ee_extended_gear_insignia";
-						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
-						class Value
-						{
-							class data
-							{
-								class type
-								{
-									type[]=
-									{
-										"STRING"
-									};
-								};
-								value="CNTOpatchAlt";
-							};
-						};
-					};
-					nAttributes=2;
-				};
-			};
-			class Item1
-			{
-				dataType="Object";
-				class PositionInfo
-				{
-					position[]={-5.8671875,0.0014390945,-4.1884766};
-				};
-				side="Independent";
-				flags=5;
-				class Attributes
-				{
-					init="call{this disableAI ""MOVE"";" \n "this setSpeaker ""NoVoice"";" \n "enableRadio false;}";
-					description="DMT Marksman";
-					isPlayable=1;
-					class Inventory
-					{
-						class primaryWeapon
-						{
-							name="hlc_rifle_PSG1A1_RIS";
-							optics="optic_SOS";
-							class primaryMuzzleMag
-							{
-								name="hlc_20rnd_762x51_Mk316_G3";
-								ammoLeft=20;
-							};
-						};
-						class handgun
-						{
-							name="hlc_pistol_P226R_357Elite";
-							optics="HLC_optic_VTAC";
-							class primaryMuzzleMag
-							{
-								name="hlc_12Rnd_357SIG_B_P226";
-								ammoLeft=12;
-							};
-						};
-						class binocular
-						{
-							name="Laserdesignator_03";
-							class primaryMuzzleMag
-							{
-								name="Laserbatteries";
-								ammoLeft=1;
-							};
-						};
-						class uniform
-						{
-							typeName="cnto_flecktarn_u_t_grassland";
-							isBackpack=0;
-							class MagazineCargo
-							{
-								items=1;
-								class Item0
-								{
-									name="SmokeShell";
-									count=2;
-									ammoLeft=1;
-								};
-							};
-							class ItemCargo
-							{
-								items=11;
-								class Item0
-								{
-									name="ACE_fieldDressing";
-									count=4;
-								};
-								class Item1
-								{
-									name="ACE_quikclot";
-									count=6;
-								};
-								class Item2
-								{
-									name="ACE_morphine";
-									count=1;
-								};
-								class Item3
-								{
-									name="ACE_tourniquet";
-									count=1;
-								};
 								class Item4
 								{
-									name="rhsusf_acc_M952V";
-									count=1;
-								};
-								class Item5
-								{
-									name="ACE_CableTie";
-									count=2;
-								};
-								class Item6
-								{
-									name="ACE_MapTools";
-									count=1;
-								};
-								class Item7
-								{
-									name="ACE_Kestrel4500";
-									count=1;
-								};
-								class Item8
-								{
-									name="ACE_RangeCard";
-									count=1;
-								};
-								class Item9
-								{
-									name="ACE_microDAGR";
-									count=1;
-								};
-								class Item10
-								{
-									name="ACRE_PRC343";
-									count=1;
-								};
-							};
-						};
-						class vest
-						{
-							typeName="cnto_flecktarn_v_l_grassland";
-							isBackpack=0;
-							class MagazineCargo
-							{
-								items=2;
-								class Item0
-								{
-									name="hlc_20rnd_762x51_Mk316_G3";
-									count=4;
-									ammoLeft=20;
-								};
-								class Item1
-								{
-									name="hlc_12Rnd_357SIG_B_P226";
-									count=1;
-									ammoLeft=12;
-								};
-							};
-							class ItemCargo
-							{
-								items=3;
-								class Item0
-								{
-									name="ACE_IR_Strobe_Item";
-									count=1;
-								};
-								class Item1
-								{
-									name="ACE_tourniquet";
-									count=1;
-								};
-								class Item2
-								{
-									name="rhsusf_acc_anpvs27";
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -9731,8 +11765,8 @@ class items
 						headgear="cnto_flecktarn_h_boo_grassland";
 					};
 				};
-				id=125;
-				type="I_Spotter_F";
+				id=77;
+				type="I_Sniper_F";
 				class CustomAttributes
 				{
 					class Attribute0
@@ -9773,14 +11807,102 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=2;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="8";
+										};
+									};
+									class Item1
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute3
+					{
+						property="speaker";
+						expression="_this setspeaker _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="Male02GRE";
+							};
+						};
+					};
+					class Attribute4
+					{
+						property="pitch";
+						expression="_this setpitch _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"SCALAR"
+									};
+								};
+								value=0.97000003;
+							};
+						};
+					};
+					nAttributes=5;
 				};
 			};
 		};
 		class Attributes
 		{
 		};
-		id=123;
+		id=46;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -9817,7 +11939,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-0.73583984,0.0014390945,-4.2490234};
+					position[]={-0.74243164,0.0014390945,-3.9348145};
 				};
 				side="Independent";
 				flags=7;
@@ -9870,7 +11992,7 @@ class items
 							};
 							class ItemCargo
 							{
-								items=9;
+								items=10;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -9914,6 +12036,11 @@ class items
 								class Item8
 								{
 									name="ACRE_PRC152";
+									count=1;
+								};
+								class Item9
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -9978,7 +12105,7 @@ class items
 						headgear="cnto_flecktarn_h_s_grassland";
 					};
 				};
-				id=127;
+				id=50;
 				type="I_support_AMort_F";
 				class CustomAttributes
 				{
@@ -10047,7 +12174,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={0.26513672,0.0014390945,-4.2490234};
+					position[]={0.25854492,0.0014390945,-3.9348145};
 				};
 				side="Independent";
 				flags=5;
@@ -10094,7 +12221,7 @@ class items
 							};
 							class ItemCargo
 							{
-								items=8;
+								items=9;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -10133,6 +12260,11 @@ class items
 								class Item7
 								{
 									name="ACE_RangeTable_82mm";
+									count=1;
+								};
+								class Item8
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -10184,7 +12316,7 @@ class items
 						headgear="cnto_flecktarn_h_c_grassland";
 					};
 				};
-				id=128;
+				id=51;
 				type="I_support_Mort_F";
 				class CustomAttributes
 				{
@@ -10252,7 +12384,7 @@ class items
 		class Attributes
 		{
 		};
-		id=126;
+		id=49;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -10289,7 +12421,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={4.5322266,0.0014390945,-1.5146484};
+					position[]={4.5258789,0.0014390945,-1.2006836};
 				};
 				side="Independent";
 				flags=7;
@@ -10370,7 +12502,7 @@ class items
 								};
 								class Item7
 								{
-									name="ACRE_PRC152";
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -10381,7 +12513,7 @@ class items
 							isBackpack=0;
 							class MagazineCargo
 							{
-								items=3;
+								items=4;
 								class Item0
 								{
 									name="SmokeShell";
@@ -10399,6 +12531,12 @@ class items
 									name="HandGrenade";
 									count=2;
 									ammoLeft=1;
+								};
+								class Item3
+								{
+									name="rhs_mag_30Rnd_556x45_M855A1_Stanag_Tracer_Red";
+									count=2;
+									ammoLeft=30;
 								};
 							};
 							class ItemCargo
@@ -10437,10 +12575,15 @@ class items
 							isBackpack=1;
 							class ItemCargo
 							{
-								items=1;
+								items=2;
 								class Item0
 								{
 									name="ToolKit";
+									count=1;
+								};
+								class Item1
+								{
+									name="ACRE_PRC152";
 									count=1;
 								};
 							};
@@ -10452,7 +12595,7 @@ class items
 						headgear="cnto_flecktarn_h_s_grassland";
 					};
 				};
-				id=130;
+				id=53;
 				type="I_engineer_F";
 				class CustomAttributes
 				{
@@ -10494,7 +12637,95 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=2;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="7";
+										};
+									};
+									class Item1
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute3
+					{
+						property="speaker";
+						expression="_this setspeaker _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="Male01GRE";
+							};
+						};
+					};
+					class Attribute4
+					{
+						property="pitch";
+						expression="_this setpitch _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"SCALAR"
+									};
+								};
+								value=0.97000003;
+							};
+						};
+					};
+					nAttributes=5;
 				};
 			};
 			class Item1
@@ -10502,7 +12733,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={5.5322266,0.0014390945,-1.5146484};
+					position[]={5.5256348,0.0014390945,-1.2004395};
 				};
 				side="Independent";
 				flags=5;
@@ -10543,7 +12774,7 @@ class items
 							isBackpack=0;
 							class ItemCargo
 							{
-								items=7;
+								items=8;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -10579,6 +12810,11 @@ class items
 									name="ACRE_PRC343";
 									count=1;
 								};
+								class Item7
+								{
+									name="ACE_epinephrine";
+									count=1;
+								};
 							};
 						};
 						class vest
@@ -10587,7 +12823,7 @@ class items
 							isBackpack=0;
 							class MagazineCargo
 							{
-								items=3;
+								items=4;
 								class Item0
 								{
 									name="SmokeShell";
@@ -10597,7 +12833,7 @@ class items
 								class Item1
 								{
 									name="rhs_mag_30Rnd_556x45_M855A1_Stanag";
-									count=4;
+									count=5;
 									ammoLeft=30;
 								};
 								class Item2
@@ -10605,6 +12841,12 @@ class items
 									name="HandGrenade";
 									count=2;
 									ammoLeft=1;
+								};
+								class Item3
+								{
+									name="rhs_mag_30Rnd_556x45_M855A1_Stanag_Tracer_Red";
+									count=1;
+									ammoLeft=30;
 								};
 							};
 							class ItemCargo
@@ -10658,7 +12900,7 @@ class items
 						headgear="cnto_flecktarn_h_c_grassland";
 					};
 				};
-				id=131;
+				id=54;
 				type="I_engineer_F";
 				class CustomAttributes
 				{
@@ -10700,7 +12942,43 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="7";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=3;
 				};
 			};
 			class Item2
@@ -10708,7 +12986,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={6.5322266,0.0014390945,-1.5146484};
+					position[]={6.5256348,0.0014390945,-1.2004395};
 				};
 				side="Independent";
 				flags=5;
@@ -10749,7 +13027,7 @@ class items
 							isBackpack=0;
 							class ItemCargo
 							{
-								items=7;
+								items=8;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -10785,6 +13063,11 @@ class items
 									name="ACRE_PRC343";
 									count=1;
 								};
+								class Item7
+								{
+									name="ACE_epinephrine";
+									count=1;
+								};
 							};
 						};
 						class vest
@@ -10793,7 +13076,7 @@ class items
 							isBackpack=0;
 							class MagazineCargo
 							{
-								items=3;
+								items=4;
 								class Item0
 								{
 									name="SmokeShell";
@@ -10803,7 +13086,7 @@ class items
 								class Item1
 								{
 									name="rhs_mag_30Rnd_556x45_M855A1_Stanag";
-									count=4;
+									count=5;
 									ammoLeft=30;
 								};
 								class Item2
@@ -10811,6 +13094,12 @@ class items
 									name="HandGrenade";
 									count=2;
 									ammoLeft=1;
+								};
+								class Item3
+								{
+									name="rhs_mag_30Rnd_556x45_M855A1_Stanag_Tracer_Red";
+									count=1;
+									ammoLeft=30;
 								};
 							};
 							class ItemCargo
@@ -10864,7 +13153,7 @@ class items
 						headgear="cnto_flecktarn_h_c_grassland";
 					};
 				};
-				id=132;
+				id=55;
 				type="I_engineer_F";
 				class CustomAttributes
 				{
@@ -10906,7 +13195,43 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="7";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=3;
 				};
 			};
 			class Item3
@@ -10914,7 +13239,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={7.5322266,0.0014390945,-1.5146484};
+					position[]={7.5256348,0.0014390945,-1.2004395};
 				};
 				side="Independent";
 				flags=5;
@@ -10955,7 +13280,7 @@ class items
 							isBackpack=0;
 							class ItemCargo
 							{
-								items=7;
+								items=8;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -10991,6 +13316,11 @@ class items
 									name="ACRE_PRC343";
 									count=1;
 								};
+								class Item7
+								{
+									name="ACE_epinephrine";
+									count=1;
+								};
 							};
 						};
 						class vest
@@ -10999,7 +13329,7 @@ class items
 							isBackpack=0;
 							class MagazineCargo
 							{
-								items=3;
+								items=4;
 								class Item0
 								{
 									name="SmokeShell";
@@ -11009,7 +13339,7 @@ class items
 								class Item1
 								{
 									name="rhs_mag_30Rnd_556x45_M855A1_Stanag";
-									count=4;
+									count=5;
 									ammoLeft=30;
 								};
 								class Item2
@@ -11017,6 +13347,12 @@ class items
 									name="HandGrenade";
 									count=2;
 									ammoLeft=1;
+								};
+								class Item3
+								{
+									name="rhs_mag_30Rnd_556x45_M855A1_Stanag_Tracer_Red";
+									count=1;
+									ammoLeft=30;
 								};
 							};
 							class ItemCargo
@@ -11070,7 +13406,7 @@ class items
 						headgear="cnto_flecktarn_h_c_grassland";
 					};
 				};
-				id=133;
+				id=56;
 				type="I_engineer_F";
 				class CustomAttributes
 				{
@@ -11112,14 +13448,50 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="7";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=3;
 				};
 			};
 		};
 		class Attributes
 		{
 		};
-		id=129;
+		id=52;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -11156,7 +13528,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-7.1357422,0.0014390945,-6.8662109};
+					position[]={-7.1420898,0.0014390945,-6.5517578};
 				};
 				side="Independent";
 				flags=7;
@@ -11197,7 +13569,7 @@ class items
 							isBackpack=0;
 							class ItemCargo
 							{
-								items=8;
+								items=9;
 								class Item0
 								{
 									name="ACE_quikclot";
@@ -11236,6 +13608,11 @@ class items
 								class Item7
 								{
 									name="ACRE_PRC148";
+									count=1;
+								};
+								class Item8
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -11296,7 +13673,7 @@ class items
 						headgear="H_HelmetCrew_I";
 					};
 				};
-				id=135;
+				id=58;
 				type="I_crew_F";
 				class CustomAttributes
 				{
@@ -11338,7 +13715,109 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					class Attribute2
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=3;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="0";
+										};
+									};
+									class Item1
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+									class Item2
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="2";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute3
+					{
+						property="speaker";
+						expression="_this setspeaker _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="Male04GRE";
+							};
+						};
+					};
+					class Attribute4
+					{
+						property="pitch";
+						expression="_this setpitch _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"SCALAR"
+									};
+								};
+								value=1.03;
+							};
+						};
+					};
+					nAttributes=5;
 				};
 			};
 			class Item1
@@ -11346,7 +13825,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-6.1357422,0.0014390945,-6.8662109};
+					position[]={-6.142334,0.0014390945,-6.552002};
 				};
 				side="Independent";
 				flags=5;
@@ -11382,7 +13861,7 @@ class items
 							isBackpack=0;
 							class ItemCargo
 							{
-								items=5;
+								items=6;
 								class Item0
 								{
 									name="ACE_quikclot";
@@ -11406,6 +13885,11 @@ class items
 								class Item4
 								{
 									name="ACE_tourniquet";
+									count=1;
+								};
+								class Item5
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -11480,7 +13964,7 @@ class items
 						headgear="H_HelmetCrew_I";
 					};
 				};
-				id=136;
+				id=59;
 				type="I_crew_F";
 				class CustomAttributes
 				{
@@ -11549,7 +14033,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-5.1357422,0.0014390945,-6.8662109};
+					position[]={-5.142334,0.0014390945,-6.552002};
 				};
 				side="Independent";
 				flags=5;
@@ -11586,7 +14070,7 @@ class items
 							isBackpack=0;
 							class ItemCargo
 							{
-								items=5;
+								items=6;
 								class Item0
 								{
 									name="ACE_quikclot";
@@ -11610,6 +14094,11 @@ class items
 								class Item4
 								{
 									name="ACE_tourniquet";
+									count=1;
+								};
+								class Item5
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -11669,7 +14158,7 @@ class items
 						headgear="H_HelmetCrew_I";
 					};
 				};
-				id=137;
+				id=60;
 				type="I_crew_F";
 				class CustomAttributes
 				{
@@ -11737,7 +14226,7 @@ class items
 		class Attributes
 		{
 		};
-		id=134;
+		id=57;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -11774,7 +14263,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-0.85595703,0.0014390945,-7.0546875};
+					position[]={-0.86254883,0.0014390945,-6.7404785};
 				};
 				side="Independent";
 				flags=7;
@@ -11815,7 +14304,7 @@ class items
 							isBackpack=0;
 							class ItemCargo
 							{
-								items=8;
+								items=9;
 								class Item0
 								{
 									name="ACE_quikclot";
@@ -11854,6 +14343,11 @@ class items
 								class Item7
 								{
 									name="ACE_tourniquet";
+									count=1;
+								};
+								class Item8
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -11914,7 +14408,7 @@ class items
 						headgear="H_PilotHelmetHeli_B";
 					};
 				};
-				id=139;
+				id=62;
 				type="I_pilot_F";
 				class CustomAttributes
 				{
@@ -11975,7 +14469,71 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					class Attribute3
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=3;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="0";
+										};
+									};
+									class Item1
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+									class Item2
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="3";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=4;
 				};
 			};
 			class Item1
@@ -11983,7 +14541,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={0.14404297,0.0014390945,-7.0537109};
+					position[]={0.13745117,0.0014390945,-6.739502};
 				};
 				side="Independent";
 				flags=5;
@@ -12023,7 +14581,7 @@ class items
 							isBackpack=0;
 							class ItemCargo
 							{
-								items=8;
+								items=9;
 								class Item0
 								{
 									name="ACE_quikclot";
@@ -12062,6 +14620,11 @@ class items
 								class Item7
 								{
 									name="ACE_tourniquet";
+									count=1;
+								};
+								class Item8
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -12136,7 +14699,7 @@ class items
 						headgear="H_PilotHelmetHeli_B";
 					};
 				};
-				id=140;
+				id=63;
 				type="I_pilot_F";
 				class CustomAttributes
 				{
@@ -12197,14 +14760,78 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					class Attribute3
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=3;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="0";
+										};
+									};
+									class Item1
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+									class Item2
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="3";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=4;
 				};
 			};
 		};
 		class Attributes
 		{
 		};
-		id=138;
+		id=61;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -12241,7 +14868,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={2.8803711,0.0014390945,-7.184082};
+					position[]={2.8737793,0.0014390945,-6.869873};
 				};
 				side="Independent";
 				flags=7;
@@ -12282,7 +14909,7 @@ class items
 							isBackpack=0;
 							class ItemCargo
 							{
-								items=8;
+								items=9;
 								class Item0
 								{
 									name="ACE_quikclot";
@@ -12321,6 +14948,11 @@ class items
 								class Item7
 								{
 									name="ACE_tourniquet";
+									count=1;
+								};
+								class Item8
+								{
+									name="ACE_epinephrine";
 									count=1;
 								};
 							};
@@ -12385,7 +15017,7 @@ class items
 						headgear="H_PilotHelmetFighter_I";
 					};
 				};
-				id=142;
+				id=65;
 				type="I_pilot_F";
 				class CustomAttributes
 				{
@@ -12484,14 +15116,78 @@ class items
 							};
 						};
 					};
-					nAttributes=5;
+					class Attribute5
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=3;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="0";
+										};
+									};
+									class Item1
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+									class Item2
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="3";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=6;
 				};
 			};
 		};
 		class Attributes
 		{
 		};
-		id=141;
+		id=64;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -12521,7 +15217,7 @@ class items
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={7.012207,0.28405476,-5.6044922};
+			position[]={7.0056152,0.28405476,-5.2902832};
 		};
 		side="Empty";
 		flags=4;
@@ -12529,7 +15225,7 @@ class items
 		{
 			init="call{[this, 200] call a3aa_fnc_boxGuard}";
 		};
-		id=143;
+		id=66;
 		type="Box_IND_Ammo_F";
 		class CustomAttributes
 		{
@@ -12560,7 +15256,7 @@ class items
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={7.065918,0.89242268,-7.9853516};
+			position[]={7.0593262,0.89242268,-7.6711426};
 		};
 		side="Empty";
 		flags=4;
@@ -12568,7 +15264,7 @@ class items
 		{
 			init="call{[this, 200] call a3aa_fnc_boxGuard}";
 		};
-		id=144;
+		id=67;
 		type="I_supplyCrate_F";
 		class CustomAttributes
 		{
@@ -12587,7 +15283,7 @@ class items
 								"STRING"
 							};
 						};
-						value="[[[[""rhs_weap_m72a7""],[4]],[[""rhs_mag_30Rnd_556x45_M855A1_Stanag"",""rhs_mag_30Rnd_556x45_M855A1_Stanag_Tracer_Red"",""rhsusf_100Rnd_556x45_soft_pouch"",""SmokeShell"",""SmokeShellGreen"",""SmokeShellBlue"",""1Rnd_HE_Grenade_shell"",""MRAWS_HEAT_F"",""MRAWS_HE_F"",""hlc_100Rnd_762x51_M_M60E4"",""HandGrenade"",""hlc_20rnd_762x51_Mk316_G3""],[80,20,12,30,8,4,15,6,3,4,24,8]],[[""ACE_fieldDressing"",""ACE_quikclot"",""ACE_packingBandage"",""ACE_elasticBandage"",""ACE_morphine"",""ACE_epinephrine"",""ACE_adenosine"",""ACE_bloodIV""],[40,60,20,20,15,15,5,10]],[[],[]]],false]";
+						value="[[[[""rhs_weap_m72a7""],[4]],[[""rhs_mag_30Rnd_556x45_M855A1_Stanag"",""rhs_mag_30Rnd_556x45_M855A1_Stanag_Tracer_Red"",""rhsusf_100Rnd_556x45_soft_pouch"",""SmokeShell"",""SmokeShellGreen"",""SmokeShellBlue"",""1Rnd_HE_Grenade_shell"",""MRAWS_HEAT_F"",""MRAWS_HE_F"",""BWA3_120Rnd_762x51_soft"",""HandGrenade"",""hlc_20rnd_762x51_Mk316_G3""],[80,20,12,30,8,4,15,6,3,4,24,8]],[[""ACE_fieldDressing"",""ACE_quikclot"",""ACE_packingBandage"",""ACE_elasticBandage"",""ACE_morphine"",""ACE_epinephrine"",""ACE_adenosine"",""ACE_bloodIV""],[40,60,20,20,15,15,5,10]],[[],[]]],false]";
 					};
 				};
 			};
@@ -12597,28 +15293,28 @@ class items
 	class Item14
 	{
 		dataType="Marker";
-		position[]={3.4570313,1.3349106e+013,-3.4047852};
+		position[]={3.4504395,1.3349106e+013,-3.0905762};
 		name="respawn_guerrila";
 		type="respawn_unknown";
-		id=145;
+		id=68;
 		atlOffset=1.3349106e+013;
 	};
 	class Item15
 	{
 		dataType="Marker";
-		position[]={5.8652344,0,-6.5053711};
+		position[]={5.8586426,0,-6.1911621};
 		name="resupply_marker";
 		text="Resupply";
 		type="mil_triangle";
 		colorName="ColorGreen";
-		id=146;
+		id=69;
 	};
 	class Item16
 	{
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={4.8935547,0.14963102,-6.9145508};
+			position[]={4.8869629,0.14963102,-6.6003418};
 			angles[]={-0,4.7330365,0};
 		};
 		side="Empty";
@@ -12626,7 +15322,7 @@ class items
 		class Attributes
 		{
 		};
-		id=147;
+		id=70;
 		type="Box_IND_WpsLaunch_F";
 		class CustomAttributes
 		{
@@ -12657,11 +15353,11 @@ class items
 		dataType="Comment";
 		class PositionInfo
 		{
-			position[]={2.8076172,0,-5.0043945};
+			position[]={2.8010254,0,-4.6896973};
 		};
-		title="v1.14.1";
-		description="-v1.14.1" \n " - A3EE box guard updated to A3AA." \n " - Custom location re-added." \n "" \n "- v1.14.0 " \n "PL: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Boonie Hat"" for more visual diversity in the platoon and to bring PL headgear in line with RU and US Standard Factions. " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n "  - Removed CNTO ""Beret"" from Backpack gear due to old logo texture. " \n " " \n "Platoon Sergeant: " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n "  - Backpack added 3CB ""Radio Backpack MR3000"" and filled it with the ACRE2 ""AN/PRC-117F"" backpack radio. This gives more incentive to bring the PLT Sgt along since he is the only one who can act as a max range radio man for the platoon. " \n " " \n "Platoon Medic: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n " " \n "Platoon Rifleman: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n " " \n "Squad Medic: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n " " \n "FTL: " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n " " \n "AR: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n "  - Added muzzle attachment RHS ""SF3P-556 1/2-28"". " \n " " \n "AAR: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n " " \n "LAT: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n " " \n "MMG Teamleader: " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n " " \n "MMG Gunner: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n "  - Unfortunately no muzzle attachments available for the MG-3! " \n " " \n "MMG Asst. Gunner: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n " " \n "MAT Teamleader: " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n " " \n "MAT Gunner: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n " " \n "MAT Asst. Gunner: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n " " \n "ENG Leader: " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Heavy"" to differentiate ENG from the rest of the platoon. " \n " " \n "ENG Rifleman: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Heavy"" to differentiate ENG from the rest of the platoon. " \n " " \n "Mortar Leader: " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Special"" to visually differentiate the Mortar Team from the rest of the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n "  - Reduced STANAG mags from 10 to 5 to match the ENG ammo count. " \n " " \n "Mortar Gunner: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Special"" to visually differentiate the Mortar Team from the rest of the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n "  - Reduced STANAG mags from 10 to 5 to match the ENG ammo count. " \n " " \n "DMT Leader " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n " " \n "DMT Marksman " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n "  - Added NVG scope RHS ""AN/PVS-27"" to the vest gear. " \n " " \n "Zeus & Co-Zeus " \n "  - Uniform changed from vanilla ""VR Suit Indie"" to CNTO ""Flecktarn Recon"" to make Zeus look a bit more like an HQ commander than a Tron character. " \n "  - Facewear changed from vanilla ""VR Goggles"" to vanilla ""Aviator Glasses"". " \n "  - Insignia added ""Zeus"". " \n " " \n "All Units: " \n "  - Disabled LAMBS AI " \n " " \n "Alpha SL: " \n "  - Enabled ""is Player"". This makes it easier for Mission Makers to quickly test a mission in the editor by just hitting ""play"" instead of having to select a specific unit every time beforehand to avoid ending up in spectator mode by default. " \n " " \n "Crates: " \n "  - Added an ACE3 medical crate with our usual base script. " \n " " \n " " \n "- v1.13.6 " \n "  - ALL Added persistent Call-Signs for all GM's (where not included in v1.13.4) " \n "  - ALL Added the code `this disableAI ""MOVE""; this setSpeaker ""NoVoice""; enableRadio false;` to all playable units to prevent them from running off and spamming the vanilla-radio during local testing. " \n "  - ALL Changed persistent call-signs (map markers) to a consistent formula: ≤ 2 syllables = written out call-sing. ≥ 3 syllables = abbreviated call-sign. " \n "  - ALL Added full changelog to all factions for quick in-game reference " \n "  - TFN Added new yellow owl insignia patches to all uniforms " \n " " \n " " \n "- v1.13.5 " \n "  - ALL Added respective GM's to Standard Faction Compositions for convenience / time saving  " \n "  - ALL Added base clean-up module to Standard Faction Compositions to ensure Mission Makers don't forget it in the future - radius set to 200x200 meters " \n " " \n " " \n "- v1.13.4  " \n "  - ALL Added @ Squad/Team names to leaders so that Team name appears in role select " \n "  - TFN Changed M249 to the FN MINIMI " \n " " \n " " \n "- v1.13.3 " \n "  - US Added Improved Bipod/SAW Grip to AR M249 " \n "  - US Removed M14 Mags " \n "  - TFN Added Bipod to M249 " \n " " \n " " \n "- v1.13.2 " \n "  - ALL Added 1 Extra Tourniquet to every Unit " \n "  - TFN DMT Lead Rifle Changed to D10 Version " \n "  - TFN DMT given extra pistol mag to bring in line with other units " \n "  - TFN AAR Weapon changed to HK416 D14.5 " \n "  - TFN Lead Elements Given AN/PEQ-16A's " \n "  - US Alpha Fireteam 2 AAR vest changed to ALT variant to match rest of faction " \n "  - US Lead Elements Given AN/PEQ-16A's " \n "  - US DMT given extra pistol mag to bring in line with other units " \n "  - US DMT Sniper Rifle Given SU-260/P (MDO) to bring zoom level to the same as Russian and TFN factions " \n "  - US DMT Bipod Changed to Harris Bipod " \n "  - US DMT Marksman Rifle changed to black version of same rifle " \n "  - US DMT Marksman Magazines changed to SR-25 version, as RHS hotfix made M14 mags incompatible with MK11 " \n "  - RUS DMT given extra pistol mag to bring in line with other units " \n "  - RUS DGR Helmets changed to TSH-4 to make distinct from US Helmets " \n "  - RUS NB Helmets changed to ZSH-7A to make distinct from US and TFN helmets " \n "  - RUS Removed RIS Rail adaptors from AK rifles " \n "  - RUS Added PG-7V rocket to MAT ammo crate. This rocket is lighter and packs less payload than the PG-7VL. This gives it an  increased effective range but is less powerful due to decreased payload " \n " " \n " " \n "- v1.12.2 " \n "  - Hotfixed US Vests across the Squads to match V.12 changes. Whoops. " \n "  - Added Angled Grip to TFN HK416s where possible.  " \n " " \n " " \n "- v1.12 " \n "  - Fixed TFN MMG Ammo preloaded into Rifle to 100RND mag from 50rnd. " \n "  - Fixed TFN DMT Marksman Ammo loaded into Rifle to correct SBLR mag. " \n "  - Changed TFN DMT Lead Suppressor to QDSS NT4 Black from Rotex-5 Grey " \n "  - Changed TFN Dagger Uniforms from Gorka R Green to FFCP Green Fatigues [RS] " \n "  - Changed US PLT Commander + Squad Leader Vest from SPCS Rifleman/OEF- CP to SPCS Squad Lead/OEF-CP " \n "  - Changed US Medic Vest from SPCS Rifleman/OEF-CP to SPCS Medic/OEF-CP " \n "  - Changed US PLT Rifleman Vest from SPCS OEF-CP to SPCS Rifleman Alt/OEF-CP " \n "  - Changed US FTL Vest from SPCS Rifleman/OEF-CP to SPCS Team Leader Alt/OEF-CP " \n "  - Changed US AR Vest from SPCS Rifleman/OEF-CP to SPCS SAW/OEF-CP " \n "  - Changed US AAR Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP " \n "  - Changed US Rifleman AT Vest from SPCS OEF-CP to SPCS Rifleman Alt/OEF-CP " \n "  - Changed US MAT/MMG/DMT/ENG/MTR Lead Vest from SPCS Rifleman/OEF-CP to SPCS Team Leader Alt/OEF-CP " \n "  - Changed US MMG Gunner Vest from SPCS Rifleman/OEF-CP to SPCS Machinegunner/OEF-CP " \n "  - Changed US MMG/MAT Ammo Bearer Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP " \n "  - Changed US MAT Gunner Vest from SPCS OEF-CP to SPCS Rifleman Alt/OEF-CP " \n "  - Changed US DMT Marksman vest from SPCS OEF-CP to SPCS Sniper/OEF-CP " \n "  - Fixed US DMT Marksman Rifle Loaded Mag to correct varient. " \n "  - Changed US Engineer Rifleman Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP. " \n "  - Changed US MTR Gunner Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP. " \n "  - Changed US DGR Uniforms from FFCP ACU Fatigues to FFCP ACU Fatigues [RS] " \n "  - Changed US DGR Driver Backpack from Assault Pack Green to Assault Pack Black " \n "  - Changed US Heli Pilot/Copilot Uniforms from Heli pilot Coveralls to FFCP Nomad Fatigues [RS] " \n "  - Fixed US Heli/Jet Pilot Vest White Smoke grenade count to 2. " \n "  - Changed US Heli Pilot/Copilot Helmet from Heli Pilot NATO to HGU-56/P (Black/Visor) " \n "  - Changed US Jet Pilot Uniform from Pilot Coveralls NATO to  FFCP Nomad Fatigues " \n "  - Changed RUS Vic/Heli/Jet Crew Weapons to PP-2000 " \n "  - Upped RUS PP-2000 Ammo counts to 6x Mag to bring in line with ammo counts for TFN and US. " \n "  - Changed RUS Heli Pilot Uniforms from Pilot Coveralls CSAT to FFCP-Fatigues EMR [RS] " \n "  - Changed RUS Heli Pilot Vest from 6B23 (6Sh116) to FFCP Tactical Vest TigerVRS " \n "  - Changed RUS Jet Pilot Uniforms from Pilot Coveralls CSAT to FFCP-Fatigues EMR [RS] " \n "  - Changed RUS Jet Pilot Vest from 6B23 (6Sh116) to FFCP Tactical Vest TigerVRS " \n " " \n " " \n "- v1.11 " \n "  - changed m40 mini grenades to m67 fragmentation " \n "  - replaced mp7 weapons with mp5k-pdw " \n "  - changed ak105 to ak74m (plum)  " \n "  - changed PKM to PKP " \n "  - changed RUS PKM ammo boxes. MMG now loads with 7TZ (AP rounds) " \n "  - added vert grip to us weapons " \n "  - replaced m14 with HK PSG1A1 " \n "  - replaced m260e4 with mg3 " \n "  - updated all ammo boxes respectively.  " \n " " \n " " \n "- v1.10 " \n "  - changed Medic loadouts from 6 x 1000ml blood bags to 2 x 1000ml and 8 x 500ml. " \n " " \n " " \n "- v1.09 " \n "  - updated Fireteam colours A1 Red A2 Yellow, B1 Green B2 Blue, C1 Red C2 Yellow. " \n " " \n " " \n "- v1.08 " \n "  - changed ""Reaper"" to ""Nightbird"", ""RPR"" to ""NB"" " \n "  - changed ""Paladin"" to ""Falcon"", ""PAL"" to ""FC"" " \n "  - changed ""DAGGER"" to ""DGR"" " \n " " \n " " \n "- v1.07 " \n "  - US and RU faction bumped to v1.07 to avoid confusion regarding version numbers (US and RU was 1.05, TFN was 1.06) " \n "  - overhauled the RU faction: updated helmets, uniforms, weapons to a more modern look " \n "  - overhauled the US faction: updated helmets and vests to armour rating of IV " \n "  - corrected some mistakes in all factions (grenade ammount of MMG gunner, ENG not having tourniquetes, DGR not having GPS-s) " \n "  - overhauled the medics of all factions to reflect recent cahnges to ACE medical (less QuikClots, more Elastic Bandages, etc.) " \n " " \n " " \n "- v1.05 " \n "  - Added a MAT ammo box on spawn. " \n " " \n " " \n "- v1.04 " \n "  - All MAT Teams carrying RPG's got the ver3 scopes with ranges for all types " \n "    of ammo. " \n "  - All Callsigns were changed to be uniformed throught no matter the faction. " \n " " \n " " \n "- v1.03 " \n "  - set crew driver/gunner and pilot/copilot/jetpilot as Engineers through the " \n "    Object: ACE Options menu in unit attributes " \n "  - overhauled the TFN faction (weapons, helmets, etc.), changes not applicable " \n "    to derived factions " \n " " \n " " \n "- v1.02 " \n "  - loadout overhaul for DMT, made them lighter + gave them tools for recon " \n "  - specified preset ACRE2 radio channels for most units " \n " " \n " " \n "- v1.01 " \n "  - updated team colors func to `a3ee_team_colors_fnc_setColor`, just load+save " \n "    the composition in editor, this fixes it " \n "  - changed RPG-7 using MAT teams to carry Kitbags " \n "  - removed one PKM ammo box from AAR, MMG gunner, MMG bearer (fixes overload) " \n "  - moved 1-2 AR boxes from AAR to AR, gave AR an Assaultpack " \n "  - added 1-2 more AR boxes to AR's Assaultpack (if enough space) " \n "  - changed HEDP to HE rockets for Carl Gustav (M3MAAWS) " \n "  - changed US crew uniform and helmet to match grey color scheme of US pilots " \n "  - changed backpacks of driver/copilot to use less contrasting colors compared " \n "    to their respective uniform/vest colors " \n "  - changed Carryall backpacks of TFN Engineers to use custom Flecktarn Carryall " \n "  - changed all (GP-25 and normal) AK74m rifles to be the non-NPZ variants " \n "  - removed secondary long-range (PRC148) from Engineers " \n " " \n " " \n "- v1.00 (and before) " \n "  - added a Comment object with version number (`v1.00`) " \n "  - added `respawn_west`, `respawn_east`, `respawn_guerrila` markers " \n "  - added `[this, 200] call a3ee_fnc_boxGuard` to init lines of resupply boxes " \n "  - added `Resupply` green triangle markers on the position of resupply boxes";
-		id=148;
+		title="v1.14.2";
+		description="-v1.14.2 " \n "-MMG: Changed MG3 to MG5 and corresponding ammo types " \n "-GM: Fixed ""assign zeus to this unit"" not being present " \n "-All Groups: Fixed radio channel presets " \n "-Gave every unit 1 epi in Uniform, or Vest if uniform was full (medic not included) " \n "-Moved element lead LR radio to backpack " \n "-Gave engineers more ammo (1 tracer + 1 for members, 2 tracer for leader) " \n "-Swap platoon boonie to ECH. " \n "-Swap DMT Marksman to ""Sniper"" class from ""Spotter"" " \n "-Added mortar supply crate " \n "-DMT: Removed NVG scope, and replaced main scope with one that can be used with goggles." \n "" \n "-v1.14.1" \n " - A3EE box guard updated to A3AA." \n " - Custom location re-added." \n "" \n "- v1.14.0 " \n "PL: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Boonie Hat"" for more visual diversity in the platoon and to bring PL headgear in line with RU and US Standard Factions. " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n "  - Removed CNTO ""Beret"" from Backpack gear due to old logo texture. " \n " " \n "Platoon Sergeant: " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n "  - Backpack added 3CB ""Radio Backpack MR3000"" and filled it with the ACRE2 ""AN/PRC-117F"" backpack radio. This gives more incentive to bring the PLT Sgt along since he is the only one who can act as a max range radio man for the platoon. " \n " " \n "Platoon Medic: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n " " \n "Platoon Rifleman: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n " " \n "Squad Medic: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n " " \n "FTL: " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n " " \n "AR: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n "  - Added muzzle attachment RHS ""SF3P-556 1/2-28"". " \n " " \n "AAR: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n " " \n "LAT: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n " " \n "MMG Teamleader: " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n " " \n "MMG Gunner: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n "  - Unfortunately no muzzle attachments available for the MG-3! " \n " " \n "MMG Asst. Gunner: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n " " \n "MAT Teamleader: " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n " " \n "MAT Gunner: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n " " \n "MAT Asst. Gunner: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n " " \n "ENG Leader: " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Heavy"" to differentiate ENG from the rest of the platoon. " \n " " \n "ENG Rifleman: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Heavy"" to differentiate ENG from the rest of the platoon. " \n " " \n "Mortar Leader: " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Special"" to visually differentiate the Mortar Team from the rest of the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n "  - Reduced STANAG mags from 10 to 5 to match the ENG ammo count. " \n " " \n "Mortar Gunner: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Special"" to visually differentiate the Mortar Team from the rest of the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n "  - Reduced STANAG mags from 10 to 5 to match the ENG ammo count. " \n " " \n "DMT Leader " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n " " \n "DMT Marksman " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n "  - Added NVG scope RHS ""AN/PVS-27"" to the vest gear. " \n " " \n "Zeus & Co-Zeus " \n "  - Uniform changed from vanilla ""VR Suit Indie"" to CNTO ""Flecktarn Recon"" to make Zeus look a bit more like an HQ commander than a Tron character. " \n "  - Facewear changed from vanilla ""VR Goggles"" to vanilla ""Aviator Glasses"". " \n "  - Insignia added ""Zeus"". " \n " " \n "All Units: " \n "  - Disabled LAMBS AI " \n " " \n "Alpha SL: " \n "  - Enabled ""is Player"". This makes it easier for Mission Makers to quickly test a mission in the editor by just hitting ""play"" instead of having to select a specific unit every time beforehand to avoid ending up in spectator mode by default. " \n " " \n "Crates: " \n "  - Added an ACE3 medical crate with our usual base script. " \n " " \n " " \n "- v1.13.6 " \n "  - ALL Added persistent Call-Signs for all GM's (where not included in v1.13.4) " \n "  - ALL Added the code `this disableAI ""MOVE""; this setSpeaker ""NoVoice""; enableRadio false;` to all playable units to prevent them from running off and spamming the vanilla-radio during local testing. " \n "  - ALL Changed persistent call-signs (map markers) to a consistent formula: ≤ 2 syllables = written out call-sing. ≥ 3 syllables = abbreviated call-sign. " \n "  - ALL Added full changelog to all factions for quick in-game reference " \n "  - TFN Added new yellow owl insignia patches to all uniforms " \n " " \n " " \n "- v1.13.5 " \n "  - ALL Added respective GM's to Standard Faction Compositions for convenience / time saving  " \n "  - ALL Added base clean-up module to Standard Faction Compositions to ensure Mission Makers don't forget it in the future - radius set to 200x200 meters " \n " " \n " " \n "- v1.13.4  " \n "  - ALL Added @ Squad/Team names to leaders so that Team name appears in role select " \n "  - TFN Changed M249 to the FN MINIMI " \n " " \n " " \n "- v1.13.3 " \n "  - US Added Improved Bipod/SAW Grip to AR M249 " \n "  - US Removed M14 Mags " \n "  - TFN Added Bipod to M249 " \n " " \n " " \n "- v1.13.2 " \n "  - ALL Added 1 Extra Tourniquet to every Unit " \n "  - TFN DMT Lead Rifle Changed to D10 Version " \n "  - TFN DMT given extra pistol mag to bring in line with other units " \n "  - TFN AAR Weapon changed to HK416 D14.5 " \n "  - TFN Lead Elements Given AN/PEQ-16A's " \n "  - US Alpha Fireteam 2 AAR vest changed to ALT variant to match rest of faction " \n "  - US Lead Elements Given AN/PEQ-16A's " \n "  - US DMT given extra pistol mag to bring in line with other units " \n "  - US DMT Sniper Rifle Given SU-260/P (MDO) to bring zoom level to the same as Russian and TFN factions " \n "  - US DMT Bipod Changed to Harris Bipod " \n "  - US DMT Marksman Rifle changed to black version of same rifle " \n "  - US DMT Marksman Magazines changed to SR-25 version, as RHS hotfix made M14 mags incompatible with MK11 " \n "  - RUS DMT given extra pistol mag to bring in line with other units " \n "  - RUS DGR Helmets changed to TSH-4 to make distinct from US Helmets " \n "  - RUS NB Helmets changed to ZSH-7A to make distinct from US and TFN helmets " \n "  - RUS Removed RIS Rail adaptors from AK rifles " \n "  - RUS Added PG-7V rocket to MAT ammo crate. This rocket is lighter and packs less payload than the PG-7VL. This gives it an  increased effective range but is less powerful due to decreased payload " \n " " \n " " \n "- v1.12.2 " \n "  - Hotfixed US Vests across the Squads to match V.12 changes. Whoops. " \n "  - Added Angled Grip to TFN HK416s where possible.  " \n " " \n " " \n "- v1.12 " \n "  - Fixed TFN MMG Ammo preloaded into Rifle to 100RND mag from 50rnd. " \n "  - Fixed TFN DMT Marksman Ammo loaded into Rifle to correct SBLR mag. " \n "  - Changed TFN DMT Lead Suppressor to QDSS NT4 Black from Rotex-5 Grey " \n "  - Changed TFN Dagger Uniforms from Gorka R Green to FFCP Green Fatigues [RS] " \n "  - Changed US PLT Commander + Squad Leader Vest from SPCS Rifleman/OEF- CP to SPCS Squad Lead/OEF-CP " \n "  - Changed US Medic Vest from SPCS Rifleman/OEF-CP to SPCS Medic/OEF-CP " \n "  - Changed US PLT Rifleman Vest from SPCS OEF-CP to SPCS Rifleman Alt/OEF-CP " \n "  - Changed US FTL Vest from SPCS Rifleman/OEF-CP to SPCS Team Leader Alt/OEF-CP " \n "  - Changed US AR Vest from SPCS Rifleman/OEF-CP to SPCS SAW/OEF-CP " \n "  - Changed US AAR Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP " \n "  - Changed US Rifleman AT Vest from SPCS OEF-CP to SPCS Rifleman Alt/OEF-CP " \n "  - Changed US MAT/MMG/DMT/ENG/MTR Lead Vest from SPCS Rifleman/OEF-CP to SPCS Team Leader Alt/OEF-CP " \n "  - Changed US MMG Gunner Vest from SPCS Rifleman/OEF-CP to SPCS Machinegunner/OEF-CP " \n "  - Changed US MMG/MAT Ammo Bearer Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP " \n "  - Changed US MAT Gunner Vest from SPCS OEF-CP to SPCS Rifleman Alt/OEF-CP " \n "  - Changed US DMT Marksman vest from SPCS OEF-CP to SPCS Sniper/OEF-CP " \n "  - Fixed US DMT Marksman Rifle Loaded Mag to correct varient. " \n "  - Changed US Engineer Rifleman Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP. " \n "  - Changed US MTR Gunner Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP. " \n "  - Changed US DGR Uniforms from FFCP ACU Fatigues to FFCP ACU Fatigues [RS] " \n "  - Changed US DGR Driver Backpack from Assault Pack Green to Assault Pack Black " \n "  - Changed US Heli Pilot/Copilot Uniforms from Heli pilot Coveralls to FFCP Nomad Fatigues [RS] " \n "  - Fixed US Heli/Jet Pilot Vest White Smoke grenade count to 2. " \n "  - Changed US Heli Pilot/Copilot Helmet from Heli Pilot NATO to HGU-56/P (Black/Visor) " \n "  - Changed US Jet Pilot Uniform from Pilot Coveralls NATO to  FFCP Nomad Fatigues " \n "  - Changed RUS Vic/Heli/Jet Crew Weapons to PP-2000 " \n "  - Upped RUS PP-2000 Ammo counts to 6x Mag to bring in line with ammo counts for TFN and US. " \n "  - Changed RUS Heli Pilot Uniforms from Pilot Coveralls CSAT to FFCP-Fatigues EMR [RS] " \n "  - Changed RUS Heli Pilot Vest from 6B23 (6Sh116) to FFCP Tactical Vest TigerVRS " \n "  - Changed RUS Jet Pilot Uniforms from Pilot Coveralls CSAT to FFCP-Fatigues EMR [RS] " \n "  - Changed RUS Jet Pilot Vest from 6B23 (6Sh116) to FFCP Tactical Vest TigerVRS " \n " " \n " " \n "- v1.11 " \n "  - changed m40 mini grenades to m67 fragmentation " \n "  - replaced mp7 weapons with mp5k-pdw " \n "  - changed ak105 to ak74m (plum)  " \n "  - changed PKM to PKP " \n "  - changed RUS PKM ammo boxes. MMG now loads with 7TZ (AP rounds) " \n "  - added vert grip to us weapons " \n "  - replaced m14 with HK PSG1A1 " \n "  - replaced m260e4 with mg3 " \n "  - updated all ammo boxes respectively.  " \n " " \n " " \n "- v1.10 " \n "  - changed Medic loadouts from 6 x 1000ml blood bags to 2 x 1000ml and 8 x 500ml. " \n " " \n " " \n "- v1.09 " \n "  - updated Fireteam colours A1 Red A2 Yellow, B1 Green B2 Blue, C1 Red C2 Yellow. " \n " " \n " " \n "- v1.08 " \n "  - changed ""Reaper"" to ""Nightbird"", ""RPR"" to ""NB"" " \n "  - changed ""Paladin"" to ""Falcon"", ""PAL"" to ""FC"" " \n "  - changed ""DAGGER"" to ""DGR"" " \n " " \n " " \n "- v1.07 " \n "  - US and RU faction bumped to v1.07 to avoid confusion regarding version numbers (US and RU was 1.05, TFN was 1.06) " \n "  - overhauled the RU faction: updated helmets, uniforms, weapons to a more modern look " \n "  - overhauled the US faction: updated helmets and vests to armour rating of IV " \n "  - corrected some mistakes in all factions (grenade ammount of MMG gunner, ENG not having tourniquetes, DGR not having GPS-s) " \n "  - overhauled the medics of all factions to reflect recent cahnges to ACE medical (less QuikClots, more Elastic Bandages, etc.) " \n " " \n " " \n "- v1.05 " \n "  - Added a MAT ammo box on spawn. " \n " " \n " " \n "- v1.04 " \n "  - All MAT Teams carrying RPG's got the ver3 scopes with ranges for all types " \n "    of ammo. " \n "  - All Callsigns were changed to be uniformed throught no matter the faction. " \n " " \n " " \n "- v1.03 " \n "  - set crew driver/gunner and pilot/copilot/jetpilot as Engineers through the " \n "    Object: ACE Options menu in unit attributes " \n "  - overhauled the TFN faction (weapons, helmets, etc.), changes not applicable " \n "    to derived factions " \n " " \n " " \n "- v1.02 " \n "  - loadout overhaul for DMT, made them lighter + gave them tools for recon " \n "  - specified preset ACRE2 radio channels for most units " \n " " \n " " \n "- v1.01 " \n "  - updated team colors func to `a3ee_team_colors_fnc_setColor`, just load+save " \n "    the composition in editor, this fixes it " \n "  - changed RPG-7 using MAT teams to carry Kitbags " \n "  - removed one PKM ammo box from AAR, MMG gunner, MMG bearer (fixes overload) " \n "  - moved 1-2 AR boxes from AAR to AR, gave AR an Assaultpack " \n "  - added 1-2 more AR boxes to AR's Assaultpack (if enough space) " \n "  - changed HEDP to HE rockets for Carl Gustav (M3MAAWS) " \n "  - changed US crew uniform and helmet to match grey color scheme of US pilots " \n "  - changed backpacks of driver/copilot to use less contrasting colors compared " \n "    to their respective uniform/vest colors " \n "  - changed Carryall backpacks of TFN Engineers to use custom Flecktarn Carryall " \n "  - changed all (GP-25 and normal) AK74m rifles to be the non-NPZ variants " \n "  - removed secondary long-range (PRC148) from Engineers " \n " " \n " " \n "- v1.00 (and before) " \n "  - added a Comment object with version number (`v1.00`) " \n "  - added `respawn_west`, `respawn_east`, `respawn_guerrila` markers " \n "  - added `[this, 200] call a3ee_fnc_boxGuard` to init lines of resupply boxes " \n "  - added `Resupply` green triangle markers on the position of resupply boxes";
+		id=71;
 	};
 	class Item18
 	{
@@ -12675,7 +15371,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={4.5317383,0.0014390945,-4.2480469};
+					position[]={4.5251465,0.0014390945,-3.9338379};
 				};
 				side="Independent";
 				flags=7;
@@ -12747,7 +15443,7 @@ class items
 						goggles="G_Aviator";
 					};
 				};
-				id=150;
+				id=73;
 				type="I_Protagonist_VR_F";
 				class CustomAttributes
 				{
@@ -12827,7 +15523,90 @@ class items
 							};
 						};
 					};
-					nAttributes=4;
+					class Attribute4
+					{
+						property="a3aa_insta_zeus_unit_curator";
+						expression="[_this, _value] call a3aa_insta_zeus_fnc_createUnitCurator";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"BOOL"
+									};
+								};
+								value=1;
+							};
+						};
+					};
+					class Attribute5
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=3;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="0";
+										};
+									};
+									class Item1
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+									class Item2
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="3";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=6;
 				};
 			};
 			class Item1
@@ -12835,7 +15614,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={5.5317383,0.0014390945,-4.2480469};
+					position[]={5.5251465,0.0014390945,-3.9338379};
 				};
 				side="Independent";
 				flags=5;
@@ -12907,7 +15686,7 @@ class items
 						goggles="G_Aviator";
 					};
 				};
-				id=151;
+				id=74;
 				type="I_Protagonist_VR_F";
 				class CustomAttributes
 				{
@@ -12987,14 +15766,97 @@ class items
 							};
 						};
 					};
-					nAttributes=4;
+					class Attribute4
+					{
+						property="a3aa_insta_zeus_unit_curator";
+						expression="[_this, _value] call a3aa_insta_zeus_fnc_createUnitCurator";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"BOOL"
+									};
+								};
+								value=1;
+							};
+						};
+					};
+					class Attribute5
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=3;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="0";
+										};
+									};
+									class Item1
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+									class Item2
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="3";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=6;
 				};
 			};
 		};
 		class Attributes
 		{
 		};
-		id=149;
+		id=72;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -13024,7 +15886,7 @@ class items
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={7.4438477,0,-3.9296875};
+			position[]={7.4372559,0,-3.6154785};
 		};
 		side="Empty";
 		flags=4;
@@ -13032,7 +15894,7 @@ class items
 		{
 			init="call{[this, 200] call a3aa_fnc_boxGuard}";
 		};
-		id=152;
+		id=75;
 		type="ACE_medicalSupplyCrate";
 		class CustomAttributes
 		{
@@ -13063,12 +15925,12 @@ class items
 		dataType="Logic";
 		class PositionInfo
 		{
-			position[]={-0.16015625,0,-0.39160156};
+			position[]={-0.16674805,0,-0.077392578};
 		};
 		areaSize[]={200,-1,200};
 		areaIsRectangle=1;
 		flags=1;
-		id=153;
+		id=76;
 		type="a3aa_ee_custom_location";
 		class CustomAttributes
 		{
@@ -13130,6 +15992,44 @@ class items
 				};
 			};
 			nAttributes=3;
+		};
+	};
+	class Item21
+	{
+		dataType="Object";
+		class PositionInfo
+		{
+			position[]={7.0439453,0.18872452,-9.9887695};
+		};
+		side="Empty";
+		flags=4;
+		class Attributes
+		{
+		};
+		id=85;
+		type="Box_IND_Wps_F";
+		class CustomAttributes
+		{
+			class Attribute0
+			{
+				property="ammoBox";
+				expression="[_this,_value] call bis_fnc_initAmmoBox;";
+				class Value
+				{
+					class data
+					{
+						class type
+						{
+							type[]=
+							{
+								"STRING"
+							};
+						};
+						value="[[[[""arifle_Mk20C_F"",""arifle_Mk20_F"",""arifle_Mk20_GL_F"",""LMG_Mk200_F"",""hgun_PDW2000_F"",""hgun_ACPC2_F""],[2,4,2,2,1,1]],[[""30Rnd_556x45_Stanag"",""9Rnd_45ACP_Mag"",""30Rnd_9x21_Mag"",""200Rnd_65x39_cased_Box"",""ACE_30Rnd_556x45_Stanag_M995_AP_mag"",""ACE_30Rnd_556x45_Stanag_Mk262_mag"",""ACE_30Rnd_556x45_Stanag_Mk318_mag""],[8,1,1,2,4,4,4]],[[""ACE_MapTools"",""ACE_RangeTable_82mm""],[2,2]],[[""I_Mortar_01_support_F"",""I_Mortar_01_weapon_F""],[2,2]]],false]";
+					};
+				};
+			};
+			nAttributes=1;
 		};
 	};
 };

--- a/reference/Task%20Force%20Noctem/composition.sqe
+++ b/reference/Task%20Force%20Noctem/composition.sqe
@@ -1,5 +1,5 @@
 version=53;
-center[]={3279.947,5,3728.8118};
+center[]={5697.6665,5,3924.2461};
 class items
 {
 	items=22;
@@ -15,7 +15,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-6.1660156,0.0014390945,7.9711914};
+					position[]={-6.28125,0.0014390945,8.0290527};
 				};
 				side="Independent";
 				flags=7;
@@ -381,7 +381,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-5.1669922,0.0014390945,7.972168};
+					position[]={-5.2822266,0.0014390945,8.0300293};
 				};
 				side="Independent";
 				flags=5;
@@ -702,7 +702,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-4.166748,0.0014390945,7.9724121};
+					position[]={-4.2817383,0.0014390945,8.0302734};
 				};
 				side="Independent";
 				flags=5;
@@ -997,7 +997,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-3.166748,0.0014390945,7.9724121};
+					position[]={-3.2817383,0.0014390945,8.0302734};
 				};
 				side="Independent";
 				flags=5;
@@ -1252,7 +1252,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-6.2241211,0.0014390945,5.6772461};
+					position[]={-6.3393555,0.0014390945,5.7351074};
 				};
 				side="Independent";
 				flags=7;
@@ -1616,7 +1616,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-5.2243652,0.0014390945,5.6784668};
+					position[]={-5.3393555,0.0014390945,5.7363281};
 				};
 				side="Independent";
 				flags=5;
@@ -1911,7 +1911,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-6.2243652,0.0014390945,3.6784668};
+					position[]={-6.3393555,0.0014390945,3.7363281};
 				};
 				side="Independent";
 				flags=5;
@@ -2125,6 +2125,25 @@ class items
 				{
 					class Attribute0
 					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="RED";
+							};
+						};
+					};
+					class Attribute1
+					{
 						property="lambs_danger_disableAI";
 						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
 						class Value
@@ -2142,7 +2161,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
@@ -2161,7 +2180,7 @@ class items
 							};
 						};
 					};
-					class Attribute2
+					class Attribute3
 					{
 						property="a3aa_ee_acre_channels_chlist";
 						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
@@ -2197,7 +2216,7 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					nAttributes=4;
 				};
 			};
 			class Item3
@@ -2205,7 +2224,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-5.2243652,0.0014390945,3.6784668};
+					position[]={-5.3393555,0.0014390945,3.7363281};
 				};
 				side="Independent";
 				flags=5;
@@ -2354,6 +2373,25 @@ class items
 				{
 					class Attribute0
 					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="RED";
+							};
+						};
+					};
+					class Attribute1
+					{
 						property="lambs_danger_disableAI";
 						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
 						class Value
@@ -2371,7 +2409,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
@@ -2390,7 +2428,7 @@ class items
 							};
 						};
 					};
-					class Attribute2
+					class Attribute3
 					{
 						property="a3aa_ee_acre_channels_chlist";
 						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
@@ -2426,7 +2464,7 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					nAttributes=4;
 				};
 			};
 			class Item4
@@ -2434,7 +2472,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-4.2243652,0.0014390945,3.6784668};
+					position[]={-4.3393555,0.0014390945,3.7363281};
 				};
 				side="Independent";
 				flags=5;
@@ -2643,6 +2681,25 @@ class items
 				{
 					class Attribute0
 					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="RED";
+							};
+						};
+					};
+					class Attribute1
+					{
 						property="lambs_danger_disableAI";
 						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
 						class Value
@@ -2660,7 +2717,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
@@ -2679,7 +2736,7 @@ class items
 							};
 						};
 					};
-					class Attribute2
+					class Attribute3
 					{
 						property="a3aa_ee_acre_channels_chlist";
 						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
@@ -2715,7 +2772,7 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					nAttributes=4;
 				};
 			};
 			class Item5
@@ -2723,7 +2780,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-3.2243652,0.0014390945,3.6784668};
+					position[]={-3.3393555,0.0014390945,3.7363281};
 				};
 				side="Independent";
 				flags=5;
@@ -2866,6 +2923,25 @@ class items
 				{
 					class Attribute0
 					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="RED";
+							};
+						};
+					};
+					class Attribute1
+					{
 						property="lambs_danger_disableAI";
 						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
 						class Value
@@ -2883,7 +2959,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
@@ -2902,7 +2978,7 @@ class items
 							};
 						};
 					};
-					class Attribute2
+					class Attribute3
 					{
 						property="a3aa_ee_acre_channels_chlist";
 						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
@@ -2938,7 +3014,7 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					nAttributes=4;
 				};
 			};
 			class Item6
@@ -2946,7 +3022,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-6.2243652,0.0014390945,1.6784668};
+					position[]={-6.3393555,0.0014390945,1.7363281};
 				};
 				side="Independent";
 				flags=5;
@@ -3160,6 +3236,25 @@ class items
 				{
 					class Attribute0
 					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="YELLOW";
+							};
+						};
+					};
+					class Attribute1
+					{
 						property="lambs_danger_disableAI";
 						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
 						class Value
@@ -3177,7 +3272,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
@@ -3196,7 +3291,7 @@ class items
 							};
 						};
 					};
-					class Attribute2
+					class Attribute3
 					{
 						property="a3aa_ee_acre_channels_chlist";
 						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
@@ -3232,7 +3327,7 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					nAttributes=4;
 				};
 			};
 			class Item7
@@ -3240,7 +3335,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-5.2243652,0.0014390945,1.6784668};
+					position[]={-5.3393555,0.0014390945,1.7363281};
 				};
 				side="Independent";
 				flags=5;
@@ -3389,6 +3484,25 @@ class items
 				{
 					class Attribute0
 					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="YELLOW";
+							};
+						};
+					};
+					class Attribute1
+					{
 						property="lambs_danger_disableAI";
 						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
 						class Value
@@ -3406,7 +3520,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
@@ -3425,7 +3539,7 @@ class items
 							};
 						};
 					};
-					class Attribute2
+					class Attribute3
 					{
 						property="a3aa_ee_acre_channels_chlist";
 						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
@@ -3461,7 +3575,7 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					nAttributes=4;
 				};
 			};
 			class Item8
@@ -3469,7 +3583,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-4.2243652,0.0014390945,1.6784668};
+					position[]={-4.3393555,0.0014390945,1.7363281};
 				};
 				side="Independent";
 				flags=5;
@@ -3678,6 +3792,25 @@ class items
 				{
 					class Attribute0
 					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="YELLOW";
+							};
+						};
+					};
+					class Attribute1
+					{
 						property="lambs_danger_disableAI";
 						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
 						class Value
@@ -3695,7 +3828,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
@@ -3714,7 +3847,7 @@ class items
 							};
 						};
 					};
-					class Attribute2
+					class Attribute3
 					{
 						property="a3aa_ee_acre_channels_chlist";
 						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
@@ -3750,7 +3883,7 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					nAttributes=4;
 				};
 			};
 			class Item9
@@ -3758,7 +3891,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-3.2243652,0.0014390945,1.6784668};
+					position[]={-3.3393555,0.0014390945,1.7363281};
 				};
 				side="Independent";
 				flags=5;
@@ -3901,6 +4034,25 @@ class items
 				{
 					class Attribute0
 					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="YELLOW";
+							};
+						};
+					};
+					class Attribute1
+					{
 						property="lambs_danger_disableAI";
 						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
 						class Value
@@ -3918,7 +4070,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
@@ -3937,7 +4089,7 @@ class items
 							};
 						};
 					};
-					class Attribute2
+					class Attribute3
 					{
 						property="a3aa_ee_acre_channels_chlist";
 						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
@@ -3973,7 +4125,7 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					nAttributes=4;
 				};
 			};
 		};
@@ -4017,7 +4169,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-0.66210938,0.0014390945,5.5661621};
+					position[]={-0.77734375,0.0014390945,5.6240234};
 				};
 				side="Independent";
 				flags=7;
@@ -4380,7 +4532,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={0.3371582,0.0014390945,5.5661621};
+					position[]={0.22216797,0.0014390945,5.6240234};
 				};
 				side="Independent";
 				flags=5;
@@ -4675,7 +4827,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-0.73339844,0.0014390945,3.5930176};
+					position[]={-0.84863281,0.0014390945,3.6508789};
 				};
 				side="Independent";
 				flags=5;
@@ -4889,6 +5041,25 @@ class items
 				{
 					class Attribute0
 					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="BLUE";
+							};
+						};
+					};
+					class Attribute1
+					{
 						property="lambs_danger_disableAI";
 						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
 						class Value
@@ -4906,7 +5077,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
@@ -4925,7 +5096,7 @@ class items
 							};
 						};
 					};
-					class Attribute2
+					class Attribute3
 					{
 						property="a3aa_ee_acre_channels_chlist";
 						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
@@ -4961,7 +5132,7 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					nAttributes=4;
 				};
 			};
 			class Item3
@@ -4969,7 +5140,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={0.3371582,0.0014390945,3.5661621};
+					position[]={0.22216797,0.0014390945,3.6240234};
 				};
 				side="Independent";
 				flags=5;
@@ -5118,6 +5289,25 @@ class items
 				{
 					class Attribute0
 					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="BLUE";
+							};
+						};
+					};
+					class Attribute1
+					{
 						property="lambs_danger_disableAI";
 						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
 						class Value
@@ -5135,7 +5325,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
@@ -5154,7 +5344,7 @@ class items
 							};
 						};
 					};
-					class Attribute2
+					class Attribute3
 					{
 						property="a3aa_ee_acre_channels_chlist";
 						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
@@ -5190,7 +5380,7 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					nAttributes=4;
 				};
 			};
 			class Item4
@@ -5198,7 +5388,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={1.3371582,0.0014390945,3.5661621};
+					position[]={1.222168,0.0014390945,3.6240234};
 				};
 				side="Independent";
 				flags=5;
@@ -5407,6 +5597,25 @@ class items
 				{
 					class Attribute0
 					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="BLUE";
+							};
+						};
+					};
+					class Attribute1
+					{
 						property="lambs_danger_disableAI";
 						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
 						class Value
@@ -5424,7 +5633,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
@@ -5443,7 +5652,7 @@ class items
 							};
 						};
 					};
-					class Attribute2
+					class Attribute3
 					{
 						property="a3aa_ee_acre_channels_chlist";
 						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
@@ -5479,7 +5688,7 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					nAttributes=4;
 				};
 			};
 			class Item5
@@ -5487,7 +5696,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={2.3371582,0.0014390945,3.5661621};
+					position[]={2.222168,0.0014390945,3.6240234};
 				};
 				side="Independent";
 				flags=5;
@@ -5630,6 +5839,25 @@ class items
 				{
 					class Attribute0
 					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="BLUE";
+							};
+						};
+					};
+					class Attribute1
+					{
 						property="lambs_danger_disableAI";
 						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
 						class Value
@@ -5647,7 +5875,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
@@ -5666,7 +5894,7 @@ class items
 							};
 						};
 					};
-					class Attribute2
+					class Attribute3
 					{
 						property="a3aa_ee_acre_channels_chlist";
 						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
@@ -5702,7 +5930,7 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					nAttributes=4;
 				};
 			};
 			class Item6
@@ -5710,7 +5938,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-0.6628418,0.0014390945,1.5661621};
+					position[]={-0.77783203,0.0014390945,1.6240234};
 				};
 				side="Independent";
 				flags=5;
@@ -5924,6 +6152,25 @@ class items
 				{
 					class Attribute0
 					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="GREEN";
+							};
+						};
+					};
+					class Attribute1
+					{
 						property="lambs_danger_disableAI";
 						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
 						class Value
@@ -5941,7 +6188,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
@@ -5960,7 +6207,7 @@ class items
 							};
 						};
 					};
-					class Attribute2
+					class Attribute3
 					{
 						property="a3aa_ee_acre_channels_chlist";
 						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
@@ -5996,7 +6243,7 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					nAttributes=4;
 				};
 			};
 			class Item7
@@ -6004,7 +6251,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={0.3371582,0.0014390945,1.5661621};
+					position[]={0.22216797,0.0014390945,1.6240234};
 				};
 				side="Independent";
 				flags=5;
@@ -6153,6 +6400,25 @@ class items
 				{
 					class Attribute0
 					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="GREEN";
+							};
+						};
+					};
+					class Attribute1
+					{
 						property="lambs_danger_disableAI";
 						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
 						class Value
@@ -6170,7 +6436,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
@@ -6189,7 +6455,7 @@ class items
 							};
 						};
 					};
-					class Attribute2
+					class Attribute3
 					{
 						property="a3aa_ee_acre_channels_chlist";
 						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
@@ -6225,7 +6491,7 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					nAttributes=4;
 				};
 			};
 			class Item8
@@ -6233,7 +6499,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={1.3371582,0.0014390945,1.5661621};
+					position[]={1.222168,0.0014390945,1.6240234};
 				};
 				side="Independent";
 				flags=5;
@@ -6442,6 +6708,25 @@ class items
 				{
 					class Attribute0
 					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="GREEN";
+							};
+						};
+					};
+					class Attribute1
+					{
 						property="lambs_danger_disableAI";
 						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
 						class Value
@@ -6459,7 +6744,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
@@ -6478,7 +6763,7 @@ class items
 							};
 						};
 					};
-					class Attribute2
+					class Attribute3
 					{
 						property="a3aa_ee_acre_channels_chlist";
 						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
@@ -6514,7 +6799,7 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					nAttributes=4;
 				};
 			};
 			class Item9
@@ -6522,7 +6807,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={2.3371582,0.0014390945,1.5661621};
+					position[]={2.222168,0.0014390945,1.6240234};
 				};
 				side="Independent";
 				flags=5;
@@ -6665,6 +6950,25 @@ class items
 				{
 					class Attribute0
 					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="GREEN";
+							};
+						};
+					};
+					class Attribute1
+					{
 						property="lambs_danger_disableAI";
 						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
 						class Value
@@ -6682,7 +6986,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
@@ -6701,7 +7005,7 @@ class items
 							};
 						};
 					};
-					class Attribute2
+					class Attribute3
 					{
 						property="a3aa_ee_acre_channels_chlist";
 						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
@@ -6737,7 +7041,7 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					nAttributes=4;
 				};
 			};
 		};
@@ -6781,7 +7085,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={4.3859863,0.0014390945,5.458252};
+					position[]={4.2709961,0.0014390945,5.5161133};
 				};
 				side="Independent";
 				flags=7;
@@ -7144,7 +7448,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={5.385498,0.0014390945,5.4577637};
+					position[]={5.2700195,0.0014390945,5.515625};
 				};
 				side="Independent";
 				flags=5;
@@ -7439,7 +7743,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={4.385498,0.0014390945,3.4577637};
+					position[]={4.2700195,0.0014390945,3.515625};
 				};
 				side="Independent";
 				flags=5;
@@ -7653,6 +7957,25 @@ class items
 				{
 					class Attribute0
 					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="RED";
+							};
+						};
+					};
+					class Attribute1
+					{
 						property="lambs_danger_disableAI";
 						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
 						class Value
@@ -7670,7 +7993,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
@@ -7689,7 +8012,7 @@ class items
 							};
 						};
 					};
-					class Attribute2
+					class Attribute3
 					{
 						property="a3aa_ee_acre_channels_chlist";
 						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
@@ -7725,7 +8048,7 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					nAttributes=4;
 				};
 			};
 			class Item3
@@ -7733,7 +8056,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={5.385498,0.0014390945,3.4577637};
+					position[]={5.2700195,0.0014390945,3.515625};
 				};
 				side="Independent";
 				flags=5;
@@ -7882,6 +8205,25 @@ class items
 				{
 					class Attribute0
 					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="RED";
+							};
+						};
+					};
+					class Attribute1
+					{
 						property="lambs_danger_disableAI";
 						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
 						class Value
@@ -7899,7 +8241,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
@@ -7918,7 +8260,7 @@ class items
 							};
 						};
 					};
-					class Attribute2
+					class Attribute3
 					{
 						property="a3aa_ee_acre_channels_chlist";
 						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
@@ -7954,7 +8296,7 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					nAttributes=4;
 				};
 			};
 			class Item4
@@ -7962,7 +8304,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={6.385498,0.0014390945,3.4577637};
+					position[]={6.2700195,0.0014390945,3.515625};
 				};
 				side="Independent";
 				flags=5;
@@ -8171,6 +8513,25 @@ class items
 				{
 					class Attribute0
 					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="RED";
+							};
+						};
+					};
+					class Attribute1
+					{
 						property="lambs_danger_disableAI";
 						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
 						class Value
@@ -8188,7 +8549,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
@@ -8207,7 +8568,7 @@ class items
 							};
 						};
 					};
-					class Attribute2
+					class Attribute3
 					{
 						property="a3aa_ee_acre_channels_chlist";
 						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
@@ -8243,7 +8604,7 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					nAttributes=4;
 				};
 			};
 			class Item5
@@ -8251,7 +8612,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={7.385498,0.0014390945,3.4577637};
+					position[]={7.2700195,0.0014390945,3.515625};
 				};
 				side="Independent";
 				flags=5;
@@ -8394,6 +8755,25 @@ class items
 				{
 					class Attribute0
 					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="RED";
+							};
+						};
+					};
+					class Attribute1
+					{
 						property="lambs_danger_disableAI";
 						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
 						class Value
@@ -8411,7 +8791,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
@@ -8430,7 +8810,7 @@ class items
 							};
 						};
 					};
-					class Attribute2
+					class Attribute3
 					{
 						property="a3aa_ee_acre_channels_chlist";
 						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
@@ -8466,7 +8846,7 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					nAttributes=4;
 				};
 			};
 			class Item6
@@ -8474,7 +8854,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={4.385498,0.0014390945,1.4577637};
+					position[]={4.2700195,0.0014390945,1.515625};
 				};
 				side="Independent";
 				flags=5;
@@ -8688,6 +9068,25 @@ class items
 				{
 					class Attribute0
 					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="YELLOW";
+							};
+						};
+					};
+					class Attribute1
+					{
 						property="lambs_danger_disableAI";
 						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
 						class Value
@@ -8705,7 +9104,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
@@ -8724,7 +9123,7 @@ class items
 							};
 						};
 					};
-					class Attribute2
+					class Attribute3
 					{
 						property="a3aa_ee_acre_channels_chlist";
 						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
@@ -8760,7 +9159,7 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					nAttributes=4;
 				};
 			};
 			class Item7
@@ -8768,7 +9167,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={5.385498,0.0014390945,1.4577637};
+					position[]={5.2700195,0.0014390945,1.515625};
 				};
 				side="Independent";
 				flags=5;
@@ -8917,6 +9316,25 @@ class items
 				{
 					class Attribute0
 					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="YELLOW";
+							};
+						};
+					};
+					class Attribute1
+					{
 						property="lambs_danger_disableAI";
 						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
 						class Value
@@ -8934,7 +9352,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
@@ -8953,7 +9371,7 @@ class items
 							};
 						};
 					};
-					class Attribute2
+					class Attribute3
 					{
 						property="a3aa_ee_acre_channels_chlist";
 						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
@@ -8989,7 +9407,7 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					nAttributes=4;
 				};
 			};
 			class Item8
@@ -8997,7 +9415,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={6.385498,0.0014390945,1.4577637};
+					position[]={6.2700195,0.0014390945,1.515625};
 				};
 				side="Independent";
 				flags=5;
@@ -9206,6 +9624,25 @@ class items
 				{
 					class Attribute0
 					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="YELLOW";
+							};
+						};
+					};
+					class Attribute1
+					{
 						property="lambs_danger_disableAI";
 						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
 						class Value
@@ -9223,7 +9660,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
@@ -9242,7 +9679,7 @@ class items
 							};
 						};
 					};
-					class Attribute2
+					class Attribute3
 					{
 						property="a3aa_ee_acre_channels_chlist";
 						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
@@ -9278,7 +9715,7 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					nAttributes=4;
 				};
 			};
 			class Item9
@@ -9286,7 +9723,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={7.385498,0.0014390945,1.4577637};
+					position[]={7.2700195,0.0014390945,1.515625};
 				};
 				side="Independent";
 				flags=5;
@@ -9429,6 +9866,25 @@ class items
 				{
 					class Attribute0
 					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="YELLOW";
+							};
+						};
+					};
+					class Attribute1
+					{
 						property="lambs_danger_disableAI";
 						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
 						class Value
@@ -9446,7 +9902,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
@@ -9465,7 +9921,7 @@ class items
 							};
 						};
 					};
-					class Attribute2
+					class Attribute3
 					{
 						property="a3aa_ee_acre_channels_chlist";
 						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
@@ -9501,7 +9957,7 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					nAttributes=4;
 				};
 			};
 		};
@@ -9545,7 +10001,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-6.6130371,0.0014390945,-1.204834};
+					position[]={-6.7280273,0.0014390945,-1.1469727};
 				};
 				side="Independent";
 				flags=7;
@@ -9908,7 +10364,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-5.6125488,0.0014390945,-1.2053223};
+					position[]={-5.7280273,0.0014390945,-1.1474609};
 				};
 				side="Independent";
 				flags=5;
@@ -10129,7 +10585,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-4.6125488,0.0014390945,-1.2053223};
+					position[]={-4.7280273,0.0014390945,-1.1474609};
 				};
 				side="Independent";
 				flags=5;
@@ -10399,7 +10855,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-0.65283203,0.0014390945,-1.262207};
+					position[]={-0.76806641,0.0014390945,-1.2043457};
 				};
 				side="Independent";
 				flags=7;
@@ -10762,7 +11218,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={0.62915039,0.0014390945,-1.2375488};
+					position[]={0.51416016,0.0014390945,-1.1796875};
 				};
 				side="Independent";
 				flags=5;
@@ -11030,7 +11486,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={1.6291504,0.0014390945,-1.2375488};
+					position[]={1.5141602,0.0014390945,-1.1796875};
 				};
 				side="Independent";
 				flags=5;
@@ -11325,7 +11781,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-5.8737793,0.0014390945,-3.8742676};
+					position[]={-5.9887695,0.0014390945,-3.8164063};
 				};
 				side="Independent";
 				flags=5;
@@ -11486,7 +11942,7 @@ class items
 						headgear="cnto_flecktarn_h_boo_grassland";
 					};
 				};
-				id=48;
+				id=47;
 				type="I_Spotter_F";
 				class CustomAttributes
 				{
@@ -11572,7 +12028,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-6.8730469,0.0014390945,-3.8737793};
+					position[]={-6.9882813,0.0014390945,-3.815918};
 				};
 				side="Independent";
 				flags=6;
@@ -11765,7 +12221,7 @@ class items
 						headgear="cnto_flecktarn_h_boo_grassland";
 					};
 				};
-				id=77;
+				id=48;
 				type="I_Sniper_F";
 				class CustomAttributes
 				{
@@ -11939,7 +12395,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-0.74243164,0.0014390945,-3.9348145};
+					position[]={-0.85791016,0.0014390945,-3.8769531};
 				};
 				side="Independent";
 				flags=7;
@@ -12174,7 +12630,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={0.25854492,0.0014390945,-3.9348145};
+					position[]={0.14306641,0.0014390945,-3.8769531};
 				};
 				side="Independent";
 				flags=5;
@@ -12421,7 +12877,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={4.5258789,0.0014390945,-1.2006836};
+					position[]={4.4106445,0.0014390945,-1.1428223};
 				};
 				side="Independent";
 				flags=7;
@@ -12733,7 +13189,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={5.5256348,0.0014390945,-1.2004395};
+					position[]={5.4106445,0.0014390945,-1.1425781};
 				};
 				side="Independent";
 				flags=5;
@@ -12986,7 +13442,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={6.5256348,0.0014390945,-1.2004395};
+					position[]={6.4106445,0.0014390945,-1.1425781};
 				};
 				side="Independent";
 				flags=5;
@@ -13239,7 +13695,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={7.5256348,0.0014390945,-1.2004395};
+					position[]={7.4106445,0.0014390945,-1.1425781};
 				};
 				side="Independent";
 				flags=5;
@@ -13528,7 +13984,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-7.1420898,0.0014390945,-6.5517578};
+					position[]={-7.2573242,0.0014390945,-6.4938965};
 				};
 				side="Independent";
 				flags=7;
@@ -13825,7 +14281,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-6.142334,0.0014390945,-6.552002};
+					position[]={-6.2573242,0.0014390945,-6.4941406};
 				};
 				side="Independent";
 				flags=5;
@@ -14033,7 +14489,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-5.142334,0.0014390945,-6.552002};
+					position[]={-5.2573242,0.0014390945,-6.4941406};
 				};
 				side="Independent";
 				flags=5;
@@ -14263,7 +14719,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-0.86254883,0.0014390945,-6.7404785};
+					position[]={-0.97802734,0.0014390945,-6.6826172};
 				};
 				side="Independent";
 				flags=7;
@@ -14541,7 +14997,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={0.13745117,0.0014390945,-6.739502};
+					position[]={0.021972656,0.0014390945,-6.6816406};
 				};
 				side="Independent";
 				flags=5;
@@ -14868,7 +15324,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={2.8737793,0.0014390945,-6.869873};
+					position[]={2.7583008,0.0014390945,-6.8120117};
 				};
 				side="Independent";
 				flags=7;
@@ -15217,7 +15673,7 @@ class items
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={7.0056152,0.28405476,-5.2902832};
+			position[]={6.8901367,0.28405476,-5.2324219};
 		};
 		side="Empty";
 		flags=4;
@@ -15256,7 +15712,7 @@ class items
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={7.0593262,0.89242268,-7.6711426};
+			position[]={6.9438477,0.89242268,-7.6132813};
 		};
 		side="Empty";
 		flags=4;
@@ -15293,7 +15749,7 @@ class items
 	class Item14
 	{
 		dataType="Marker";
-		position[]={3.4504395,1.3349106e+013,-3.0905762};
+		position[]={3.3354492,1.3349106e+013,-3.0327148};
 		name="respawn_guerrila";
 		type="respawn_unknown";
 		id=68;
@@ -15302,7 +15758,7 @@ class items
 	class Item15
 	{
 		dataType="Marker";
-		position[]={5.8586426,0,-6.1911621};
+		position[]={5.7436523,0,-6.1333008};
 		name="resupply_marker";
 		text="Resupply";
 		type="mil_triangle";
@@ -15314,7 +15770,7 @@ class items
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={4.8869629,0.14963102,-6.6003418};
+			position[]={4.7719727,0.14963102,-6.5424805};
 			angles[]={-0,4.7330365,0};
 		};
 		side="Empty";
@@ -15353,10 +15809,10 @@ class items
 		dataType="Comment";
 		class PositionInfo
 		{
-			position[]={2.8010254,0,-4.6896973};
+			position[]={2.6865234,0,-4.6320801};
 		};
 		title="v1.14.2";
-		description="-v1.14.2 " \n "-MMG: Changed MG3 to MG5 and corresponding ammo types " \n "-GM: Fixed ""assign zeus to this unit"" not being present " \n "-All Groups: Fixed radio channel presets " \n "-Gave every unit 1 epi in Uniform, or Vest if uniform was full (medic not included) " \n "-Moved element lead LR radio to backpack " \n "-Gave engineers more ammo (1 tracer + 1 for members, 2 tracer for leader) " \n "-Swap platoon boonie to ECH. " \n "-Swap DMT Marksman to ""Sniper"" class from ""Spotter"" " \n "-Added mortar supply crate " \n "-DMT: Removed NVG scope, and replaced main scope with one that can be used with goggles." \n "" \n "-v1.14.1" \n " - A3EE box guard updated to A3AA." \n " - Custom location re-added." \n "" \n "- v1.14.0 " \n "PL: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Boonie Hat"" for more visual diversity in the platoon and to bring PL headgear in line with RU and US Standard Factions. " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n "  - Removed CNTO ""Beret"" from Backpack gear due to old logo texture. " \n " " \n "Platoon Sergeant: " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n "  - Backpack added 3CB ""Radio Backpack MR3000"" and filled it with the ACRE2 ""AN/PRC-117F"" backpack radio. This gives more incentive to bring the PLT Sgt along since he is the only one who can act as a max range radio man for the platoon. " \n " " \n "Platoon Medic: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n " " \n "Platoon Rifleman: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n " " \n "Squad Medic: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n " " \n "FTL: " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n " " \n "AR: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n "  - Added muzzle attachment RHS ""SF3P-556 1/2-28"". " \n " " \n "AAR: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n " " \n "LAT: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n " " \n "MMG Teamleader: " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n " " \n "MMG Gunner: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n "  - Unfortunately no muzzle attachments available for the MG-3! " \n " " \n "MMG Asst. Gunner: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n " " \n "MAT Teamleader: " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n " " \n "MAT Gunner: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n " " \n "MAT Asst. Gunner: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n " " \n "ENG Leader: " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Heavy"" to differentiate ENG from the rest of the platoon. " \n " " \n "ENG Rifleman: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Heavy"" to differentiate ENG from the rest of the platoon. " \n " " \n "Mortar Leader: " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Special"" to visually differentiate the Mortar Team from the rest of the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n "  - Reduced STANAG mags from 10 to 5 to match the ENG ammo count. " \n " " \n "Mortar Gunner: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Special"" to visually differentiate the Mortar Team from the rest of the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n "  - Reduced STANAG mags from 10 to 5 to match the ENG ammo count. " \n " " \n "DMT Leader " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n " " \n "DMT Marksman " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n "  - Added NVG scope RHS ""AN/PVS-27"" to the vest gear. " \n " " \n "Zeus & Co-Zeus " \n "  - Uniform changed from vanilla ""VR Suit Indie"" to CNTO ""Flecktarn Recon"" to make Zeus look a bit more like an HQ commander than a Tron character. " \n "  - Facewear changed from vanilla ""VR Goggles"" to vanilla ""Aviator Glasses"". " \n "  - Insignia added ""Zeus"". " \n " " \n "All Units: " \n "  - Disabled LAMBS AI " \n " " \n "Alpha SL: " \n "  - Enabled ""is Player"". This makes it easier for Mission Makers to quickly test a mission in the editor by just hitting ""play"" instead of having to select a specific unit every time beforehand to avoid ending up in spectator mode by default. " \n " " \n "Crates: " \n "  - Added an ACE3 medical crate with our usual base script. " \n " " \n " " \n "- v1.13.6 " \n "  - ALL Added persistent Call-Signs for all GM's (where not included in v1.13.4) " \n "  - ALL Added the code `this disableAI ""MOVE""; this setSpeaker ""NoVoice""; enableRadio false;` to all playable units to prevent them from running off and spamming the vanilla-radio during local testing. " \n "  - ALL Changed persistent call-signs (map markers) to a consistent formula: ≤ 2 syllables = written out call-sing. ≥ 3 syllables = abbreviated call-sign. " \n "  - ALL Added full changelog to all factions for quick in-game reference " \n "  - TFN Added new yellow owl insignia patches to all uniforms " \n " " \n " " \n "- v1.13.5 " \n "  - ALL Added respective GM's to Standard Faction Compositions for convenience / time saving  " \n "  - ALL Added base clean-up module to Standard Faction Compositions to ensure Mission Makers don't forget it in the future - radius set to 200x200 meters " \n " " \n " " \n "- v1.13.4  " \n "  - ALL Added @ Squad/Team names to leaders so that Team name appears in role select " \n "  - TFN Changed M249 to the FN MINIMI " \n " " \n " " \n "- v1.13.3 " \n "  - US Added Improved Bipod/SAW Grip to AR M249 " \n "  - US Removed M14 Mags " \n "  - TFN Added Bipod to M249 " \n " " \n " " \n "- v1.13.2 " \n "  - ALL Added 1 Extra Tourniquet to every Unit " \n "  - TFN DMT Lead Rifle Changed to D10 Version " \n "  - TFN DMT given extra pistol mag to bring in line with other units " \n "  - TFN AAR Weapon changed to HK416 D14.5 " \n "  - TFN Lead Elements Given AN/PEQ-16A's " \n "  - US Alpha Fireteam 2 AAR vest changed to ALT variant to match rest of faction " \n "  - US Lead Elements Given AN/PEQ-16A's " \n "  - US DMT given extra pistol mag to bring in line with other units " \n "  - US DMT Sniper Rifle Given SU-260/P (MDO) to bring zoom level to the same as Russian and TFN factions " \n "  - US DMT Bipod Changed to Harris Bipod " \n "  - US DMT Marksman Rifle changed to black version of same rifle " \n "  - US DMT Marksman Magazines changed to SR-25 version, as RHS hotfix made M14 mags incompatible with MK11 " \n "  - RUS DMT given extra pistol mag to bring in line with other units " \n "  - RUS DGR Helmets changed to TSH-4 to make distinct from US Helmets " \n "  - RUS NB Helmets changed to ZSH-7A to make distinct from US and TFN helmets " \n "  - RUS Removed RIS Rail adaptors from AK rifles " \n "  - RUS Added PG-7V rocket to MAT ammo crate. This rocket is lighter and packs less payload than the PG-7VL. This gives it an  increased effective range but is less powerful due to decreased payload " \n " " \n " " \n "- v1.12.2 " \n "  - Hotfixed US Vests across the Squads to match V.12 changes. Whoops. " \n "  - Added Angled Grip to TFN HK416s where possible.  " \n " " \n " " \n "- v1.12 " \n "  - Fixed TFN MMG Ammo preloaded into Rifle to 100RND mag from 50rnd. " \n "  - Fixed TFN DMT Marksman Ammo loaded into Rifle to correct SBLR mag. " \n "  - Changed TFN DMT Lead Suppressor to QDSS NT4 Black from Rotex-5 Grey " \n "  - Changed TFN Dagger Uniforms from Gorka R Green to FFCP Green Fatigues [RS] " \n "  - Changed US PLT Commander + Squad Leader Vest from SPCS Rifleman/OEF- CP to SPCS Squad Lead/OEF-CP " \n "  - Changed US Medic Vest from SPCS Rifleman/OEF-CP to SPCS Medic/OEF-CP " \n "  - Changed US PLT Rifleman Vest from SPCS OEF-CP to SPCS Rifleman Alt/OEF-CP " \n "  - Changed US FTL Vest from SPCS Rifleman/OEF-CP to SPCS Team Leader Alt/OEF-CP " \n "  - Changed US AR Vest from SPCS Rifleman/OEF-CP to SPCS SAW/OEF-CP " \n "  - Changed US AAR Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP " \n "  - Changed US Rifleman AT Vest from SPCS OEF-CP to SPCS Rifleman Alt/OEF-CP " \n "  - Changed US MAT/MMG/DMT/ENG/MTR Lead Vest from SPCS Rifleman/OEF-CP to SPCS Team Leader Alt/OEF-CP " \n "  - Changed US MMG Gunner Vest from SPCS Rifleman/OEF-CP to SPCS Machinegunner/OEF-CP " \n "  - Changed US MMG/MAT Ammo Bearer Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP " \n "  - Changed US MAT Gunner Vest from SPCS OEF-CP to SPCS Rifleman Alt/OEF-CP " \n "  - Changed US DMT Marksman vest from SPCS OEF-CP to SPCS Sniper/OEF-CP " \n "  - Fixed US DMT Marksman Rifle Loaded Mag to correct varient. " \n "  - Changed US Engineer Rifleman Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP. " \n "  - Changed US MTR Gunner Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP. " \n "  - Changed US DGR Uniforms from FFCP ACU Fatigues to FFCP ACU Fatigues [RS] " \n "  - Changed US DGR Driver Backpack from Assault Pack Green to Assault Pack Black " \n "  - Changed US Heli Pilot/Copilot Uniforms from Heli pilot Coveralls to FFCP Nomad Fatigues [RS] " \n "  - Fixed US Heli/Jet Pilot Vest White Smoke grenade count to 2. " \n "  - Changed US Heli Pilot/Copilot Helmet from Heli Pilot NATO to HGU-56/P (Black/Visor) " \n "  - Changed US Jet Pilot Uniform from Pilot Coveralls NATO to  FFCP Nomad Fatigues " \n "  - Changed RUS Vic/Heli/Jet Crew Weapons to PP-2000 " \n "  - Upped RUS PP-2000 Ammo counts to 6x Mag to bring in line with ammo counts for TFN and US. " \n "  - Changed RUS Heli Pilot Uniforms from Pilot Coveralls CSAT to FFCP-Fatigues EMR [RS] " \n "  - Changed RUS Heli Pilot Vest from 6B23 (6Sh116) to FFCP Tactical Vest TigerVRS " \n "  - Changed RUS Jet Pilot Uniforms from Pilot Coveralls CSAT to FFCP-Fatigues EMR [RS] " \n "  - Changed RUS Jet Pilot Vest from 6B23 (6Sh116) to FFCP Tactical Vest TigerVRS " \n " " \n " " \n "- v1.11 " \n "  - changed m40 mini grenades to m67 fragmentation " \n "  - replaced mp7 weapons with mp5k-pdw " \n "  - changed ak105 to ak74m (plum)  " \n "  - changed PKM to PKP " \n "  - changed RUS PKM ammo boxes. MMG now loads with 7TZ (AP rounds) " \n "  - added vert grip to us weapons " \n "  - replaced m14 with HK PSG1A1 " \n "  - replaced m260e4 with mg3 " \n "  - updated all ammo boxes respectively.  " \n " " \n " " \n "- v1.10 " \n "  - changed Medic loadouts from 6 x 1000ml blood bags to 2 x 1000ml and 8 x 500ml. " \n " " \n " " \n "- v1.09 " \n "  - updated Fireteam colours A1 Red A2 Yellow, B1 Green B2 Blue, C1 Red C2 Yellow. " \n " " \n " " \n "- v1.08 " \n "  - changed ""Reaper"" to ""Nightbird"", ""RPR"" to ""NB"" " \n "  - changed ""Paladin"" to ""Falcon"", ""PAL"" to ""FC"" " \n "  - changed ""DAGGER"" to ""DGR"" " \n " " \n " " \n "- v1.07 " \n "  - US and RU faction bumped to v1.07 to avoid confusion regarding version numbers (US and RU was 1.05, TFN was 1.06) " \n "  - overhauled the RU faction: updated helmets, uniforms, weapons to a more modern look " \n "  - overhauled the US faction: updated helmets and vests to armour rating of IV " \n "  - corrected some mistakes in all factions (grenade ammount of MMG gunner, ENG not having tourniquetes, DGR not having GPS-s) " \n "  - overhauled the medics of all factions to reflect recent cahnges to ACE medical (less QuikClots, more Elastic Bandages, etc.) " \n " " \n " " \n "- v1.05 " \n "  - Added a MAT ammo box on spawn. " \n " " \n " " \n "- v1.04 " \n "  - All MAT Teams carrying RPG's got the ver3 scopes with ranges for all types " \n "    of ammo. " \n "  - All Callsigns were changed to be uniformed throught no matter the faction. " \n " " \n " " \n "- v1.03 " \n "  - set crew driver/gunner and pilot/copilot/jetpilot as Engineers through the " \n "    Object: ACE Options menu in unit attributes " \n "  - overhauled the TFN faction (weapons, helmets, etc.), changes not applicable " \n "    to derived factions " \n " " \n " " \n "- v1.02 " \n "  - loadout overhaul for DMT, made them lighter + gave them tools for recon " \n "  - specified preset ACRE2 radio channels for most units " \n " " \n " " \n "- v1.01 " \n "  - updated team colors func to `a3ee_team_colors_fnc_setColor`, just load+save " \n "    the composition in editor, this fixes it " \n "  - changed RPG-7 using MAT teams to carry Kitbags " \n "  - removed one PKM ammo box from AAR, MMG gunner, MMG bearer (fixes overload) " \n "  - moved 1-2 AR boxes from AAR to AR, gave AR an Assaultpack " \n "  - added 1-2 more AR boxes to AR's Assaultpack (if enough space) " \n "  - changed HEDP to HE rockets for Carl Gustav (M3MAAWS) " \n "  - changed US crew uniform and helmet to match grey color scheme of US pilots " \n "  - changed backpacks of driver/copilot to use less contrasting colors compared " \n "    to their respective uniform/vest colors " \n "  - changed Carryall backpacks of TFN Engineers to use custom Flecktarn Carryall " \n "  - changed all (GP-25 and normal) AK74m rifles to be the non-NPZ variants " \n "  - removed secondary long-range (PRC148) from Engineers " \n " " \n " " \n "- v1.00 (and before) " \n "  - added a Comment object with version number (`v1.00`) " \n "  - added `respawn_west`, `respawn_east`, `respawn_guerrila` markers " \n "  - added `[this, 200] call a3ee_fnc_boxGuard` to init lines of resupply boxes " \n "  - added `Resupply` green triangle markers on the position of resupply boxes";
+		description="-v1.14.2 " \n "-MMG: Changed MG3 to MG5 and corresponding ammo types " \n "-GM: Fixed ""assign zeus to this unit"" not being present" \n "-Fixed fireteam colours from A3AA update. " \n "-All Groups: Fixed radio channel presets " \n "-Gave every unit 1 epi in Uniform, or Vest if uniform was full (medic not included) " \n "-Moved element lead LR radio to backpack " \n "-Gave engineers more ammo (1 tracer + 1 for members, 2 tracer for leader) " \n "-Swap platoon boonie to ECH. " \n "-Swap DMT Marksman to ""Sniper"" class from ""Spotter"" " \n "-Added mortar supply crate " \n "-DMT: Removed NVG scope, and replaced main scope with one that can be used with goggles." \n "" \n "-v1.14.1" \n " - A3EE box guard updated to A3AA." \n " - Custom location re-added." \n "" \n "- v1.14.0 " \n "PL: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Boonie Hat"" for more visual diversity in the platoon and to bring PL headgear in line with RU and US Standard Factions. " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n "  - Removed CNTO ""Beret"" from Backpack gear due to old logo texture. " \n " " \n "Platoon Sergeant: " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n "  - Backpack added 3CB ""Radio Backpack MR3000"" and filled it with the ACRE2 ""AN/PRC-117F"" backpack radio. This gives more incentive to bring the PLT Sgt along since he is the only one who can act as a max range radio man for the platoon. " \n " " \n "Platoon Medic: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n " " \n "Platoon Rifleman: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n " " \n "Squad Medic: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n " " \n "FTL: " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n " " \n "AR: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n "  - Added muzzle attachment RHS ""SF3P-556 1/2-28"". " \n " " \n "AAR: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n " " \n "LAT: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n " " \n "MMG Teamleader: " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n " " \n "MMG Gunner: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n "  - Unfortunately no muzzle attachments available for the MG-3! " \n " " \n "MMG Asst. Gunner: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n " " \n "MAT Teamleader: " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n " " \n "MAT Gunner: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n " " \n "MAT Asst. Gunner: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n " " \n "ENG Leader: " \n "  - Uniform changed from CNTO ""Flecktarn"" to CNTO ""Flecktarn Recon"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Heavy"" to differentiate ENG from the rest of the platoon. " \n " " \n "ENG Rifleman: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Heavy"" to differentiate ENG from the rest of the platoon. " \n " " \n "Mortar Leader: " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Special"" to visually differentiate the Mortar Team from the rest of the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n "  - Reduced STANAG mags from 10 to 5 to match the ENG ammo count. " \n " " \n "Mortar Gunner: " \n "  - Helmet changed from CNTO ""Flecktarn Enhanced Combat Helmet"" to CNTO ""Flecktarn Combat Helmet"" for more visual diversity in the platoon. " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Special"" to visually differentiate the Mortar Team from the rest of the platoon. " \n "  - Rifle changed from RHS ""HK416 D14.5"" to RHS ""HK416 D10"", stats remain the same (except lighter weight) but visual weapon diversity in the platoon is increased. " \n "  - Reduced STANAG mags from 10 to 5 to match the ENG ammo count. " \n " " \n "DMT Leader " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n " " \n "DMT Marksman " \n "  - Vest changed from CNTO ""Flecktarn Carrier"" to CNTO ""Flecktarn Carrier Lite"" for more visual diversity in the platoon. " \n "  - Added NVG scope RHS ""AN/PVS-27"" to the vest gear. " \n " " \n "Zeus & Co-Zeus " \n "  - Uniform changed from vanilla ""VR Suit Indie"" to CNTO ""Flecktarn Recon"" to make Zeus look a bit more like an HQ commander than a Tron character. " \n "  - Facewear changed from vanilla ""VR Goggles"" to vanilla ""Aviator Glasses"". " \n "  - Insignia added ""Zeus"". " \n " " \n "All Units: " \n "  - Disabled LAMBS AI " \n " " \n "Alpha SL: " \n "  - Enabled ""is Player"". This makes it easier for Mission Makers to quickly test a mission in the editor by just hitting ""play"" instead of having to select a specific unit every time beforehand to avoid ending up in spectator mode by default. " \n " " \n "Crates: " \n "  - Added an ACE3 medical crate with our usual base script. " \n " " \n " " \n "- v1.13.6 " \n "  - ALL Added persistent Call-Signs for all GM's (where not included in v1.13.4) " \n "  - ALL Added the code `this disableAI ""MOVE""; this setSpeaker ""NoVoice""; enableRadio false;` to all playable units to prevent them from running off and spamming the vanilla-radio during local testing. " \n "  - ALL Changed persistent call-signs (map markers) to a consistent formula: ≤ 2 syllables = written out call-sing. ≥ 3 syllables = abbreviated call-sign. " \n "  - ALL Added full changelog to all factions for quick in-game reference " \n "  - TFN Added new yellow owl insignia patches to all uniforms " \n " " \n " " \n "- v1.13.5 " \n "  - ALL Added respective GM's to Standard Faction Compositions for convenience / time saving  " \n "  - ALL Added base clean-up module to Standard Faction Compositions to ensure Mission Makers don't forget it in the future - radius set to 200x200 meters " \n " " \n " " \n "- v1.13.4  " \n "  - ALL Added @ Squad/Team names to leaders so that Team name appears in role select " \n "  - TFN Changed M249 to the FN MINIMI " \n " " \n " " \n "- v1.13.3 " \n "  - US Added Improved Bipod/SAW Grip to AR M249 " \n "  - US Removed M14 Mags " \n "  - TFN Added Bipod to M249 " \n " " \n " " \n "- v1.13.2 " \n "  - ALL Added 1 Extra Tourniquet to every Unit " \n "  - TFN DMT Lead Rifle Changed to D10 Version " \n "  - TFN DMT given extra pistol mag to bring in line with other units " \n "  - TFN AAR Weapon changed to HK416 D14.5 " \n "  - TFN Lead Elements Given AN/PEQ-16A's " \n "  - US Alpha Fireteam 2 AAR vest changed to ALT variant to match rest of faction " \n "  - US Lead Elements Given AN/PEQ-16A's " \n "  - US DMT given extra pistol mag to bring in line with other units " \n "  - US DMT Sniper Rifle Given SU-260/P (MDO) to bring zoom level to the same as Russian and TFN factions " \n "  - US DMT Bipod Changed to Harris Bipod " \n "  - US DMT Marksman Rifle changed to black version of same rifle " \n "  - US DMT Marksman Magazines changed to SR-25 version, as RHS hotfix made M14 mags incompatible with MK11 " \n "  - RUS DMT given extra pistol mag to bring in line with other units " \n "  - RUS DGR Helmets changed to TSH-4 to make distinct from US Helmets " \n "  - RUS NB Helmets changed to ZSH-7A to make distinct from US and TFN helmets " \n "  - RUS Removed RIS Rail adaptors from AK rifles " \n "  - RUS Added PG-7V rocket to MAT ammo crate. This rocket is lighter and packs less payload than the PG-7VL. This gives it an  increased effective range but is less powerful due to decreased payload " \n " " \n " " \n "- v1.12.2 " \n "  - Hotfixed US Vests across the Squads to match V.12 changes. Whoops. " \n "  - Added Angled Grip to TFN HK416s where possible.  " \n " " \n " " \n "- v1.12 " \n "  - Fixed TFN MMG Ammo preloaded into Rifle to 100RND mag from 50rnd. " \n "  - Fixed TFN DMT Marksman Ammo loaded into Rifle to correct SBLR mag. " \n "  - Changed TFN DMT Lead Suppressor to QDSS NT4 Black from Rotex-5 Grey " \n "  - Changed TFN Dagger Uniforms from Gorka R Green to FFCP Green Fatigues [RS] " \n "  - Changed US PLT Commander + Squad Leader Vest from SPCS Rifleman/OEF- CP to SPCS Squad Lead/OEF-CP " \n "  - Changed US Medic Vest from SPCS Rifleman/OEF-CP to SPCS Medic/OEF-CP " \n "  - Changed US PLT Rifleman Vest from SPCS OEF-CP to SPCS Rifleman Alt/OEF-CP " \n "  - Changed US FTL Vest from SPCS Rifleman/OEF-CP to SPCS Team Leader Alt/OEF-CP " \n "  - Changed US AR Vest from SPCS Rifleman/OEF-CP to SPCS SAW/OEF-CP " \n "  - Changed US AAR Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP " \n "  - Changed US Rifleman AT Vest from SPCS OEF-CP to SPCS Rifleman Alt/OEF-CP " \n "  - Changed US MAT/MMG/DMT/ENG/MTR Lead Vest from SPCS Rifleman/OEF-CP to SPCS Team Leader Alt/OEF-CP " \n "  - Changed US MMG Gunner Vest from SPCS Rifleman/OEF-CP to SPCS Machinegunner/OEF-CP " \n "  - Changed US MMG/MAT Ammo Bearer Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP " \n "  - Changed US MAT Gunner Vest from SPCS OEF-CP to SPCS Rifleman Alt/OEF-CP " \n "  - Changed US DMT Marksman vest from SPCS OEF-CP to SPCS Sniper/OEF-CP " \n "  - Fixed US DMT Marksman Rifle Loaded Mag to correct varient. " \n "  - Changed US Engineer Rifleman Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP. " \n "  - Changed US MTR Gunner Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP. " \n "  - Changed US DGR Uniforms from FFCP ACU Fatigues to FFCP ACU Fatigues [RS] " \n "  - Changed US DGR Driver Backpack from Assault Pack Green to Assault Pack Black " \n "  - Changed US Heli Pilot/Copilot Uniforms from Heli pilot Coveralls to FFCP Nomad Fatigues [RS] " \n "  - Fixed US Heli/Jet Pilot Vest White Smoke grenade count to 2. " \n "  - Changed US Heli Pilot/Copilot Helmet from Heli Pilot NATO to HGU-56/P (Black/Visor) " \n "  - Changed US Jet Pilot Uniform from Pilot Coveralls NATO to  FFCP Nomad Fatigues " \n "  - Changed RUS Vic/Heli/Jet Crew Weapons to PP-2000 " \n "  - Upped RUS PP-2000 Ammo counts to 6x Mag to bring in line with ammo counts for TFN and US. " \n "  - Changed RUS Heli Pilot Uniforms from Pilot Coveralls CSAT to FFCP-Fatigues EMR [RS] " \n "  - Changed RUS Heli Pilot Vest from 6B23 (6Sh116) to FFCP Tactical Vest TigerVRS " \n "  - Changed RUS Jet Pilot Uniforms from Pilot Coveralls CSAT to FFCP-Fatigues EMR [RS] " \n "  - Changed RUS Jet Pilot Vest from 6B23 (6Sh116) to FFCP Tactical Vest TigerVRS " \n " " \n " " \n "- v1.11 " \n "  - changed m40 mini grenades to m67 fragmentation " \n "  - replaced mp7 weapons with mp5k-pdw " \n "  - changed ak105 to ak74m (plum)  " \n "  - changed PKM to PKP " \n "  - changed RUS PKM ammo boxes. MMG now loads with 7TZ (AP rounds) " \n "  - added vert grip to us weapons " \n "  - replaced m14 with HK PSG1A1 " \n "  - replaced m260e4 with mg3 " \n "  - updated all ammo boxes respectively.  " \n " " \n " " \n "- v1.10 " \n "  - changed Medic loadouts from 6 x 1000ml blood bags to 2 x 1000ml and 8 x 500ml. " \n " " \n " " \n "- v1.09 " \n "  - updated Fireteam colours A1 Red A2 Yellow, B1 Green B2 Blue, C1 Red C2 Yellow. " \n " " \n " " \n "- v1.08 " \n "  - changed ""Reaper"" to ""Nightbird"", ""RPR"" to ""NB"" " \n "  - changed ""Paladin"" to ""Falcon"", ""PAL"" to ""FC"" " \n "  - changed ""DAGGER"" to ""DGR"" " \n " " \n " " \n "- v1.07 " \n "  - US and RU faction bumped to v1.07 to avoid confusion regarding version numbers (US and RU was 1.05, TFN was 1.06) " \n "  - overhauled the RU faction: updated helmets, uniforms, weapons to a more modern look " \n "  - overhauled the US faction: updated helmets and vests to armour rating of IV " \n "  - corrected some mistakes in all factions (grenade ammount of MMG gunner, ENG not having tourniquetes, DGR not having GPS-s) " \n "  - overhauled the medics of all factions to reflect recent cahnges to ACE medical (less QuikClots, more Elastic Bandages, etc.) " \n " " \n " " \n "- v1.05 " \n "  - Added a MAT ammo box on spawn. " \n " " \n " " \n "- v1.04 " \n "  - All MAT Teams carrying RPG's got the ver3 scopes with ranges for all types " \n "    of ammo. " \n "  - All Callsigns were changed to be uniformed throught no matter the faction. " \n " " \n " " \n "- v1.03 " \n "  - set crew driver/gunner and pilot/copilot/jetpilot as Engineers through the " \n "    Object: ACE Options menu in unit attributes " \n "  - overhauled the TFN faction (weapons, helmets, etc.), changes not applicable " \n "    to derived factions " \n " " \n " " \n "- v1.02 " \n "  - loadout overhaul for DMT, made them lighter + gave them tools for recon " \n "  - specified preset ACRE2 radio channels for most units " \n " " \n " " \n "- v1.01 " \n "  - updated team colors func to `a3ee_team_colors_fnc_setColor`, just load+save " \n "    the composition in editor, this fixes it " \n "  - changed RPG-7 using MAT teams to carry Kitbags " \n "  - removed one PKM ammo box from AAR, MMG gunner, MMG bearer (fixes overload) " \n "  - moved 1-2 AR boxes from AAR to AR, gave AR an Assaultpack " \n "  - added 1-2 more AR boxes to AR's Assaultpack (if enough space) " \n "  - changed HEDP to HE rockets for Carl Gustav (M3MAAWS) " \n "  - changed US crew uniform and helmet to match grey color scheme of US pilots " \n "  - changed backpacks of driver/copilot to use less contrasting colors compared " \n "    to their respective uniform/vest colors " \n "  - changed Carryall backpacks of TFN Engineers to use custom Flecktarn Carryall " \n "  - changed all (GP-25 and normal) AK74m rifles to be the non-NPZ variants " \n "  - removed secondary long-range (PRC148) from Engineers " \n " " \n " " \n "- v1.00 (and before) " \n "  - added a Comment object with version number (`v1.00`) " \n "  - added `respawn_west`, `respawn_east`, `respawn_guerrila` markers " \n "  - added `[this, 200] call a3ee_fnc_boxGuard` to init lines of resupply boxes " \n "  - added `Resupply` green triangle markers on the position of resupply boxes";
 		id=71;
 	};
 	class Item18
@@ -15371,7 +15827,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={4.5251465,0.0014390945,-3.9338379};
+					position[]={4.409668,0.0014390945,-3.8759766};
 				};
 				side="Independent";
 				flags=7;
@@ -15614,7 +16070,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={5.5251465,0.0014390945,-3.9338379};
+					position[]={5.409668,0.0014390945,-3.8759766};
 				};
 				side="Independent";
 				flags=5;
@@ -15886,7 +16342,7 @@ class items
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={7.4372559,0,-3.6154785};
+			position[]={7.3217773,0,-3.5576172};
 		};
 		side="Empty";
 		flags=4;
@@ -15925,7 +16381,7 @@ class items
 		dataType="Logic";
 		class PositionInfo
 		{
-			position[]={-0.16674805,0,-0.077392578};
+			position[]={-0.28173828,0,-0.01953125};
 		};
 		areaSize[]={200,-1,200};
 		areaIsRectangle=1;
@@ -15999,14 +16455,14 @@ class items
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={7.0439453,0.18872452,-9.9887695};
+			position[]={6.9287109,0.18872452,-9.9309082};
 		};
 		side="Empty";
 		flags=4;
 		class Attributes
 		{
 		};
-		id=85;
+		id=77;
 		type="Box_IND_Wps_F";
 		class CustomAttributes
 		{


### PR DESCRIPTION
TFN:
-v1.14.2
-MMG: Changed MG3 to MG5 and corresponding ammo types
-GM: Fixed "assign zeus to this unit" not being present
-All Groups: Fixed radio channel presets
-Fix fireteam colours
-Gave every unit 1 epi in Uniform, or Vest if uniform was full (medic not included)
-Moved element lead LR radio to backpack
-Gave engineers more ammo (1 tracer + 1 for members, 2 tracer for leader)
-Swap platoon boonie to ECH.
-Swap DMT Marksman to "Sniper" class from "Spotter"
-Added mortar supply crate
-DMT: Removed NVG scope, and replaced main scope with one that can be used with goggles.

PMC:
-v1.14.2
-GM: Fixed "assign zeus to this unit" not being present
-All Groups: Fixed radio channel presets
-Fix fireteam colours
-Gave every unit 1 epi in Uniform, or Vest if uniform was full (medic not included)
-Moved element lead LR radio to backpack
-Added mortar supply crate
-DMT: Removed NVG scope, and replaced main scope with one that can be used with goggles.
-Gave engineers more ammo (1 tracer + 1 for members, 2 tracer for leader)

Fix #117 Fix #114 Fix #113 Fix #110 Fix #107 Fix #106 Fix #95 Fix #86 Fix #83 Fix #82 Fix #77 Fix #94 
