### PR TITLE
US Army Update v1.14.2

### DIFF
--- a/reference/US%20Army/composition.sqe
+++ b/reference/US%20Army/composition.sqe
@@ -1,5 +1,5 @@
 version=53;
-center[]={3166.6851,5,6658.1196};
+center[]={3964.76,5,959.98376};
 class items
 {
 	items=22;
@@ -8,7 +8,7 @@ class items
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={7.6958008,0.28405476,-6.8476563};
+			position[]={7.5751953,0.28405476,-6.7614746};
 		};
 		side="Empty";
 		flags=4;
@@ -49,7 +49,7 @@ class items
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={5.7749023,0.14963102,-7.8720703};
+			position[]={5.6542969,0.14963102,-7.7858887};
 			angles[]={-0,1.5258367,0};
 		};
 		side="Empty";
@@ -90,7 +90,7 @@ class items
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={7.8789063,0.89242268,-9.3217773};
+			position[]={7.7578125,0.89242268,-9.2355957};
 		};
 		side="Empty";
 		flags=4;
@@ -129,7 +129,7 @@ class items
 	class Item3
 	{
 		dataType="Marker";
-		position[]={2.0783691,2.4371225e+032,-4.7963867};
+		position[]={1.9575195,2.4371225e+032,-4.7102051};
 		name="respawn_west";
 		type="respawn_unknown";
 		angle=359.38086;
@@ -139,7 +139,7 @@ class items
 	class Item4
 	{
 		dataType="Marker";
-		position[]={6.9367676,0,-7.9663086};
+		position[]={6.815918,0,-7.880127};
 		name="resupply_marker_4";
 		text="Resupply";
 		type="mil_triangle";
@@ -151,10 +151,10 @@ class items
 		dataType="Comment";
 		class PositionInfo
 		{
-			position[]={4.1574707,0.001999855,-6.0517578};
+			position[]={4.0371094,0.001999855,-5.9657593};
 		};
-		title="v1.14.1";
-		description="-v1.14.1" \n " - A3EE box guard updated to A3AA." \n " - Custom location re-added." \n "" \n "- v1.14.0" \n "PL: " \n "- Backpack changed from vanilla ""Assault Pack MTP"" to vanilla ""Assault Pack Coyote"" for more visual contrast. Carry capacity remains the same. " \n "- Rifle changed from RHS ""M4A1 (M203s)"" to RHS ""M16A4 (Carryhandle/M203)"" for increased for increased weapon diversity in the platoon. PL has now a more accurate long-range shooting platform. " \n "- Mags changed from RHS ""30Rnd STANAG M855A1"" to RHS ""30Rnd PMAG M855A1"" and from RHS ""30Rnd STANAG M856A1 (tracer)"" to RHS ""30Rnd PMAG M856A1 (tracer)"" for increased visual fidelity. " \n " " \n "Platoon Sergeant: " \n "- Helmet changed from vanilla ""Enhanced Combat Helmet (desert)"" to RHS ""ACH (tan/headset/ESS)"" to indicate association with platoon lead element and for more visual diversity in the platoon. " \n "- Backpack added 3CB ""Radio Backpack MR3000"" and filled it with the ACRE2 ""AN/PRC-117F"" backpack radio. This gives more incentive to bring the PLT Sgt along since he is the only one who can act as a max range radio man for the platoon. " \n "- Mags changed from RHS ""30Rnd STANAG M855A1"" to RHS ""30Rnd PMAG M855A1"" and from RHS ""30Rnd STANAG M856A1 (tracer)"" to RHS ""30Rnd PMAG M856A1 (tracer)"" for increased visual fidelity. " \n " " \n "Platoon Medic: " \n "- Helmet changed from vanilla ""Enhanced Combat Helmet (desert)"" to RHS ""ACH (tan)"" to indicate association with platoon lead element and for more visual diversity in the platoon. " \n "- Backpack changed from vanilla ""Kitbag MTP"" to vanilla ""Kitbag Coyote"" for more visual contrast. Carry capacity remains the same. " \n "- Mags changed from RHS ""30Rnd STANAG M855A1"" to RHS ""30Rnd PMAG M855A1"" and from RHS ""30Rnd STANAG M856A1 (tracer)"" to RHS ""30Rnd PMAG M856A1 (tracer)"" for increased visual fidelity. " \n " " \n "Platoon Rifleman: " \n "- Helmet changed from vanilla ""Enhanced Combat Helmet (desert)"" to RHS ""ACH (tan/ESS)"" to indicate association with platoon lead element and for more visual diversity in the platoon. " \n "- Rifle changed from RHS ""M4A1 PIP"" to RHS ""M16A4 (Carryhandle)"" for increased weapon diversity in the platoon. More accurate shooting platform to compensate the lack of interesting weaponry such as a LAT, an AR or a grenade launcher. " \n "- Mags changed from RHS ""30Rnd STANAG M855A1"" to RHS ""30Rnd PMAG M855A1"" and from RHS ""30Rnd STANAG M856A1 (tracer)"" to RHS ""30Rnd PMAG M856A1 (tracer)"" for increased visual fidelity. " \n " " \n "SL: " \n "- Helmet changed from vanilla ""Enhanced Combat Helmet (desert)"" to RHS ""ACH OEF-CP (Headset/ESS/Alt)"". " \n "- Backpack changed from vanilla ""Assault Pack MTP"" to vanilla ""Assault Pack Coyote"" for more visual contrast. Carry capacity remains the same. " \n "- Rifle changed from RHS ""M4A1 (M203s)"" to RHS ""M16A4 (Carryhandle/M203)"" for increased for increased weapon diversity in the platoon. SL has now a more accurate long-range shooting platform. " \n "- Mags changed from RHS ""30Rnd STANAG M855A1"" to RHS ""30Rnd PMAG M855A1"" and from RHS ""30Rnd STANAG M856A1 (tracer)"" to RHS ""30Rnd PMAG M856A1 (tracer)"" for increased visual fidelity. " \n " " \n "Medic: " \n "- Helmet changed from vanilla ""Enhanced Combat Helmet (desert)"" to RHS ""ACH OEF-CP (Alt)"". " \n "- Backpack changed from vanilla ""Kitbag MTP"" to vanilla ""Kitbag Coyote"" for more visual contrast. Carry capacity remains the same. " \n "- Mags changed from RHS ""30Rnd STANAG M855A1"" to RHS ""30Rnd PMAG M855A1"" and from RHS ""30Rnd STANAG M856A1 (tracer)"" to RHS ""30Rnd PMAG M856A1 (tracer)"" for increased visual fidelity. " \n " " \n "FTL: " \n "- Helmet changed from vanilla ""Enhanced Combat Helmet (desert)"" to RHS ""ACH OEF-CP (Headset/ESS/Alt)"". " \n "- Vest changed from RHS ""SPCS (Team Leader Alt/OEF-CP)"" to RHS ""SPCS (Grenadier/OEF-CP)"" for more visual diversity in the platoon. Carry capacity remains the same. " \n "- Backpack changed from vanilla ""Assault Pack MTP"" to vanilla ""Assault Pack Coyote"" for more visual contrast. Carry capacity remains the same. " \n "- Mags changed from RHS ""30Rnd STANAG M855A1"" to RHS ""30Rnd PMAG M855A1"" and from RHS ""30Rnd STANAG M856A1 (tracer)"" to RHS ""30Rnd PMAG M856A1 (tracer)"" for increased visual fidelity. " \n " " \n "AR: " \n "- Helmet changed from vanilla ""Enhanced Combat Helmet (desert)"" to RHS ""ACH OEF-CP (ESS/Alt)"" or RHS ""ACH OEF-CP (Alt)"". Both helmets are given out semi-randomly to increase visual variety in the platoon. " \n "- Backpack changed from vanilla ""Assault Pack MTP"" to vanilla ""Assault Pack Coyote"" for more visual contrast. Carry capacity remains the same. " \n "- Added muzzle attachment RHS ""SFMB-556 1/2-28"". " \n " " \n "AAR: " \n "- Helmet changed from vanilla ""Enhanced Combat Helmet (desert)"" to RHS ""ACH OEF-CP (Headset/Alt)"". " \n "- Vest changed from RHS ""SPCS (Rifleman Alt/OEF-CP)"" to RHS ""SPCS (Team Leader/OEF-CP)"" for more visual diversity in the platoon. Carry capacity remains the same. " \n "- Backpack changed from vanilla ""Kitbag MTP"" to vanilla ""Kitbag Coyote"" for more visual contrast. Carry capacity remains the same. " \n "- Rifle changed from RHS ""M4A1 PIP"" to RHS ""M16A4 (Carryhandle)"" for increased weapon diversity in the platoon. More accurate shooting platform to compensate the lack of interesting weaponry such as a LAT, an AR or a grenade launcher. " \n "- Mags changed from RHS ""30Rnd STANAG M855A1"" to RHS ""30Rnd PMAG M855A1"" and from RHS ""30Rnd STANAG M856A1 (tracer)"" to RHS ""30Rnd PMAG M856A1 (tracer)"" for increased visual fidelity. " \n " " \n "LAT: " \n "- Helmet changed from vanilla ""Enhanced Combat Helmet (desert)"" to RHS ""ACH OEF-CP (ESS/Alt)"" or RHS ""ACH OEF-CP (Alt)"". Both helmets are given out semi-randomly to increase visual variety in the platoon. " \n "- Mags changed from RHS ""30Rnd STANAG M855A1"" to RHS ""30Rnd PMAG M855A1"" and from RHS ""30Rnd STANAG M856A1 (tracer)"" to RHS ""30Rnd PMAG M856A1 (tracer)"" for increased visual fidelity. " \n " " \n "MMG Teamleader: " \n "- Helmet changed from vanilla ""Enhanced Combat Helmet (desert)"" to RHS ""ACH OEF-CP (Headset/Alt)"". " \n "- Backpack changed from vanilla ""Assault Pack MTP"" to vanilla ""Assault Pack Coyote"" for more visual contrast. Carry capacity remains the same. " \n "- Mags changed from RHS ""30Rnd STANAG M855A1"" to RHS ""30Rnd PMAG M855A1"" and from RHS ""30Rnd STANAG M856A1 (tracer)"" to RHS ""30Rnd PMAG M856A1 (tracer)"" for increased visual fidelity. " \n " " \n "MMG Gunner: " \n "- Helmet changed from vanilla ""Enhanced Combat Helmet (desert)"" to RHS ""ACH OEF-CP (ESS/Alt)""." \n "- Backpack changed from vanilla ""Kitbag MTP"" to vanilla ""Kitbag Coyote"" for more visual contrast. Carry capacity remains the same. " \n "- Added muzzle attachment RHS ""ARDEC 4-Prong"". " \n " " \n "MMG Asst. Gunner: " \n "- Helmet changed from vanilla ""Enhanced Combat Helmet (desert)"" to RHS ""ACH OEF-CP (Alt)"". " \n "- Backpack changed from vanilla ""Kitbag MTP"" to vanilla ""Kitbag Coyote"" for more visual contrast. Carry capacity remains the same. " \n "- Mags changed from RHS ""30Rnd STANAG M855A1"" to RHS ""30Rnd PMAG M855A1"" and from RHS ""30Rnd STANAG M856A1 (tracer)"" to RHS ""30Rnd PMAG M856A1 (tracer)"" for increased visual fidelity. " \n " " \n "MAT Teamleader: " \n "- Helmet changed from vanilla ""Enhanced Combat Helmet (desert)"" to RHS ""ACH OEF-CP (Headset/Alt)"". " \n "- Backpack changed from vanilla ""Assault Pack MTP"" to vanilla ""Assault Pack Coyote"" for more visual contrast. Carry capacity remains the same. " \n "- Mags changed from RHS ""30Rnd STANAG M855A1"" to RHS ""30Rnd PMAG M855A1"" and from RHS ""30Rnd STANAG M856A1 (tracer)"" to RHS ""30Rnd PMAG M856A1 (tracer)"" for increased visual fidelity. " \n " " \n "MAT Gunner: " \n "- Helmet changed from vanilla ""Enhanced Combat Helmet (desert)"" to RHS ""ACH OEF-CP (ESS/Alt)""." \n "- Vest changed from RHS ""SPCS (Rifleman Alt/OEF-CP)"" to RHS ""SPCS (OEF-CP)"" for more visual diversity in the platoon. Carry capacity remains the same. " \n "- Backpack changed from vanilla ""Kitbag MTP"" to vanilla ""Kitbag Coyote"" for more visual contrast. Carry capacity remains the same. " \n "- Mags changed from RHS ""30Rnd STANAG M855A1"" to RHS ""30Rnd PMAG M855A1"" and from RHS ""30Rnd STANAG M856A1 (tracer)"" to RHS ""30Rnd PMAG M856A1 (tracer)"" for increased visual fidelity. " \n " " \n "MAT Asst. Gunner: " \n "- Helmet changed from vanilla ""Enhanced Combat Helmet (desert)"" to RHS ""ACH OEF-CP (Alt)"". " \n "- Backpack changed from vanilla ""Kitbag MTP"" to vanilla ""Kitbag Coyote"" for more visual contrast. Carry capacity remains the same. " \n "- Mags changed from RHS ""30Rnd STANAG M855A1"" to RHS ""30Rnd PMAG M855A1"" and from RHS ""30Rnd STANAG M856A1 (tracer)"" to RHS ""30Rnd PMAG M856A1 (tracer)"" for increased visual fidelity. " \n " " \n "ENG Leader: " \n "- Helmet changed from vanilla ""Enhanced Combat Helmet (desert)"" to RHS ""ACH OEF-CP (Headset/ESS/Alt)"". " \n "- Vest changed from RHS ""SPCS (Team Leader Alt/OEF-CP)"" to vanilla ""Carrier GL Rig (green)"" for a bulkier look to visually distinguish EOD/ENG from the rest of the platoon. " \n "- Backpack changed from vanilla ""Carryall MTP"" to vanilla ""Carryall Coyote"" for more visual contrast. Carry capacity remains the same. " \n "- Mags changed from RHS ""30Rnd STANAG M855A1"" to RHS ""30Rnd PMAG M855A1"" and from RHS ""30Rnd STANAG M856A1 (tracer)"" to RHS ""30Rnd PMAG M856A1 (tracer)"" for increased visual fidelity. " \n " " \n "ENG Rifleman: " \n "- Helmet changed from vanilla ""Enhanced Combat Helmet (desert)"" to RHS ""ACH OEF-CP (Headset/Alt)"". " \n "- Vest changed from RHS ""SPCS (Team Leader Alt/OEF-CP)"" to vanilla ""Carrier GL Rig (green)"" for a bulkier look to visually distinguish EOD/ENG from the rest of the platoon. " \n "- Backpack changed from vanilla ""Carryall MTP"" to vanilla ""Carryall Coyote"" for more visual contrast. Carry capacity remains the same. " \n "- Mags changed from RHS ""30Rnd STANAG M855A1"" to RHS ""30Rnd PMAG M855A1"" and from RHS ""30Rnd STANAG M856A1 (tracer)"" to RHS ""30Rnd PMAG M856A1 (tracer)"" for increased visual fidelity. " \n " " \n "Mortar Leader: " \n "- Helmet changed from vanilla ""Enhanced Combat Helmet (desert)"" to RHS ""ACH OEF-CP (Headset/Alt)"". " \n "- Mags changed from RHS ""30Rnd STANAG M855A1"" to RHS ""30Rnd PMAG M855A1"" and from RHS ""30Rnd STANAG M856A1 (tracer)"" to RHS ""30Rnd PMAG M856A1 (tracer)"" for increased visual fidelity. " \n " " \n "Mortar Gunner: " \n "- Helmet changed from vanilla ""Enhanced Combat Helmet (desert)"" to RHS ""ACH OEF-CP (Alt)"". " \n "- Vest changed from RHS ""SPCS (Rifleman Alt/OEF-CP)"" to RHS ""SPCS (SAW/OEF-CP)"" for more visual diversity in the platoon. Carry capacity remains the same. " \n "- Mags changed from RHS ""30Rnd STANAG M855A1"" to RHS ""30Rnd PMAG M855A1"" and from RHS ""30Rnd STANAG M856A1 (tracer)"" to RHS ""30Rnd PMAG M856A1 (tracer)"" for increased visual fidelity. " \n " " \n "DGR Commander: " \n "- Helmet changed from RHS ""ACVC-H MK-1697"" to RHS ""ACVC-H MK-1697 (ESS)"" to better visually indicate the element leader. " \n "- Rifle changed from vanilla ""Scorpion Evo 3 A1"" to NiArms ""H&K MP5A3"" to bring weaponry visually more in line with the rest of the platoon.  " \n " " \n "DGR Gunner & Driver: " \n "- Rifle changed from vanilla ""Scorpion Evo 3 A1"" to NiArms ""H&K MP5A3"" to bring weaponry visually more in line with the rest of the platoon.  " \n " " \n "DMT Marksman " \n "- Rifle scope changed from RH ""Leopold Mark 4 LR/T"" to RHS ""M8541A SSDS"" for more visual conformity with NVG variant of the same scope. Note: max. zoom is reduced from x20 to x15 however the Marksman gains a MRDS sight for CQB. " \n "- Added scope RHS ""M8541A + AN/PVS-27"" to the vest gear. This is the NVG version of the regular scope. " \n " " \n "Nightbird Pilot & Co-Pilot: " \n "- Rifle changed from vanilla ""Scorpion Evo 3 A1"" to NiArms ""H&K MP5A3"" to bring weaponry visually more in line with the rest of the platoon.  " \n " " \n "Falcon Pilot: " \n "- Rifle changed from vanilla ""Scorpion Evo 3 A1"" to NiArms ""H&K MP5A3"" to bring weaponry visually more in line with the rest of the platoon.  " \n " " \n "Zeus & Co-Zeus " \n "- Uniform changed from vanilla ""VR Suit NATO"" to RHS ""Combat Uniform OCP"" to make Zeus look a bit more like an HQ commander than a Tron character. " \n "- Headgear added RHS ""Patrol Cap OEF-CP"". " \n "- Facewear changed from vanilla ""VR Goggles"" to vanilla ""Aviator Glasses"". " \n "- Insignia added ""Zeus"". " \n " " \n "All Units: " \n "- Disabled LAMBS AI " \n " " \n "Alpha SL: " \n "- Enabled ""is Player"". This makes it easier for Mission Makers to quickly test a mission in the editor by just hitting ""play"" instead of having to select a specific unit every time beforehand to avoid ending up in spectator mode by default.  " \n " " \n "Crates: " \n "- Added an ACE3 medical crate with our usual base script." \n "" \n "" \n "-v1.13.6" \n "  - ALL Added persistent Call-Signs for all GM's (where not included in v1.13.4)" \n "  - ALL Added the code`this disableAI ""MOVE""; this setSpeaker ""NoVoice""; enableRadio false;` to all playable units to prevent them from running off and spamming the vanilla-radio during local testing." \n "  - ALL Changed persistent call-signs (map markers) to a consistent formula: ≤ 2 syllables = written out call-sing. ≥ 3 syllables = abbreviated call-sign." \n "  - ALL Added full changelog to all factions for quick in-game reference" \n "  - TFN Added new yellow owl insignia patches to all uniforms" \n "" \n "- v1.13.5" \n "  - ALL Added respective GM's to Standard Faction Compositions for convenience / time saving " \n "  - ALL Added base clean-up module to Standard Faction Compositions to ensure Mission Makers don't forget it in the future - radius set to 200x200 meters" \n "" \n "- v1.13.4 " \n "  - ALL Added @ Squad/Team names to leaders so that Team name appears in role select" \n "  - TFN Changed M249 to the FN MINIMI" \n "" \n "- v1.13.3" \n "  - US Added Improved Bipod/SAW Grip to AR M249" \n "  - US Removed M14 Mags" \n "  - TFN Added Bipod to M249" \n "" \n "- v1.13.2" \n "  - ALL Added 1 Extra Tourniquet to every Unit" \n "  - TFN DMT Lead Rifle Changed to D10 Version" \n "  - TFN DMT given extra pistol mag to bring in line with other units" \n "  - TFN AAR Weapon changed to HK416 D14.5" \n "  - TFN Lead Elements Given AN/PEQ-16A's" \n "  - US Alpha Fireteam 2 AAR vest changed to ALT variant to match rest of faction" \n "  - US Lead Elements Given AN/PEQ-16A's" \n "  - US DMT given extra pistol mag to bring in line with other units" \n "  - US DMT Sniper Rifle Given SU-260/P (MDO) to bring zoom level to the same as Russian and TFN factions" \n "  - US DMT Bipod Changed to Harris Bipod" \n "  - US DMT Marksman Rifle changed to black version of same rifle" \n "  - US DMT Marksman Magazines changed to SR-25 version, as RHS hotfix made M14 mags incompatible with MK11" \n "  - RUS DMT given extra pistol mag to bring in line with other units" \n "  - RUS DGR Helmets changed to TSH-4 to make distinct from US Helmets" \n "  - RUS NB Helmets changed to ZSH-7A to make distinct from US and TFN helmets" \n "  - RUS Removed RIS Rail adaptors from AK rifles" \n "  - RUS Added PG-7V rocket to MAT ammo crate. This rocket is lighter and packs less payload than the PG-7VL. This gives it an  increased effective range but is less powerful due to decreased payload" \n "" \n "- v1.12.2" \n "  - Hotfixed US Vests across the Squads to match V.12 changes. Whoops." \n "  - Added Angled Grip to TFN HK416s where possible. " \n "" \n "- v1.12" \n "  - Fixed TFN MMG Ammo preloaded into Rifle to 100RND mag from 50rnd." \n "  - Fixed TFN DMT Marksman Ammo loaded into Rifle to correct SBLR mag." \n "  - Changed TFN DMT Lead Suppressor to QDSS NT4 Black from Rotex-5 Grey" \n "  - Changed TFN Dagger Uniforms from Gorka R Green to FFCP Green Fatigues [RS]" \n "  - Changed US PLT Commander + Squad Leader Vest from SPCS Rifleman/OEF- CP to SPCS Squad Lead/OEF-CP" \n "  - Changed US Medic Vest from SPCS Rifleman/OEF-CP to SPCS Medic/OEF-CP" \n "  - Changed US PLT Rifleman Vest from SPCS OEF-CP to SPCS Rifleman Alt/OEF-CP" \n "  - Changed US FTL Vest from SPCS Rifleman/OEF-CP to SPCS Team Leader Alt/OEF-CP" \n "  - Changed US AR Vest from SPCS Rifleman/OEF-CP to SPCS SAW/OEF-CP" \n "  - Changed US AAR Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP" \n "  - Changed US Rifleman AT Vest from SPCS OEF-CP to SPCS Rifleman Alt/OEF-CP" \n "  - Changed US MAT/MMG/DMT/ENG/MTR Lead Vest from SPCS Rifleman/OEF-CP to SPCS Team Leader Alt/OEF-CP" \n "  - Changed US MMG Gunner Vest from SPCS Rifleman/OEF-CP to SPCS Machinegunner/OEF-CP" \n "  - Changed US MMG/MAT Ammo Bearer Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP" \n "  - Changed US MAT Gunner Vest from SPCS OEF-CP to SPCS Rifleman Alt/OEF-CP" \n "  - Changed US DMT Marksman vest from SPCS OEF-CP to SPCS Sniper/OEF-CP" \n "  - Fixed US DMT Marksman Rifle Loaded Mag to correct varient." \n "  - Changed US Engineer Rifleman Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP." \n "  - Changed US MTR Gunner Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP." \n "  - Changed US DGR Uniforms from FFCP ACU Fatigues to FFCP ACU Fatigues [RS]" \n "  - Changed US DGR Driver Backpack from Assault Pack Green to Assault Pack Black" \n "  - Changed US Heli Pilot/Copilot Uniforms from Heli pilot Coveralls to FFCP Nomad Fatigues [RS]" \n "  - Fixed US Heli/Jet Pilot Vest White Smoke grenade count to 2." \n "  - Changed US Heli Pilot/Copilot Helmet from Heli Pilot NATO to HGU-56/P (Black/Visor)" \n "  - Changed US Jet Pilot Uniform from Pilot Coveralls NATO to  FFCP Nomad Fatigues" \n "  - Changed RUS Vic/Heli/Jet Crew Weapons to PP-2000" \n "  - Upped RUS PP-2000 Ammo counts to 6x Mag to bring in line with ammo counts for TFN and US." \n "  - Changed RUS Heli Pilot Uniforms from Pilot Coveralls CSAT to FFCP-Fatigues EMR [RS]" \n "  - Changed RUS Heli Pilot Vest from 6B23 (6Sh116) to FFCP Tactical Vest TigerVRS" \n "  - Changed RUS Jet Pilot Uniforms from Pilot Coveralls CSAT to FFCP-Fatigues EMR [RS]" \n "  - Changed RUS Jet Pilot Vest from 6B23 (6Sh116) to FFCP Tactical Vest TigerVRS" \n "" \n "- v1.11" \n "  - changed m40 mini grenades to m67 fragmentation" \n "  - replaced mp7 weapons with mp5k-pdw" \n "  - changed ak105 to ak74m (plum) " \n "  - changed PKM to PKP" \n "  - changed RUS PKM ammo boxes. MMG now loads with 7TZ (AP rounds)" \n "  - added vert grip to us weapons" \n "  - replaced m14 with HK PSG1A1" \n "  - replaced m260e4 with mg3" \n "  - updated all ammo boxes respectively. " \n "" \n "- v1.10" \n "  - changed Medic loadouts from 6 x 1000ml blood bags to 2 x 1000ml and 8 x 500ml." \n "" \n "- v1.09" \n "  - updated Fireteam colours A1 Red A2 Yellow, B1 Green B2 Blue, C1 Red C2 Yellow." \n "" \n "- v1.08" \n "  - changed ""Reaper"" to ""Nightbird"", ""RPR"" to ""NB""" \n "  - changed ""Paladin"" to ""Falcon"", ""PAL"" to ""FC""" \n "  - changed ""DAGGER"" to ""DGR""" \n "" \n "- v1.07" \n "  - US and RU faction bumped to v1.07 to avoid confusion regarding version numbers (US and RU was 1.05, TFN was 1.06)" \n "  - overhauled the RU faction: updated helmets, uniforms, weapons to a more modern look" \n "  - overhauled the US faction: updated helmets and vests to armour rating of IV" \n "  - corrected some mistakes in all factions (grenade ammount of MMG gunner, ENG not having tourniquetes, DGR not having GPS-s)" \n "  - overhauled the medics of all factions to reflect recent cahnges to ACE medical (less QuikClots, more Elastic Bandages, etc.)" \n "" \n "- v1.05" \n "  - Added a MAT ammo box on spawn." \n "" \n "- v1.04" \n "  - All MAT Teams carrying RPG's got the ver3 scopes with ranges for all types" \n "    of ammo." \n "  - All Callsigns were changed to be uniformed throught no matter the faction." \n "" \n "- v1.03" \n "  - set crew driver/gunner and pilot/copilot/jetpilot as Engineers through the" \n "    Object: ACE Options menu in unit attributes" \n "  - overhauled the TFN faction (weapons, helmets, etc.), changes not applicable" \n "    to derived factions" \n "" \n "- v1.02" \n "  - loadout overhaul for DMT, made them lighter + gave them tools for recon" \n "  - specified preset ACRE2 radio channels for most units" \n "" \n "- v1.01" \n "  - updated team colors func to `a3ee_team_colors_fnc_setColor`, just load+save" \n "    the composition in editor, this fixes it" \n "  - changed RPG-7 using MAT teams to carry Kitbags" \n "  - removed one PKM ammo box from AAR, MMG gunner, MMG bearer (fixes overload)" \n "  - moved 1-2 AR boxes from AAR to AR, gave AR an Assaultpack" \n "  - added 1-2 more AR boxes to AR's Assaultpack (if enough space)" \n "  - changed HEDP to HE rockets for Carl Gustav (M3MAAWS)" \n "  - changed US crew uniform and helmet to match grey color scheme of US pilots" \n "  - changed backpacks of driver/copilot to use less contrasting colors compared" \n "    to their respective uniform/vest colors" \n "  - changed Carryall backpacks of TFN Engineers to use custom Flecktarn Carryall" \n "  - changed all (GP-25 and normal) AK74m rifles to be the non-NPZ variants" \n "  - removed secondary long-range (PRC148) from Engineers" \n "" \n "- v1.00 (and before)" \n "  - added a Comment object with version number (`v1.00`)" \n "  - added `respawn_west`, `respawn_east`, `respawn_guerrila` markers" \n "  - added `[this, 200] call a3ee_fnc_boxGuard` to init lines of resupply boxes" \n "  - added `Resupply` green triangle markers on the position of resupply boxes";
+		title="v1.14.2";
+		description="- v1.14.2" \n "" \n "PL: " \n "- Headgear changed from RHS ""Patrol Cap OEF-CP"" to RHS ""ACH OEF-CP (Headset/Alt)"" to give leader a helmet (issue #82). " \n "- Uniform content: moved radios 152 & 148 to backpack (issue #95). " \n " " \n "Platoon Sergeant: " \n "- Headgear changed from RHS ""ACH (Tan/Headset/ESS)"" to RHS ""ACH OEF-CP (Headset/Alt)"" to fit the rest of the platoon (issue #112). " \n " " \n "Platoon Medic: " \n "- Headgear changed from RHS ""ACH (Tan)"" to RHS ""ACH OEF-CP (Alt)"" to fit the rest of the platoon (issue #112). " \n " " \n "Platoon Rifleman: " \n "- Headgear changed from RHS ""ACH (Tan/ESS)"" to RHS ""ACH OEF-CP (ESS/Alt)"" to fit the rest of the platoon (issue #112). " \n " " \n "SL: " \n "- Uniform content: moved radio 152 to backpack (issue #95). " \n " " \n "MMG Leader: " \n "- Uniform content: moved radio 152 to backpack (issue #95). " \n " " \n "MAT Leader: " \n "- Uniform content: moved radio 152 to backpack (issue #95). " \n " " \n "MAT Gunner: " \n "- Launcher replaced with TFN ""MAAWS Mk4 Mod 0 (olive)"" Launcher (issue #90). " \n " " \n "ENG Leader: " \n "- Uniform content: moved radio 152 to backpack (issue #95). " \n "- Backpack content: changed ammo count to 4 regular mags and 2 tracer mag (issue #83). " \n " " \n "ENG Rifleman: " \n "- Backpack content: changed ammo count to 5 regular mags and 1 tracer mag (issue #83). " \n " " \n "DMT Marksman: " \n "- Soldier class changed from ""B_spotter_F"" to ""B_soldier_M_F"" (issue #94). " \n " " \n "MTR Leader: " \n "- Vest content: changed ammo count to 5 regular mags and 1 tracer mag (issue #83). " \n " " \n "MTR Gunner: " \n "- Vest content: changed ammo count to 5 regular mags and 1 tracer mag (issue #83). " \n " " \n "Zeus: " \n "- Fixed missing Zeus status (issue #113). " \n " " \n "PLT & SQD Medic, Rifleman, LAT, MMG Ammo Bearer, MAT Gunner, MAT Ammo Bearer, Engineer: " \n "- Uniform content: added 1x Pistolmag to ensure Riflemags do not get split across uniform and vest (uniform container always gets filled first by the game). " \n " " \n "All Units: " \n "- Fixed missing standard ACRE2 radio channels (issue #110). " \n "- Uniform content: added 1x epinephrine (issue #107) and sorted all items in a more logical manner (issue #111). " \n "- Vest content: sorted all items in a more logical manner (issue #111). " \n "- Backpack content: sorted all items in a more logical manner (issue #111). " \n "- Fireteam members: fixed ST HUD colours for fireteam members of Alpha, Bravo and Charlie (issue #117). " \n " " \n "Crates: " \n "- Added a mortar supply crate (issue #77)." \n "" \n "" \n "-v1.14.1" \n " - A3EE box guard updated to A3AA." \n " - Custom location re-added." \n "" \n "- v1.14.0" \n "PL: " \n "- Backpack changed from vanilla ""Assault Pack MTP"" to vanilla ""Assault Pack Coyote"" for more visual contrast. Carry capacity remains the same. " \n "- Rifle changed from RHS ""M4A1 (M203s)"" to RHS ""M16A4 (Carryhandle/M203)"" for increased for increased weapon diversity in the platoon. PL has now a more accurate long-range shooting platform. " \n "- Mags changed from RHS ""30Rnd STANAG M855A1"" to RHS ""30Rnd PMAG M855A1"" and from RHS ""30Rnd STANAG M856A1 (tracer)"" to RHS ""30Rnd PMAG M856A1 (tracer)"" for increased visual fidelity. " \n " " \n "Platoon Sergeant: " \n "- Helmet changed from vanilla ""Enhanced Combat Helmet (desert)"" to RHS ""ACH (tan/headset/ESS)"" to indicate association with platoon lead element and for more visual diversity in the platoon. " \n "- Backpack added 3CB ""Radio Backpack MR3000"" and filled it with the ACRE2 ""AN/PRC-117F"" backpack radio. This gives more incentive to bring the PLT Sgt along since he is the only one who can act as a max range radio man for the platoon. " \n "- Mags changed from RHS ""30Rnd STANAG M855A1"" to RHS ""30Rnd PMAG M855A1"" and from RHS ""30Rnd STANAG M856A1 (tracer)"" to RHS ""30Rnd PMAG M856A1 (tracer)"" for increased visual fidelity. " \n " " \n "Platoon Medic: " \n "- Helmet changed from vanilla ""Enhanced Combat Helmet (desert)"" to RHS ""ACH (tan)"" to indicate association with platoon lead element and for more visual diversity in the platoon. " \n "- Backpack changed from vanilla ""Kitbag MTP"" to vanilla ""Kitbag Coyote"" for more visual contrast. Carry capacity remains the same. " \n "- Mags changed from RHS ""30Rnd STANAG M855A1"" to RHS ""30Rnd PMAG M855A1"" and from RHS ""30Rnd STANAG M856A1 (tracer)"" to RHS ""30Rnd PMAG M856A1 (tracer)"" for increased visual fidelity. " \n " " \n "Platoon Rifleman: " \n "- Helmet changed from vanilla ""Enhanced Combat Helmet (desert)"" to RHS ""ACH (tan/ESS)"" to indicate association with platoon lead element and for more visual diversity in the platoon. " \n "- Rifle changed from RHS ""M4A1 PIP"" to RHS ""M16A4 (Carryhandle)"" for increased weapon diversity in the platoon. More accurate shooting platform to compensate the lack of interesting weaponry such as a LAT, an AR or a grenade launcher. " \n "- Mags changed from RHS ""30Rnd STANAG M855A1"" to RHS ""30Rnd PMAG M855A1"" and from RHS ""30Rnd STANAG M856A1 (tracer)"" to RHS ""30Rnd PMAG M856A1 (tracer)"" for increased visual fidelity. " \n " " \n "SL: " \n "- Helmet changed from vanilla ""Enhanced Combat Helmet (desert)"" to RHS ""ACH OEF-CP (Headset/ESS/Alt)"". " \n "- Backpack changed from vanilla ""Assault Pack MTP"" to vanilla ""Assault Pack Coyote"" for more visual contrast. Carry capacity remains the same. " \n "- Rifle changed from RHS ""M4A1 (M203s)"" to RHS ""M16A4 (Carryhandle/M203)"" for increased for increased weapon diversity in the platoon. SL has now a more accurate long-range shooting platform. " \n "- Mags changed from RHS ""30Rnd STANAG M855A1"" to RHS ""30Rnd PMAG M855A1"" and from RHS ""30Rnd STANAG M856A1 (tracer)"" to RHS ""30Rnd PMAG M856A1 (tracer)"" for increased visual fidelity. " \n " " \n "Medic: " \n "- Helmet changed from vanilla ""Enhanced Combat Helmet (desert)"" to RHS ""ACH OEF-CP (Alt)"". " \n "- Backpack changed from vanilla ""Kitbag MTP"" to vanilla ""Kitbag Coyote"" for more visual contrast. Carry capacity remains the same. " \n "- Mags changed from RHS ""30Rnd STANAG M855A1"" to RHS ""30Rnd PMAG M855A1"" and from RHS ""30Rnd STANAG M856A1 (tracer)"" to RHS ""30Rnd PMAG M856A1 (tracer)"" for increased visual fidelity. " \n " " \n "FTL: " \n "- Helmet changed from vanilla ""Enhanced Combat Helmet (desert)"" to RHS ""ACH OEF-CP (Headset/ESS/Alt)"". " \n "- Vest changed from RHS ""SPCS (Team Leader Alt/OEF-CP)"" to RHS ""SPCS (Grenadier/OEF-CP)"" for more visual diversity in the platoon. Carry capacity remains the same. " \n "- Backpack changed from vanilla ""Assault Pack MTP"" to vanilla ""Assault Pack Coyote"" for more visual contrast. Carry capacity remains the same. " \n "- Mags changed from RHS ""30Rnd STANAG M855A1"" to RHS ""30Rnd PMAG M855A1"" and from RHS ""30Rnd STANAG M856A1 (tracer)"" to RHS ""30Rnd PMAG M856A1 (tracer)"" for increased visual fidelity. " \n " " \n "AR: " \n "- Helmet changed from vanilla ""Enhanced Combat Helmet (desert)"" to RHS ""ACH OEF-CP (ESS/Alt)"" or RHS ""ACH OEF-CP (Alt)"". Both helmets are given out semi-randomly to increase visual variety in the platoon. " \n "- Backpack changed from vanilla ""Assault Pack MTP"" to vanilla ""Assault Pack Coyote"" for more visual contrast. Carry capacity remains the same. " \n "- Added muzzle attachment RHS ""SFMB-556 1/2-28"". " \n " " \n "AAR: " \n "- Helmet changed from vanilla ""Enhanced Combat Helmet (desert)"" to RHS ""ACH OEF-CP (Headset/Alt)"". " \n "- Vest changed from RHS ""SPCS (Rifleman Alt/OEF-CP)"" to RHS ""SPCS (Team Leader/OEF-CP)"" for more visual diversity in the platoon. Carry capacity remains the same. " \n "- Backpack changed from vanilla ""Kitbag MTP"" to vanilla ""Kitbag Coyote"" for more visual contrast. Carry capacity remains the same. " \n "- Rifle changed from RHS ""M4A1 PIP"" to RHS ""M16A4 (Carryhandle)"" for increased weapon diversity in the platoon. More accurate shooting platform to compensate the lack of interesting weaponry such as a LAT, an AR or a grenade launcher. " \n "- Mags changed from RHS ""30Rnd STANAG M855A1"" to RHS ""30Rnd PMAG M855A1"" and from RHS ""30Rnd STANAG M856A1 (tracer)"" to RHS ""30Rnd PMAG M856A1 (tracer)"" for increased visual fidelity. " \n " " \n "LAT: " \n "- Helmet changed from vanilla ""Enhanced Combat Helmet (desert)"" to RHS ""ACH OEF-CP (ESS/Alt)"" or RHS ""ACH OEF-CP (Alt)"". Both helmets are given out semi-randomly to increase visual variety in the platoon. " \n "- Mags changed from RHS ""30Rnd STANAG M855A1"" to RHS ""30Rnd PMAG M855A1"" and from RHS ""30Rnd STANAG M856A1 (tracer)"" to RHS ""30Rnd PMAG M856A1 (tracer)"" for increased visual fidelity. " \n " " \n "MMG Teamleader: " \n "- Helmet changed from vanilla ""Enhanced Combat Helmet (desert)"" to RHS ""ACH OEF-CP (Headset/Alt)"". " \n "- Backpack changed from vanilla ""Assault Pack MTP"" to vanilla ""Assault Pack Coyote"" for more visual contrast. Carry capacity remains the same. " \n "- Mags changed from RHS ""30Rnd STANAG M855A1"" to RHS ""30Rnd PMAG M855A1"" and from RHS ""30Rnd STANAG M856A1 (tracer)"" to RHS ""30Rnd PMAG M856A1 (tracer)"" for increased visual fidelity. " \n " " \n "MMG Gunner: " \n "- Helmet changed from vanilla ""Enhanced Combat Helmet (desert)"" to RHS ""ACH OEF-CP (ESS/Alt)""." \n "- Backpack changed from vanilla ""Kitbag MTP"" to vanilla ""Kitbag Coyote"" for more visual contrast. Carry capacity remains the same. " \n "- Added muzzle attachment RHS ""ARDEC 4-Prong"". " \n " " \n "MMG Asst. Gunner: " \n "- Helmet changed from vanilla ""Enhanced Combat Helmet (desert)"" to RHS ""ACH OEF-CP (Alt)"". " \n "- Backpack changed from vanilla ""Kitbag MTP"" to vanilla ""Kitbag Coyote"" for more visual contrast. Carry capacity remains the same. " \n "- Mags changed from RHS ""30Rnd STANAG M855A1"" to RHS ""30Rnd PMAG M855A1"" and from RHS ""30Rnd STANAG M856A1 (tracer)"" to RHS ""30Rnd PMAG M856A1 (tracer)"" for increased visual fidelity. " \n " " \n "MAT Teamleader: " \n "- Helmet changed from vanilla ""Enhanced Combat Helmet (desert)"" to RHS ""ACH OEF-CP (Headset/Alt)"". " \n "- Backpack changed from vanilla ""Assault Pack MTP"" to vanilla ""Assault Pack Coyote"" for more visual contrast. Carry capacity remains the same. " \n "- Mags changed from RHS ""30Rnd STANAG M855A1"" to RHS ""30Rnd PMAG M855A1"" and from RHS ""30Rnd STANAG M856A1 (tracer)"" to RHS ""30Rnd PMAG M856A1 (tracer)"" for increased visual fidelity. " \n " " \n "MAT Gunner: " \n "- Helmet changed from vanilla ""Enhanced Combat Helmet (desert)"" to RHS ""ACH OEF-CP (ESS/Alt)""." \n "- Vest changed from RHS ""SPCS (Rifleman Alt/OEF-CP)"" to RHS ""SPCS (OEF-CP)"" for more visual diversity in the platoon. Carry capacity remains the same. " \n "- Backpack changed from vanilla ""Kitbag MTP"" to vanilla ""Kitbag Coyote"" for more visual contrast. Carry capacity remains the same. " \n "- Mags changed from RHS ""30Rnd STANAG M855A1"" to RHS ""30Rnd PMAG M855A1"" and from RHS ""30Rnd STANAG M856A1 (tracer)"" to RHS ""30Rnd PMAG M856A1 (tracer)"" for increased visual fidelity. " \n " " \n "MAT Asst. Gunner: " \n "- Helmet changed from vanilla ""Enhanced Combat Helmet (desert)"" to RHS ""ACH OEF-CP (Alt)"". " \n "- Backpack changed from vanilla ""Kitbag MTP"" to vanilla ""Kitbag Coyote"" for more visual contrast. Carry capacity remains the same. " \n "- Mags changed from RHS ""30Rnd STANAG M855A1"" to RHS ""30Rnd PMAG M855A1"" and from RHS ""30Rnd STANAG M856A1 (tracer)"" to RHS ""30Rnd PMAG M856A1 (tracer)"" for increased visual fidelity. " \n " " \n "ENG Leader: " \n "- Helmet changed from vanilla ""Enhanced Combat Helmet (desert)"" to RHS ""ACH OEF-CP (Headset/ESS/Alt)"". " \n "- Vest changed from RHS ""SPCS (Team Leader Alt/OEF-CP)"" to vanilla ""Carrier GL Rig (green)"" for a bulkier look to visually distinguish EOD/ENG from the rest of the platoon. " \n "- Backpack changed from vanilla ""Carryall MTP"" to vanilla ""Carryall Coyote"" for more visual contrast. Carry capacity remains the same. " \n "- Mags changed from RHS ""30Rnd STANAG M855A1"" to RHS ""30Rnd PMAG M855A1"" and from RHS ""30Rnd STANAG M856A1 (tracer)"" to RHS ""30Rnd PMAG M856A1 (tracer)"" for increased visual fidelity. " \n " " \n "ENG Rifleman: " \n "- Helmet changed from vanilla ""Enhanced Combat Helmet (desert)"" to RHS ""ACH OEF-CP (Headset/Alt)"". " \n "- Vest changed from RHS ""SPCS (Team Leader Alt/OEF-CP)"" to vanilla ""Carrier GL Rig (green)"" for a bulkier look to visually distinguish EOD/ENG from the rest of the platoon. " \n "- Backpack changed from vanilla ""Carryall MTP"" to vanilla ""Carryall Coyote"" for more visual contrast. Carry capacity remains the same. " \n "- Mags changed from RHS ""30Rnd STANAG M855A1"" to RHS ""30Rnd PMAG M855A1"" and from RHS ""30Rnd STANAG M856A1 (tracer)"" to RHS ""30Rnd PMAG M856A1 (tracer)"" for increased visual fidelity. " \n " " \n "Mortar Leader: " \n "- Helmet changed from vanilla ""Enhanced Combat Helmet (desert)"" to RHS ""ACH OEF-CP (Headset/Alt)"". " \n "- Mags changed from RHS ""30Rnd STANAG M855A1"" to RHS ""30Rnd PMAG M855A1"" and from RHS ""30Rnd STANAG M856A1 (tracer)"" to RHS ""30Rnd PMAG M856A1 (tracer)"" for increased visual fidelity. " \n " " \n "Mortar Gunner: " \n "- Helmet changed from vanilla ""Enhanced Combat Helmet (desert)"" to RHS ""ACH OEF-CP (Alt)"". " \n "- Vest changed from RHS ""SPCS (Rifleman Alt/OEF-CP)"" to RHS ""SPCS (SAW/OEF-CP)"" for more visual diversity in the platoon. Carry capacity remains the same. " \n "- Mags changed from RHS ""30Rnd STANAG M855A1"" to RHS ""30Rnd PMAG M855A1"" and from RHS ""30Rnd STANAG M856A1 (tracer)"" to RHS ""30Rnd PMAG M856A1 (tracer)"" for increased visual fidelity. " \n " " \n "DGR Commander: " \n "- Helmet changed from RHS ""ACVC-H MK-1697"" to RHS ""ACVC-H MK-1697 (ESS)"" to better visually indicate the element leader. " \n "- Rifle changed from vanilla ""Scorpion Evo 3 A1"" to NiArms ""H&K MP5A3"" to bring weaponry visually more in line with the rest of the platoon.  " \n " " \n "DGR Gunner & Driver: " \n "- Rifle changed from vanilla ""Scorpion Evo 3 A1"" to NiArms ""H&K MP5A3"" to bring weaponry visually more in line with the rest of the platoon.  " \n " " \n "DMT Marksman " \n "- Rifle scope changed from RH ""Leopold Mark 4 LR/T"" to RHS ""M8541A SSDS"" for more visual conformity with NVG variant of the same scope. Note: max. zoom is reduced from x20 to x15 however the Marksman gains a MRDS sight for CQB. " \n "- Added scope RHS ""M8541A + AN/PVS-27"" to the vest gear. This is the NVG version of the regular scope. " \n " " \n "Nightbird Pilot & Co-Pilot: " \n "- Rifle changed from vanilla ""Scorpion Evo 3 A1"" to NiArms ""H&K MP5A3"" to bring weaponry visually more in line with the rest of the platoon.  " \n " " \n "Falcon Pilot: " \n "- Rifle changed from vanilla ""Scorpion Evo 3 A1"" to NiArms ""H&K MP5A3"" to bring weaponry visually more in line with the rest of the platoon.  " \n " " \n "Zeus & Co-Zeus " \n "- Uniform changed from vanilla ""VR Suit NATO"" to RHS ""Combat Uniform OCP"" to make Zeus look a bit more like an HQ commander than a Tron character. " \n "- Headgear added RHS ""Patrol Cap OEF-CP"". " \n "- Facewear changed from vanilla ""VR Goggles"" to vanilla ""Aviator Glasses"". " \n "- Insignia added ""Zeus"". " \n " " \n "All Units: " \n "- Disabled LAMBS AI " \n " " \n "Alpha SL: " \n "- Enabled ""is Player"". This makes it easier for Mission Makers to quickly test a mission in the editor by just hitting ""play"" instead of having to select a specific unit every time beforehand to avoid ending up in spectator mode by default.  " \n " " \n "Crates: " \n "- Added an ACE3 medical crate with our usual base script." \n "" \n "" \n "-v1.13.6" \n "  - ALL Added persistent Call-Signs for all GM's (where not included in v1.13.4)" \n "  - ALL Added the code`this disableAI ""MOVE""; this setSpeaker ""NoVoice""; enableRadio false;` to all playable units to prevent them from running off and spamming the vanilla-radio during local testing." \n "  - ALL Changed persistent call-signs (map markers) to a consistent formula: ≤ 2 syllables = written out call-sing. ≥ 3 syllables = abbreviated call-sign." \n "  - ALL Added full changelog to all factions for quick in-game reference" \n "  - TFN Added new yellow owl insignia patches to all uniforms" \n "" \n "- v1.13.5" \n "  - ALL Added respective GM's to Standard Faction Compositions for convenience / time saving " \n "  - ALL Added base clean-up module to Standard Faction Compositions to ensure Mission Makers don't forget it in the future - radius set to 200x200 meters" \n "" \n "- v1.13.4 " \n "  - ALL Added @ Squad/Team names to leaders so that Team name appears in role select" \n "  - TFN Changed M249 to the FN MINIMI" \n "" \n "- v1.13.3" \n "  - US Added Improved Bipod/SAW Grip to AR M249" \n "  - US Removed M14 Mags" \n "  - TFN Added Bipod to M249" \n "" \n "- v1.13.2" \n "  - ALL Added 1 Extra Tourniquet to every Unit" \n "  - TFN DMT Lead Rifle Changed to D10 Version" \n "  - TFN DMT given extra pistol mag to bring in line with other units" \n "  - TFN AAR Weapon changed to HK416 D14.5" \n "  - TFN Lead Elements Given AN/PEQ-16A's" \n "  - US Alpha Fireteam 2 AAR vest changed to ALT variant to match rest of faction" \n "  - US Lead Elements Given AN/PEQ-16A's" \n "  - US DMT given extra pistol mag to bring in line with other units" \n "  - US DMT Sniper Rifle Given SU-260/P (MDO) to bring zoom level to the same as Russian and TFN factions" \n "  - US DMT Bipod Changed to Harris Bipod" \n "  - US DMT Marksman Rifle changed to black version of same rifle" \n "  - US DMT Marksman Magazines changed to SR-25 version, as RHS hotfix made M14 mags incompatible with MK11" \n "  - RUS DMT given extra pistol mag to bring in line with other units" \n "  - RUS DGR Helmets changed to TSH-4 to make distinct from US Helmets" \n "  - RUS NB Helmets changed to ZSH-7A to make distinct from US and TFN helmets" \n "  - RUS Removed RIS Rail adaptors from AK rifles" \n "  - RUS Added PG-7V rocket to MAT ammo crate. This rocket is lighter and packs less payload than the PG-7VL. This gives it an  increased effective range but is less powerful due to decreased payload" \n "" \n "- v1.12.2" \n "  - Hotfixed US Vests across the Squads to match V.12 changes. Whoops." \n "  - Added Angled Grip to TFN HK416s where possible. " \n "" \n "- v1.12" \n "  - Fixed TFN MMG Ammo preloaded into Rifle to 100RND mag from 50rnd." \n "  - Fixed TFN DMT Marksman Ammo loaded into Rifle to correct SBLR mag." \n "  - Changed TFN DMT Lead Suppressor to QDSS NT4 Black from Rotex-5 Grey" \n "  - Changed TFN Dagger Uniforms from Gorka R Green to FFCP Green Fatigues [RS]" \n "  - Changed US PLT Commander + Squad Leader Vest from SPCS Rifleman/OEF- CP to SPCS Squad Lead/OEF-CP" \n "  - Changed US Medic Vest from SPCS Rifleman/OEF-CP to SPCS Medic/OEF-CP" \n "  - Changed US PLT Rifleman Vest from SPCS OEF-CP to SPCS Rifleman Alt/OEF-CP" \n "  - Changed US FTL Vest from SPCS Rifleman/OEF-CP to SPCS Team Leader Alt/OEF-CP" \n "  - Changed US AR Vest from SPCS Rifleman/OEF-CP to SPCS SAW/OEF-CP" \n "  - Changed US AAR Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP" \n "  - Changed US Rifleman AT Vest from SPCS OEF-CP to SPCS Rifleman Alt/OEF-CP" \n "  - Changed US MAT/MMG/DMT/ENG/MTR Lead Vest from SPCS Rifleman/OEF-CP to SPCS Team Leader Alt/OEF-CP" \n "  - Changed US MMG Gunner Vest from SPCS Rifleman/OEF-CP to SPCS Machinegunner/OEF-CP" \n "  - Changed US MMG/MAT Ammo Bearer Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP" \n "  - Changed US MAT Gunner Vest from SPCS OEF-CP to SPCS Rifleman Alt/OEF-CP" \n "  - Changed US DMT Marksman vest from SPCS OEF-CP to SPCS Sniper/OEF-CP" \n "  - Fixed US DMT Marksman Rifle Loaded Mag to correct varient." \n "  - Changed US Engineer Rifleman Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP." \n "  - Changed US MTR Gunner Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP." \n "  - Changed US DGR Uniforms from FFCP ACU Fatigues to FFCP ACU Fatigues [RS]" \n "  - Changed US DGR Driver Backpack from Assault Pack Green to Assault Pack Black" \n "  - Changed US Heli Pilot/Copilot Uniforms from Heli pilot Coveralls to FFCP Nomad Fatigues [RS]" \n "  - Fixed US Heli/Jet Pilot Vest White Smoke grenade count to 2." \n "  - Changed US Heli Pilot/Copilot Helmet from Heli Pilot NATO to HGU-56/P (Black/Visor)" \n "  - Changed US Jet Pilot Uniform from Pilot Coveralls NATO to  FFCP Nomad Fatigues" \n "  - Changed RUS Vic/Heli/Jet Crew Weapons to PP-2000" \n "  - Upped RUS PP-2000 Ammo counts to 6x Mag to bring in line with ammo counts for TFN and US." \n "  - Changed RUS Heli Pilot Uniforms from Pilot Coveralls CSAT to FFCP-Fatigues EMR [RS]" \n "  - Changed RUS Heli Pilot Vest from 6B23 (6Sh116) to FFCP Tactical Vest TigerVRS" \n "  - Changed RUS Jet Pilot Uniforms from Pilot Coveralls CSAT to FFCP-Fatigues EMR [RS]" \n "  - Changed RUS Jet Pilot Vest from 6B23 (6Sh116) to FFCP Tactical Vest TigerVRS" \n "" \n "- v1.11" \n "  - changed m40 mini grenades to m67 fragmentation" \n "  - replaced mp7 weapons with mp5k-pdw" \n "  - changed ak105 to ak74m (plum) " \n "  - changed PKM to PKP" \n "  - changed RUS PKM ammo boxes. MMG now loads with 7TZ (AP rounds)" \n "  - added vert grip to us weapons" \n "  - replaced m14 with HK PSG1A1" \n "  - replaced m260e4 with mg3" \n "  - updated all ammo boxes respectively. " \n "" \n "- v1.10" \n "  - changed Medic loadouts from 6 x 1000ml blood bags to 2 x 1000ml and 8 x 500ml." \n "" \n "- v1.09" \n "  - updated Fireteam colours A1 Red A2 Yellow, B1 Green B2 Blue, C1 Red C2 Yellow." \n "" \n "- v1.08" \n "  - changed ""Reaper"" to ""Nightbird"", ""RPR"" to ""NB""" \n "  - changed ""Paladin"" to ""Falcon"", ""PAL"" to ""FC""" \n "  - changed ""DAGGER"" to ""DGR""" \n "" \n "- v1.07" \n "  - US and RU faction bumped to v1.07 to avoid confusion regarding version numbers (US and RU was 1.05, TFN was 1.06)" \n "  - overhauled the RU faction: updated helmets, uniforms, weapons to a more modern look" \n "  - overhauled the US faction: updated helmets and vests to armour rating of IV" \n "  - corrected some mistakes in all factions (grenade ammount of MMG gunner, ENG not having tourniquetes, DGR not having GPS-s)" \n "  - overhauled the medics of all factions to reflect recent cahnges to ACE medical (less QuikClots, more Elastic Bandages, etc.)" \n "" \n "- v1.05" \n "  - Added a MAT ammo box on spawn." \n "" \n "- v1.04" \n "  - All MAT Teams carrying RPG's got the ver3 scopes with ranges for all types" \n "    of ammo." \n "  - All Callsigns were changed to be uniformed throught no matter the faction." \n "" \n "- v1.03" \n "  - set crew driver/gunner and pilot/copilot/jetpilot as Engineers through the" \n "    Object: ACE Options menu in unit attributes" \n "  - overhauled the TFN faction (weapons, helmets, etc.), changes not applicable" \n "    to derived factions" \n "" \n "- v1.02" \n "  - loadout overhaul for DMT, made them lighter + gave them tools for recon" \n "  - specified preset ACRE2 radio channels for most units" \n "" \n "- v1.01" \n "  - updated team colors func to `a3ee_team_colors_fnc_setColor`, just load+save" \n "    the composition in editor, this fixes it" \n "  - changed RPG-7 using MAT teams to carry Kitbags" \n "  - removed one PKM ammo box from AAR, MMG gunner, MMG bearer (fixes overload)" \n "  - moved 1-2 AR boxes from AAR to AR, gave AR an Assaultpack" \n "  - added 1-2 more AR boxes to AR's Assaultpack (if enough space)" \n "  - changed HEDP to HE rockets for Carl Gustav (M3MAAWS)" \n "  - changed US crew uniform and helmet to match grey color scheme of US pilots" \n "  - changed backpacks of driver/copilot to use less contrasting colors compared" \n "    to their respective uniform/vest colors" \n "  - changed Carryall backpacks of TFN Engineers to use custom Flecktarn Carryall" \n "  - changed all (GP-25 and normal) AK74m rifles to be the non-NPZ variants" \n "  - removed secondary long-range (PRC148) from Engineers" \n "" \n "- v1.00 (and before)" \n "  - added a Comment object with version number (`v1.00`)" \n "  - added `respawn_west`, `respawn_east`, `respawn_guerrila` markers" \n "  - added `[this, 200] call a3ee_fnc_boxGuard` to init lines of resupply boxes" \n "  - added `Resupply` green triangle markers on the position of resupply boxes";
 		id=5;
 		atlOffset=0.001999855;
 	};
@@ -163,7 +163,7 @@ class items
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={7.652832,0,-4.7539063};
+			position[]={7.5322266,0,-4.6677246};
 		};
 		side="Empty";
 		flags=4;
@@ -211,7 +211,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-5.873291,0.0014390945,8.9360352};
+					position[]={-5.9941406,0.0014390945,9.0222168};
 				};
 				side="West";
 				flags=7;
@@ -305,7 +305,7 @@ class items
 								};
 								class Item7
 								{
-									name="rhs_acc_2dpZenit";
+									name="rhsusf_acc_M952V";
 									count=1;
 								};
 								class Item8
@@ -584,7 +584,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-4.873291,0.0014390945,8.9350586};
+					position[]={-4.9941406,0.0014390945,9.0212402};
 				};
 				side="West";
 				flags=5;
@@ -658,7 +658,7 @@ class items
 								};
 								class Item6
 								{
-									name="rhs_acc_2dpZenit";
+									name="rhsusf_acc_M952V";
 									count=1;
 								};
 								class Item7
@@ -918,7 +918,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-3.8728027,0.0014390945,8.9350586};
+					position[]={-3.9936523,0.0014390945,9.0212402};
 				};
 				side="West";
 				flags=5;
@@ -992,7 +992,7 @@ class items
 								};
 								class Item5
 								{
-									name="rhs_acc_2dpZenit";
+									name="rhsusf_acc_M952V";
 									count=1;
 								};
 								class Item6
@@ -1221,7 +1221,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-2.8728027,0.0014390945,8.9350586};
+					position[]={-2.9936523,0.0014390945,9.0212402};
 				};
 				side="West";
 				flags=5;
@@ -1294,7 +1294,7 @@ class items
 								};
 								class Item5
 								{
-									name="rhs_acc_2dpZenit";
+									name="rhsusf_acc_M952V";
 									count=1;
 								};
 								class Item6
@@ -1484,7 +1484,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-5.8352051,0.0014390945,6.019043};
+					position[]={-5.9560547,0.0014390945,6.1052246};
 				};
 				side="West";
 				flags=7;
@@ -1534,9 +1534,9 @@ class items
 								items=1;
 								class Item0
 								{
-									name="SmokeShell";
-									count=2;
-									ammoLeft=1;
+									name="rhsusf_mag_15Rnd_9x19_JHP";
+									count=1;
+									ammoLeft=15;
 								};
 							};
 							class ItemCargo
@@ -1554,37 +1554,37 @@ class items
 								};
 								class Item2
 								{
-									name="ACE_morphine";
-									count=1;
+									name="ACE_tourniquet";
+									count=2;
 								};
 								class Item3
 								{
-									name="ACE_tourniquet";
+									name="ACE_morphine";
 									count=1;
 								};
 								class Item4
 								{
-									name="rhsusf_acc_M952V";
+									name="ACE_epinephrine";
 									count=1;
 								};
 								class Item5
 								{
-									name="ACRE_PRC343";
-									count=1;
-								};
-								class Item6
-								{
 									name="ACE_CableTie";
 									count=2;
 								};
-								class Item7
+								class Item6
 								{
 									name="ACE_MapTools";
 									count=1;
 								};
+								class Item7
+								{
+									name="rhsusf_acc_M952V";
+									count=1;
+								};
 								class Item8
 								{
-									name="ACRE_PRC152";
+									name="ACRE_PRC343";
 									count=1;
 								};
 							};
@@ -1595,45 +1595,24 @@ class items
 							isBackpack=0;
 							class MagazineCargo
 							{
-								items=5;
+								items=3;
 								class Item0
 								{
-									name="SmokeShell";
-									count=2;
-									ammoLeft=1;
+									name="rhs_mag_30Rnd_556x45_M855A1_PMAG";
+									count=6;
+									ammoLeft=30;
 								};
 								class Item1
 								{
-									name="rhsusf_mag_15Rnd_9x19_JHP";
-									count=1;
-									ammoLeft=15;
+									name="rhs_mag_30Rnd_556x45_M855A1_PMAG_Tracer_Red";
+									count=4;
+									ammoLeft=30;
 								};
 								class Item2
 								{
 									name="HandGrenade";
 									count=2;
 									ammoLeft=1;
-								};
-								class Item3
-								{
-									name="rhs_mag_30Rnd_556x45_M855A1_PMAG";
-									count=6;
-									ammoLeft=30;
-								};
-								class Item4
-								{
-									name="rhs_mag_30Rnd_556x45_M855A1_PMAG_Tracer_Red";
-									count=4;
-									ammoLeft=30;
-								};
-							};
-							class ItemCargo
-							{
-								items=1;
-								class Item0
-								{
-									name="ACE_tourniquet";
-									count=1;
 								};
 							};
 						};
@@ -1671,7 +1650,7 @@ class items
 								class Item4
 								{
 									name="SmokeShell";
-									count=3;
+									count=7;
 									ammoLeft=1;
 								};
 								class Item5
@@ -1689,10 +1668,15 @@ class items
 							};
 							class ItemCargo
 							{
-								items=1;
+								items=2;
 								class Item0
 								{
 									name="ACE_IR_Strobe_Item";
+									count=1;
+								};
+								class Item1
+								{
+									name="ACRE_PRC152";
 									count=1;
 								};
 							};
@@ -1861,7 +1845,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-4.8337402,0.0014390945,6.0180664};
+					position[]={-4.9545898,0.0014390945,6.104248};
 				};
 				side="West";
 				flags=5;
@@ -1900,14 +1884,14 @@ class items
 								items=1;
 								class Item0
 								{
-									name="SmokeShell";
-									count=4;
-									ammoLeft=1;
+									name="rhsusf_mag_15Rnd_9x19_JHP";
+									count=2;
+									ammoLeft=15;
 								};
 							};
 							class ItemCargo
 							{
-								items=6;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -1920,20 +1904,25 @@ class items
 								};
 								class Item2
 								{
-									name="ACE_morphine";
-									count=1;
+									name="ACE_tourniquet";
+									count=2;
 								};
 								class Item3
 								{
-									name="ACE_tourniquet";
+									name="ACE_morphine";
 									count=1;
 								};
 								class Item4
 								{
-									name="rhsusf_acc_M952V";
+									name="ACE_epinephrine";
 									count=1;
 								};
 								class Item5
+								{
+									name="rhsusf_acc_M952V";
+									count=1;
+								};
+								class Item6
 								{
 									name="ACRE_PRC343";
 									count=1;
@@ -1946,39 +1935,24 @@ class items
 							isBackpack=0;
 							class MagazineCargo
 							{
-								items=4;
+								items=3;
 								class Item0
-								{
-									name="rhsusf_mag_15Rnd_9x19_JHP";
-									count=1;
-									ammoLeft=15;
-								};
-								class Item1
-								{
-									name="HandGrenade";
-									count=2;
-									ammoLeft=1;
-								};
-								class Item2
 								{
 									name="rhs_mag_30Rnd_556x45_M855A1_PMAG";
 									count=8;
 									ammoLeft=30;
 								};
-								class Item3
+								class Item1
 								{
 									name="rhs_mag_30Rnd_556x45_M855A1_PMAG_Tracer_Red";
 									count=2;
 									ammoLeft=30;
 								};
-							};
-							class ItemCargo
-							{
-								items=1;
-								class Item0
+								class Item2
 								{
-									name="ACE_tourniquet";
-									count=1;
+									name="HandGrenade";
+									count=2;
+									ammoLeft=1;
 								};
 							};
 						};
@@ -1992,7 +1966,7 @@ class items
 								class Item0
 								{
 									name="SmokeShell";
-									count=8;
+									count=10;
 									ammoLeft=1;
 								};
 								class Item1
@@ -2174,7 +2148,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-5.8337402,0.0014390945,4.0180664};
+					position[]={-5.9545898,0.0014390945,4.104248};
 				};
 				side="West";
 				flags=5;
@@ -2223,14 +2197,14 @@ class items
 								items=1;
 								class Item0
 								{
-									name="SmokeShell";
-									count=4;
-									ammoLeft=1;
+									name="rhsusf_mag_15Rnd_9x19_JHP";
+									count=1;
+									ammoLeft=15;
 								};
 							};
 							class ItemCargo
 							{
-								items=8;
+								items=9;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -2243,32 +2217,37 @@ class items
 								};
 								class Item2
 								{
-									name="ACE_morphine";
-									count=1;
+									name="ACE_tourniquet";
+									count=2;
 								};
 								class Item3
 								{
-									name="ACE_tourniquet";
+									name="ACE_morphine";
 									count=1;
 								};
 								class Item4
 								{
-									name="rhsusf_acc_M952V";
+									name="ACE_epinephrine";
 									count=1;
 								};
 								class Item5
 								{
-									name="ACRE_PRC343";
-									count=1;
-								};
-								class Item6
-								{
 									name="ACE_CableTie";
 									count=2;
 								};
-								class Item7
+								class Item6
 								{
 									name="ACE_MapTools";
+									count=1;
+								};
+								class Item7
+								{
+									name="rhsusf_acc_M952V";
+									count=1;
+								};
+								class Item8
+								{
+									name="ACRE_PRC343";
 									count=1;
 								};
 							};
@@ -2279,39 +2258,24 @@ class items
 							isBackpack=0;
 							class MagazineCargo
 							{
-								items=4;
+								items=3;
 								class Item0
-								{
-									name="rhsusf_mag_15Rnd_9x19_JHP";
-									count=1;
-									ammoLeft=15;
-								};
-								class Item1
-								{
-									name="HandGrenade";
-									count=2;
-									ammoLeft=1;
-								};
-								class Item2
 								{
 									name="rhs_mag_30Rnd_556x45_M855A1_PMAG";
 									count=6;
 									ammoLeft=30;
 								};
-								class Item3
+								class Item1
 								{
 									name="rhs_mag_30Rnd_556x45_M855A1_PMAG_Tracer_Red";
 									count=4;
 									ammoLeft=30;
 								};
-							};
-							class ItemCargo
-							{
-								items=1;
-								class Item0
+								class Item2
 								{
-									name="ACE_tourniquet";
-									count=1;
+									name="HandGrenade";
+									count=2;
+									ammoLeft=1;
 								};
 							};
 						};
@@ -2343,7 +2307,7 @@ class items
 								class Item3
 								{
 									name="SmokeShell";
-									count=3;
+									count=7;
 									ammoLeft=1;
 								};
 								class Item4
@@ -2500,7 +2464,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-4.8337402,0.0014390945,4.0180664};
+					position[]={-4.9545898,0.0014390945,4.104248};
 				};
 				side="West";
 				flags=5;
@@ -2540,14 +2504,14 @@ class items
 								items=1;
 								class Item0
 								{
-									name="SmokeShell";
-									count=4;
-									ammoLeft=1;
+									name="rhsusf_mag_15Rnd_9x19_JHP";
+									count=1;
+									ammoLeft=15;
 								};
 							};
 							class ItemCargo
 							{
-								items=6;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -2560,20 +2524,25 @@ class items
 								};
 								class Item2
 								{
-									name="ACE_morphine";
-									count=1;
+									name="ACE_tourniquet";
+									count=2;
 								};
 								class Item3
 								{
-									name="ACE_tourniquet";
+									name="ACE_morphine";
 									count=1;
 								};
 								class Item4
 								{
-									name="rhsusf_acc_M952V";
+									name="ACE_epinephrine";
 									count=1;
 								};
 								class Item5
+								{
+									name="rhsusf_acc_M952V";
+									count=1;
+								};
+								class Item6
 								{
 									name="ACRE_PRC343";
 									count=1;
@@ -2586,7 +2555,7 @@ class items
 							isBackpack=0;
 							class MagazineCargo
 							{
-								items=3;
+								items=2;
 								class Item0
 								{
 									name="rhsusf_100Rnd_556x45_soft_pouch";
@@ -2595,24 +2564,9 @@ class items
 								};
 								class Item1
 								{
-									name="rhsusf_mag_15Rnd_9x19_JHP";
-									count=1;
-									ammoLeft=15;
-								};
-								class Item2
-								{
 									name="HandGrenade";
 									count=2;
 									ammoLeft=1;
-								};
-							};
-							class ItemCargo
-							{
-								items=1;
-								class Item0
-								{
-									name="ACE_tourniquet";
-									count=1;
 								};
 							};
 						};
@@ -2761,7 +2715,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-3.8337402,0.0014390945,4.0180664};
+					position[]={-3.9545898,0.0014390945,4.104248};
 				};
 				side="West";
 				flags=5;
@@ -2804,14 +2758,14 @@ class items
 								items=1;
 								class Item0
 								{
-									name="SmokeShell";
-									count=4;
-									ammoLeft=1;
+									name="rhsusf_mag_15Rnd_9x19_JHP";
+									count=1;
+									ammoLeft=15;
 								};
 							};
 							class ItemCargo
 							{
-								items=8;
+								items=9;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -2824,32 +2778,37 @@ class items
 								};
 								class Item2
 								{
-									name="ACE_morphine";
-									count=1;
+									name="ACE_tourniquet";
+									count=2;
 								};
 								class Item3
 								{
-									name="ACE_tourniquet";
+									name="ACE_morphine";
 									count=1;
 								};
 								class Item4
 								{
-									name="rhsusf_acc_M952V";
+									name="ACE_epinephrine";
 									count=1;
 								};
 								class Item5
 								{
-									name="ACRE_PRC343";
-									count=1;
-								};
-								class Item6
-								{
 									name="ACE_CableTie";
 									count=2;
 								};
-								class Item7
+								class Item6
 								{
 									name="ACE_MapTools";
+									count=1;
+								};
+								class Item7
+								{
+									name="rhsusf_acc_M952V";
+									count=1;
+								};
+								class Item8
+								{
+									name="ACRE_PRC343";
 									count=1;
 								};
 							};
@@ -2860,39 +2819,24 @@ class items
 							isBackpack=0;
 							class MagazineCargo
 							{
-								items=4;
+								items=3;
 								class Item0
 								{
-									name="rhsusf_mag_15Rnd_9x19_JHP";
-									count=1;
-									ammoLeft=15;
+									name="rhs_mag_30Rnd_556x45_M855A1_PMAG";
+									count=8;
+									ammoLeft=30;
 								};
 								class Item1
+								{
+									name="rhs_mag_30Rnd_556x45_M855A1_PMAG_Tracer_Red";
+									count=2;
+									ammoLeft=30;
+								};
+								class Item2
 								{
 									name="HandGrenade";
 									count=2;
 									ammoLeft=1;
-								};
-								class Item2
-								{
-									name="rhs_mag_30Rnd_556x45_M855A1_PMAG";
-									count=6;
-									ammoLeft=30;
-								};
-								class Item3
-								{
-									name="rhs_mag_30Rnd_556x45_M855A1_PMAG_Tracer_Red";
-									count=4;
-									ammoLeft=30;
-								};
-							};
-							class ItemCargo
-							{
-								items=1;
-								class Item0
-								{
-									name="ACE_tourniquet";
-									count=1;
 								};
 							};
 						};
@@ -2905,39 +2849,39 @@ class items
 								items=6;
 								class Item0
 								{
+									name="rhs_mag_30Rnd_556x45_M855A1_PMAG";
+									count=9;
+									ammoLeft=30;
+								};
+								class Item1
+								{
 									name="rhsusf_100Rnd_556x45_soft_pouch";
 									count=2;
 									ammoLeft=100;
 								};
-								class Item1
-								{
-									name="SmokeShell";
-									count=3;
-									ammoLeft=1;
-								};
 								class Item2
-								{
-									name="SmokeShellGreen";
-									count=2;
-									ammoLeft=1;
-								};
-								class Item3
-								{
-									name="SmokeShellBlue";
-									count=1;
-									ammoLeft=1;
-								};
-								class Item4
 								{
 									name="HandGrenade";
 									count=2;
 									ammoLeft=1;
 								};
+								class Item3
+								{
+									name="SmokeShell";
+									count=4;
+									ammoLeft=1;
+								};
+								class Item4
+								{
+									name="SmokeShellGreen";
+									count=2;
+									ammoLeft=1;
+								};
 								class Item5
 								{
-									name="rhs_mag_30Rnd_556x45_M855A1_PMAG";
-									count=8;
-									ammoLeft=30;
+									name="SmokeShellBlue";
+									count=1;
+									ammoLeft=1;
 								};
 							};
 							class ItemCargo
@@ -3081,7 +3025,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-2.8337402,0.0014390945,4.0180664};
+					position[]={-2.9545898,0.0014390945,4.104248};
 				};
 				side="West";
 				flags=5;
@@ -3124,14 +3068,14 @@ class items
 								items=1;
 								class Item0
 								{
-									name="SmokeShell";
-									count=4;
-									ammoLeft=1;
+									name="rhsusf_mag_15Rnd_9x19_JHP";
+									count=2;
+									ammoLeft=15;
 								};
 							};
 							class ItemCargo
 							{
-								items=6;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -3144,20 +3088,25 @@ class items
 								};
 								class Item2
 								{
-									name="ACE_morphine";
-									count=1;
+									name="ACE_tourniquet";
+									count=2;
 								};
 								class Item3
 								{
-									name="ACE_tourniquet";
+									name="ACE_morphine";
 									count=1;
 								};
 								class Item4
 								{
-									name="rhsusf_acc_M952V";
+									name="ACE_epinephrine";
 									count=1;
 								};
 								class Item5
+								{
+									name="rhsusf_acc_M952V";
+									count=1;
+								};
+								class Item6
 								{
 									name="ACRE_PRC343";
 									count=1;
@@ -3173,36 +3122,27 @@ class items
 								items=4;
 								class Item0
 								{
-									name="rhsusf_mag_15Rnd_9x19_JHP";
-									count=1;
-									ammoLeft=15;
-								};
-								class Item1
-								{
-									name="HandGrenade";
-									count=2;
-									ammoLeft=1;
-								};
-								class Item2
-								{
 									name="rhs_mag_30Rnd_556x45_M855A1_PMAG";
 									count=8;
 									ammoLeft=30;
 								};
-								class Item3
+								class Item1
 								{
 									name="rhs_mag_30Rnd_556x45_M855A1_PMAG_Tracer_Red";
 									count=2;
 									ammoLeft=30;
 								};
-							};
-							class ItemCargo
-							{
-								items=1;
-								class Item0
+								class Item2
 								{
-									name="ACE_tourniquet";
-									count=1;
+									name="HandGrenade";
+									count=2;
+									ammoLeft=1;
+								};
+								class Item3
+								{
+									name="SmokeShell";
+									count=4;
+									ammoLeft=1;
 								};
 							};
 						};
@@ -3336,7 +3276,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-5.8337402,0.0014390945,2.0180664};
+					position[]={-5.9545898,0.0014390945,2.104248};
 				};
 				side="West";
 				flags=5;
@@ -3385,14 +3325,14 @@ class items
 								items=1;
 								class Item0
 								{
-									name="SmokeShell";
-									count=4;
-									ammoLeft=1;
+									name="rhsusf_mag_15Rnd_9x19_JHP";
+									count=1;
+									ammoLeft=15;
 								};
 							};
 							class ItemCargo
 							{
-								items=8;
+								items=9;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -3405,32 +3345,37 @@ class items
 								};
 								class Item2
 								{
-									name="ACE_morphine";
-									count=1;
+									name="ACE_tourniquet";
+									count=2;
 								};
 								class Item3
 								{
-									name="ACE_tourniquet";
+									name="ACE_morphine";
 									count=1;
 								};
 								class Item4
 								{
-									name="rhsusf_acc_M952V";
+									name="ACE_epinephrine";
 									count=1;
 								};
 								class Item5
 								{
-									name="ACRE_PRC343";
-									count=1;
-								};
-								class Item6
-								{
 									name="ACE_CableTie";
 									count=2;
 								};
-								class Item7
+								class Item6
 								{
 									name="ACE_MapTools";
+									count=1;
+								};
+								class Item7
+								{
+									name="rhsusf_acc_M952V";
+									count=1;
+								};
+								class Item8
+								{
+									name="ACRE_PRC343";
 									count=1;
 								};
 							};
@@ -3441,39 +3386,24 @@ class items
 							isBackpack=0;
 							class MagazineCargo
 							{
-								items=4;
+								items=3;
 								class Item0
-								{
-									name="rhsusf_mag_15Rnd_9x19_JHP";
-									count=1;
-									ammoLeft=15;
-								};
-								class Item1
-								{
-									name="HandGrenade";
-									count=2;
-									ammoLeft=1;
-								};
-								class Item2
 								{
 									name="rhs_mag_30Rnd_556x45_M855A1_PMAG";
 									count=6;
 									ammoLeft=30;
 								};
-								class Item3
+								class Item1
 								{
 									name="rhs_mag_30Rnd_556x45_M855A1_PMAG_Tracer_Red";
 									count=4;
 									ammoLeft=30;
 								};
-							};
-							class ItemCargo
-							{
-								items=1;
-								class Item0
+								class Item2
 								{
-									name="ACE_tourniquet";
-									count=1;
+									name="HandGrenade";
+									count=2;
+									ammoLeft=1;
 								};
 							};
 						};
@@ -3505,7 +3435,7 @@ class items
 								class Item3
 								{
 									name="SmokeShell";
-									count=3;
+									count=7;
 									ammoLeft=1;
 								};
 								class Item4
@@ -3662,7 +3592,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-4.8337402,0.0014390945,2.0180664};
+					position[]={-4.9545898,0.0014390945,2.104248};
 				};
 				side="West";
 				flags=5;
@@ -3702,14 +3632,14 @@ class items
 								items=1;
 								class Item0
 								{
-									name="SmokeShell";
-									count=4;
-									ammoLeft=1;
+									name="rhsusf_mag_15Rnd_9x19_JHP";
+									count=1;
+									ammoLeft=15;
 								};
 							};
 							class ItemCargo
 							{
-								items=6;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -3722,20 +3652,25 @@ class items
 								};
 								class Item2
 								{
-									name="ACE_morphine";
-									count=1;
+									name="ACE_tourniquet";
+									count=2;
 								};
 								class Item3
 								{
-									name="ACE_tourniquet";
+									name="ACE_morphine";
 									count=1;
 								};
 								class Item4
 								{
-									name="rhsusf_acc_M952V";
+									name="ACE_epinephrine";
 									count=1;
 								};
 								class Item5
+								{
+									name="rhsusf_acc_M952V";
+									count=1;
+								};
+								class Item6
 								{
 									name="ACRE_PRC343";
 									count=1;
@@ -3748,7 +3683,7 @@ class items
 							isBackpack=0;
 							class MagazineCargo
 							{
-								items=3;
+								items=2;
 								class Item0
 								{
 									name="rhsusf_100Rnd_556x45_soft_pouch";
@@ -3757,24 +3692,9 @@ class items
 								};
 								class Item1
 								{
-									name="rhsusf_mag_15Rnd_9x19_JHP";
-									count=1;
-									ammoLeft=15;
-								};
-								class Item2
-								{
 									name="HandGrenade";
 									count=2;
 									ammoLeft=1;
-								};
-							};
-							class ItemCargo
-							{
-								items=1;
-								class Item0
-								{
-									name="ACE_tourniquet";
-									count=1;
 								};
 							};
 						};
@@ -3923,7 +3843,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-3.8337402,0.0014390945,2.0180664};
+					position[]={-3.9545898,0.0014390945,2.104248};
 				};
 				side="West";
 				flags=5;
@@ -3966,14 +3886,14 @@ class items
 								items=1;
 								class Item0
 								{
-									name="SmokeShell";
-									count=4;
-									ammoLeft=1;
+									name="rhsusf_mag_15Rnd_9x19_JHP";
+									count=1;
+									ammoLeft=15;
 								};
 							};
 							class ItemCargo
 							{
-								items=8;
+								items=9;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -3986,32 +3906,37 @@ class items
 								};
 								class Item2
 								{
-									name="ACE_morphine";
-									count=1;
+									name="ACE_tourniquet";
+									count=2;
 								};
 								class Item3
 								{
-									name="ACE_tourniquet";
+									name="ACE_morphine";
 									count=1;
 								};
 								class Item4
 								{
-									name="rhsusf_acc_M952V";
+									name="ACE_epinephrine";
 									count=1;
 								};
 								class Item5
 								{
-									name="ACRE_PRC343";
-									count=1;
-								};
-								class Item6
-								{
 									name="ACE_CableTie";
 									count=2;
 								};
-								class Item7
+								class Item6
 								{
 									name="ACE_MapTools";
+									count=1;
+								};
+								class Item7
+								{
+									name="rhsusf_acc_M952V";
+									count=1;
+								};
+								class Item8
+								{
+									name="ACRE_PRC343";
 									count=1;
 								};
 							};
@@ -4022,39 +3947,24 @@ class items
 							isBackpack=0;
 							class MagazineCargo
 							{
-								items=4;
+								items=3;
 								class Item0
 								{
-									name="rhsusf_mag_15Rnd_9x19_JHP";
-									count=1;
-									ammoLeft=15;
+									name="rhs_mag_30Rnd_556x45_M855A1_PMAG";
+									count=8;
+									ammoLeft=30;
 								};
 								class Item1
+								{
+									name="rhs_mag_30Rnd_556x45_M855A1_PMAG_Tracer_Red";
+									count=2;
+									ammoLeft=30;
+								};
+								class Item2
 								{
 									name="HandGrenade";
 									count=2;
 									ammoLeft=1;
-								};
-								class Item2
-								{
-									name="rhs_mag_30Rnd_556x45_M855A1_PMAG";
-									count=6;
-									ammoLeft=30;
-								};
-								class Item3
-								{
-									name="rhs_mag_30Rnd_556x45_M855A1_PMAG_Tracer_Red";
-									count=4;
-									ammoLeft=30;
-								};
-							};
-							class ItemCargo
-							{
-								items=1;
-								class Item0
-								{
-									name="ACE_tourniquet";
-									count=1;
 								};
 							};
 						};
@@ -4067,39 +3977,39 @@ class items
 								items=6;
 								class Item0
 								{
+									name="rhs_mag_30Rnd_556x45_M855A1_PMAG";
+									count=9;
+									ammoLeft=30;
+								};
+								class Item1
+								{
 									name="rhsusf_100Rnd_556x45_soft_pouch";
 									count=2;
 									ammoLeft=100;
 								};
-								class Item1
-								{
-									name="SmokeShell";
-									count=3;
-									ammoLeft=1;
-								};
 								class Item2
-								{
-									name="SmokeShellGreen";
-									count=2;
-									ammoLeft=1;
-								};
-								class Item3
-								{
-									name="SmokeShellBlue";
-									count=1;
-									ammoLeft=1;
-								};
-								class Item4
 								{
 									name="HandGrenade";
 									count=2;
 									ammoLeft=1;
 								};
+								class Item3
+								{
+									name="SmokeShell";
+									count=4;
+									ammoLeft=1;
+								};
+								class Item4
+								{
+									name="SmokeShellGreen";
+									count=2;
+									ammoLeft=1;
+								};
 								class Item5
 								{
-									name="rhs_mag_30Rnd_556x45_M855A1_PMAG";
-									count=8;
-									ammoLeft=30;
+									name="SmokeShellBlue";
+									count=1;
+									ammoLeft=1;
 								};
 							};
 							class ItemCargo
@@ -4243,7 +4153,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-2.8337402,0.0014390945,2.0180664};
+					position[]={-2.9545898,0.0014390945,2.104248};
 				};
 				side="West";
 				flags=5;
@@ -4286,14 +4196,14 @@ class items
 								items=1;
 								class Item0
 								{
-									name="SmokeShell";
-									count=4;
-									ammoLeft=1;
+									name="rhsusf_mag_15Rnd_9x19_JHP";
+									count=2;
+									ammoLeft=15;
 								};
 							};
 							class ItemCargo
 							{
-								items=6;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -4306,20 +4216,25 @@ class items
 								};
 								class Item2
 								{
-									name="ACE_morphine";
-									count=1;
+									name="ACE_tourniquet";
+									count=2;
 								};
 								class Item3
 								{
-									name="ACE_tourniquet";
+									name="ACE_morphine";
 									count=1;
 								};
 								class Item4
 								{
-									name="rhsusf_acc_M952V";
+									name="ACE_epinephrine";
 									count=1;
 								};
 								class Item5
+								{
+									name="rhsusf_acc_M952V";
+									count=1;
+								};
+								class Item6
 								{
 									name="ACRE_PRC343";
 									count=1;
@@ -4335,36 +4250,27 @@ class items
 								items=4;
 								class Item0
 								{
-									name="rhsusf_mag_15Rnd_9x19_JHP";
-									count=1;
-									ammoLeft=15;
-								};
-								class Item1
-								{
-									name="HandGrenade";
-									count=2;
-									ammoLeft=1;
-								};
-								class Item2
-								{
 									name="rhs_mag_30Rnd_556x45_M855A1_PMAG";
 									count=8;
 									ammoLeft=30;
 								};
-								class Item3
+								class Item1
 								{
 									name="rhs_mag_30Rnd_556x45_M855A1_PMAG_Tracer_Red";
 									count=2;
 									ammoLeft=30;
 								};
-							};
-							class ItemCargo
-							{
-								items=1;
-								class Item0
+								class Item2
 								{
-									name="ACE_tourniquet";
-									count=1;
+									name="HandGrenade";
+									count=2;
+									ammoLeft=1;
+								};
+								class Item3
+								{
+									name="SmokeShell";
+									count=4;
+									ammoLeft=1;
 								};
 							};
 						};
@@ -4534,7 +4440,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-1.3381348,0.0014390945,5.9838867};
+					position[]={-1.4589844,0.0014390945,6.0700684};
 				};
 				side="West";
 				flags=7;
@@ -4583,9 +4489,9 @@ class items
 								items=1;
 								class Item0
 								{
-									name="SmokeShell";
-									count=2;
-									ammoLeft=1;
+									name="rhsusf_mag_15Rnd_9x19_JHP";
+									count=1;
+									ammoLeft=15;
 								};
 							};
 							class ItemCargo
@@ -4603,37 +4509,37 @@ class items
 								};
 								class Item2
 								{
-									name="ACE_morphine";
-									count=1;
+									name="ACE_tourniquet";
+									count=2;
 								};
 								class Item3
 								{
-									name="ACE_tourniquet";
+									name="ACE_morphine";
 									count=1;
 								};
 								class Item4
 								{
-									name="rhsusf_acc_M952V";
+									name="ACE_epinephrine";
 									count=1;
 								};
 								class Item5
 								{
-									name="ACRE_PRC343";
-									count=1;
-								};
-								class Item6
-								{
 									name="ACE_CableTie";
 									count=2;
 								};
-								class Item7
+								class Item6
 								{
 									name="ACE_MapTools";
 									count=1;
 								};
+								class Item7
+								{
+									name="rhs_acc_2dpZenit";
+									count=1;
+								};
 								class Item8
 								{
-									name="ACRE_PRC152";
+									name="ACRE_PRC343";
 									count=1;
 								};
 							};
@@ -4644,45 +4550,24 @@ class items
 							isBackpack=0;
 							class MagazineCargo
 							{
-								items=5;
+								items=3;
 								class Item0
 								{
-									name="SmokeShell";
-									count=2;
-									ammoLeft=1;
+									name="rhs_mag_30Rnd_556x45_M855A1_PMAG";
+									count=6;
+									ammoLeft=30;
 								};
 								class Item1
 								{
-									name="rhsusf_mag_15Rnd_9x19_JHP";
-									count=1;
-									ammoLeft=15;
+									name="rhs_mag_30Rnd_556x45_M855A1_PMAG_Tracer_Red";
+									count=4;
+									ammoLeft=30;
 								};
 								class Item2
 								{
 									name="HandGrenade";
 									count=2;
 									ammoLeft=1;
-								};
-								class Item3
-								{
-									name="rhs_mag_30Rnd_556x45_M855A1_PMAG";
-									count=6;
-									ammoLeft=30;
-								};
-								class Item4
-								{
-									name="rhs_mag_30Rnd_556x45_M855A1_PMAG_Tracer_Red";
-									count=4;
-									ammoLeft=30;
-								};
-							};
-							class ItemCargo
-							{
-								items=1;
-								class Item0
-								{
-									name="ACE_tourniquet";
-									count=1;
 								};
 							};
 						};
@@ -4720,7 +4605,7 @@ class items
 								class Item4
 								{
 									name="SmokeShell";
-									count=3;
+									count=7;
 									ammoLeft=1;
 								};
 								class Item5
@@ -4738,10 +4623,15 @@ class items
 							};
 							class ItemCargo
 							{
-								items=1;
+								items=2;
 								class Item0
 								{
 									name="ACE_IR_Strobe_Item";
+									count=1;
+								};
+								class Item1
+								{
+									name="ACRE_PRC152";
 									count=1;
 								};
 							};
@@ -4910,7 +4800,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-0.33862305,0.0014390945,5.9838867};
+					position[]={-0.45947266,0.0014390945,6.0700684};
 				};
 				side="West";
 				flags=5;
@@ -4949,14 +4839,14 @@ class items
 								items=1;
 								class Item0
 								{
-									name="SmokeShell";
-									count=4;
-									ammoLeft=1;
+									name="rhsusf_mag_15Rnd_9x19_JHP";
+									count=2;
+									ammoLeft=15;
 								};
 							};
 							class ItemCargo
 							{
-								items=6;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -4969,20 +4859,25 @@ class items
 								};
 								class Item2
 								{
-									name="ACE_morphine";
-									count=1;
+									name="ACE_tourniquet";
+									count=2;
 								};
 								class Item3
 								{
-									name="ACE_tourniquet";
+									name="ACE_morphine";
 									count=1;
 								};
 								class Item4
 								{
-									name="rhsusf_acc_M952V";
+									name="ACE_epinephrine";
 									count=1;
 								};
 								class Item5
+								{
+									name="rhsusf_acc_M952V";
+									count=1;
+								};
+								class Item6
 								{
 									name="ACRE_PRC343";
 									count=1;
@@ -4995,39 +4890,24 @@ class items
 							isBackpack=0;
 							class MagazineCargo
 							{
-								items=4;
+								items=3;
 								class Item0
-								{
-									name="rhsusf_mag_15Rnd_9x19_JHP";
-									count=1;
-									ammoLeft=15;
-								};
-								class Item1
-								{
-									name="HandGrenade";
-									count=2;
-									ammoLeft=1;
-								};
-								class Item2
 								{
 									name="rhs_mag_30Rnd_556x45_M855A1_PMAG";
 									count=8;
 									ammoLeft=30;
 								};
-								class Item3
+								class Item1
 								{
 									name="rhs_mag_30Rnd_556x45_M855A1_PMAG_Tracer_Red";
 									count=2;
 									ammoLeft=30;
 								};
-							};
-							class ItemCargo
-							{
-								items=1;
-								class Item0
+								class Item2
 								{
-									name="ACE_tourniquet";
-									count=1;
+									name="HandGrenade";
+									count=2;
+									ammoLeft=1;
 								};
 							};
 						};
@@ -5041,7 +4921,7 @@ class items
 								class Item0
 								{
 									name="SmokeShell";
-									count=8;
+									count=10;
 									ammoLeft=1;
 								};
 								class Item1
@@ -5223,7 +5103,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-1.338623,0.0014390945,3.9838867};
+					position[]={-1.4594727,0.0014390945,4.0700684};
 				};
 				side="West";
 				flags=5;
@@ -5272,14 +5152,14 @@ class items
 								items=1;
 								class Item0
 								{
-									name="SmokeShell";
-									count=4;
-									ammoLeft=1;
+									name="rhsusf_mag_15Rnd_9x19_JHP";
+									count=1;
+									ammoLeft=15;
 								};
 							};
 							class ItemCargo
 							{
-								items=8;
+								items=9;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -5292,32 +5172,37 @@ class items
 								};
 								class Item2
 								{
-									name="ACE_morphine";
-									count=1;
+									name="ACE_tourniquet";
+									count=2;
 								};
 								class Item3
 								{
-									name="ACE_tourniquet";
+									name="ACE_morphine";
 									count=1;
 								};
 								class Item4
 								{
-									name="rhsusf_acc_M952V";
+									name="ACE_epinephrine";
 									count=1;
 								};
 								class Item5
 								{
-									name="ACRE_PRC343";
-									count=1;
-								};
-								class Item6
-								{
 									name="ACE_CableTie";
 									count=2;
 								};
-								class Item7
+								class Item6
 								{
 									name="ACE_MapTools";
+									count=1;
+								};
+								class Item7
+								{
+									name="rhsusf_acc_M952V";
+									count=1;
+								};
+								class Item8
+								{
+									name="ACRE_PRC343";
 									count=1;
 								};
 							};
@@ -5328,39 +5213,24 @@ class items
 							isBackpack=0;
 							class MagazineCargo
 							{
-								items=4;
+								items=3;
 								class Item0
-								{
-									name="rhsusf_mag_15Rnd_9x19_JHP";
-									count=1;
-									ammoLeft=15;
-								};
-								class Item1
-								{
-									name="HandGrenade";
-									count=2;
-									ammoLeft=1;
-								};
-								class Item2
 								{
 									name="rhs_mag_30Rnd_556x45_M855A1_PMAG";
 									count=6;
 									ammoLeft=30;
 								};
-								class Item3
+								class Item1
 								{
 									name="rhs_mag_30Rnd_556x45_M855A1_PMAG_Tracer_Red";
 									count=4;
 									ammoLeft=30;
 								};
-							};
-							class ItemCargo
-							{
-								items=1;
-								class Item0
+								class Item2
 								{
-									name="ACE_tourniquet";
-									count=1;
+									name="HandGrenade";
+									count=2;
+									ammoLeft=1;
 								};
 							};
 						};
@@ -5392,7 +5262,7 @@ class items
 								class Item3
 								{
 									name="SmokeShell";
-									count=3;
+									count=7;
 									ammoLeft=1;
 								};
 								class Item4
@@ -5549,7 +5419,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-0.33862305,0.0014390945,3.9838867};
+					position[]={-0.45947266,0.0014390945,4.0700684};
 				};
 				side="West";
 				flags=5;
@@ -5589,14 +5459,14 @@ class items
 								items=1;
 								class Item0
 								{
-									name="SmokeShell";
-									count=4;
-									ammoLeft=1;
+									name="rhsusf_mag_15Rnd_9x19_JHP";
+									count=1;
+									ammoLeft=15;
 								};
 							};
 							class ItemCargo
 							{
-								items=6;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -5609,20 +5479,25 @@ class items
 								};
 								class Item2
 								{
-									name="ACE_morphine";
-									count=1;
+									name="ACE_tourniquet";
+									count=2;
 								};
 								class Item3
 								{
-									name="ACE_tourniquet";
+									name="ACE_morphine";
 									count=1;
 								};
 								class Item4
 								{
-									name="rhsusf_acc_M952V";
+									name="ACE_epinephrine";
 									count=1;
 								};
 								class Item5
+								{
+									name="rhsusf_acc_M952V";
+									count=1;
+								};
+								class Item6
 								{
 									name="ACRE_PRC343";
 									count=1;
@@ -5635,7 +5510,7 @@ class items
 							isBackpack=0;
 							class MagazineCargo
 							{
-								items=3;
+								items=2;
 								class Item0
 								{
 									name="rhsusf_100Rnd_556x45_soft_pouch";
@@ -5644,24 +5519,9 @@ class items
 								};
 								class Item1
 								{
-									name="rhsusf_mag_15Rnd_9x19_JHP";
-									count=1;
-									ammoLeft=15;
-								};
-								class Item2
-								{
 									name="HandGrenade";
 									count=2;
 									ammoLeft=1;
-								};
-							};
-							class ItemCargo
-							{
-								items=1;
-								class Item0
-								{
-									name="ACE_tourniquet";
-									count=1;
 								};
 							};
 						};
@@ -5810,7 +5670,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={0.66137695,0.0014390945,3.9838867};
+					position[]={0.54052734,0.0014390945,4.0700684};
 				};
 				side="West";
 				flags=5;
@@ -5853,14 +5713,14 @@ class items
 								items=1;
 								class Item0
 								{
-									name="SmokeShell";
-									count=4;
-									ammoLeft=1;
+									name="rhsusf_mag_15Rnd_9x19_JHP";
+									count=1;
+									ammoLeft=15;
 								};
 							};
 							class ItemCargo
 							{
-								items=8;
+								items=9;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -5873,32 +5733,37 @@ class items
 								};
 								class Item2
 								{
-									name="ACE_morphine";
-									count=1;
+									name="ACE_tourniquet";
+									count=2;
 								};
 								class Item3
 								{
-									name="ACE_tourniquet";
+									name="ACE_morphine";
 									count=1;
 								};
 								class Item4
 								{
-									name="rhsusf_acc_M952V";
+									name="ACE_epinephrine";
 									count=1;
 								};
 								class Item5
 								{
-									name="ACRE_PRC343";
-									count=1;
-								};
-								class Item6
-								{
 									name="ACE_CableTie";
 									count=2;
 								};
-								class Item7
+								class Item6
 								{
 									name="ACE_MapTools";
+									count=1;
+								};
+								class Item7
+								{
+									name="rhsusf_acc_M952V";
+									count=1;
+								};
+								class Item8
+								{
+									name="ACRE_PRC343";
 									count=1;
 								};
 							};
@@ -5909,39 +5774,24 @@ class items
 							isBackpack=0;
 							class MagazineCargo
 							{
-								items=4;
+								items=3;
 								class Item0
 								{
-									name="rhsusf_mag_15Rnd_9x19_JHP";
-									count=1;
-									ammoLeft=15;
+									name="rhs_mag_30Rnd_556x45_M855A1_PMAG";
+									count=8;
+									ammoLeft=30;
 								};
 								class Item1
+								{
+									name="rhs_mag_30Rnd_556x45_M855A1_PMAG_Tracer_Red";
+									count=2;
+									ammoLeft=30;
+								};
+								class Item2
 								{
 									name="HandGrenade";
 									count=2;
 									ammoLeft=1;
-								};
-								class Item2
-								{
-									name="rhs_mag_30Rnd_556x45_M855A1_PMAG";
-									count=6;
-									ammoLeft=30;
-								};
-								class Item3
-								{
-									name="rhs_mag_30Rnd_556x45_M855A1_PMAG_Tracer_Red";
-									count=4;
-									ammoLeft=30;
-								};
-							};
-							class ItemCargo
-							{
-								items=1;
-								class Item0
-								{
-									name="ACE_tourniquet";
-									count=1;
 								};
 							};
 						};
@@ -5954,39 +5804,39 @@ class items
 								items=6;
 								class Item0
 								{
+									name="rhs_mag_30Rnd_556x45_M855A1_PMAG";
+									count=9;
+									ammoLeft=30;
+								};
+								class Item1
+								{
 									name="rhsusf_100Rnd_556x45_soft_pouch";
 									count=2;
 									ammoLeft=100;
 								};
-								class Item1
-								{
-									name="SmokeShell";
-									count=3;
-									ammoLeft=1;
-								};
 								class Item2
-								{
-									name="SmokeShellGreen";
-									count=2;
-									ammoLeft=1;
-								};
-								class Item3
-								{
-									name="SmokeShellBlue";
-									count=1;
-									ammoLeft=1;
-								};
-								class Item4
 								{
 									name="HandGrenade";
 									count=2;
 									ammoLeft=1;
 								};
+								class Item3
+								{
+									name="SmokeShell";
+									count=4;
+									ammoLeft=1;
+								};
+								class Item4
+								{
+									name="SmokeShellGreen";
+									count=2;
+									ammoLeft=1;
+								};
 								class Item5
 								{
-									name="rhs_mag_30Rnd_556x45_M855A1_PMAG";
-									count=8;
-									ammoLeft=30;
+									name="SmokeShellBlue";
+									count=1;
+									ammoLeft=1;
 								};
 							};
 							class ItemCargo
@@ -6130,7 +5980,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={1.661377,0.0014390945,3.9838867};
+					position[]={1.5405273,0.0014390945,4.0700684};
 				};
 				side="West";
 				flags=5;
@@ -6173,14 +6023,14 @@ class items
 								items=1;
 								class Item0
 								{
-									name="SmokeShell";
-									count=4;
-									ammoLeft=1;
+									name="rhsusf_mag_15Rnd_9x19_JHP";
+									count=2;
+									ammoLeft=15;
 								};
 							};
 							class ItemCargo
 							{
-								items=6;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -6193,20 +6043,25 @@ class items
 								};
 								class Item2
 								{
-									name="ACE_morphine";
-									count=1;
+									name="ACE_tourniquet";
+									count=2;
 								};
 								class Item3
 								{
-									name="ACE_tourniquet";
+									name="ACE_morphine";
 									count=1;
 								};
 								class Item4
 								{
-									name="rhsusf_acc_M952V";
+									name="ACE_epinephrine";
 									count=1;
 								};
 								class Item5
+								{
+									name="rhsusf_acc_M952V";
+									count=1;
+								};
+								class Item6
 								{
 									name="ACRE_PRC343";
 									count=1;
@@ -6222,36 +6077,27 @@ class items
 								items=4;
 								class Item0
 								{
-									name="rhsusf_mag_15Rnd_9x19_JHP";
-									count=1;
-									ammoLeft=15;
-								};
-								class Item1
-								{
-									name="HandGrenade";
-									count=2;
-									ammoLeft=1;
-								};
-								class Item2
-								{
 									name="rhs_mag_30Rnd_556x45_M855A1_PMAG";
 									count=8;
 									ammoLeft=30;
 								};
-								class Item3
+								class Item1
 								{
 									name="rhs_mag_30Rnd_556x45_M855A1_PMAG_Tracer_Red";
 									count=2;
 									ammoLeft=30;
 								};
-							};
-							class ItemCargo
-							{
-								items=1;
-								class Item0
+								class Item2
 								{
-									name="ACE_tourniquet";
-									count=1;
+									name="HandGrenade";
+									count=2;
+									ammoLeft=1;
+								};
+								class Item3
+								{
+									name="SmokeShell";
+									count=4;
+									ammoLeft=1;
 								};
 							};
 						};
@@ -6385,7 +6231,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-1.338623,0.0014390945,1.9838867};
+					position[]={-1.4594727,0.0014390945,2.0700684};
 				};
 				side="West";
 				flags=5;
@@ -6434,14 +6280,14 @@ class items
 								items=1;
 								class Item0
 								{
-									name="SmokeShell";
-									count=4;
-									ammoLeft=1;
+									name="rhsusf_mag_15Rnd_9x19_JHP";
+									count=1;
+									ammoLeft=15;
 								};
 							};
 							class ItemCargo
 							{
-								items=8;
+								items=9;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -6454,32 +6300,37 @@ class items
 								};
 								class Item2
 								{
-									name="ACE_morphine";
-									count=1;
+									name="ACE_tourniquet";
+									count=2;
 								};
 								class Item3
 								{
-									name="ACE_tourniquet";
+									name="ACE_morphine";
 									count=1;
 								};
 								class Item4
 								{
-									name="rhsusf_acc_M952V";
+									name="ACE_epinephrine";
 									count=1;
 								};
 								class Item5
 								{
-									name="ACRE_PRC343";
-									count=1;
-								};
-								class Item6
-								{
 									name="ACE_CableTie";
 									count=2;
 								};
-								class Item7
+								class Item6
 								{
 									name="ACE_MapTools";
+									count=1;
+								};
+								class Item7
+								{
+									name="rhsusf_acc_M952V";
+									count=1;
+								};
+								class Item8
+								{
+									name="ACRE_PRC343";
 									count=1;
 								};
 							};
@@ -6490,39 +6341,24 @@ class items
 							isBackpack=0;
 							class MagazineCargo
 							{
-								items=4;
+								items=3;
 								class Item0
-								{
-									name="rhsusf_mag_15Rnd_9x19_JHP";
-									count=1;
-									ammoLeft=15;
-								};
-								class Item1
-								{
-									name="HandGrenade";
-									count=2;
-									ammoLeft=1;
-								};
-								class Item2
 								{
 									name="rhs_mag_30Rnd_556x45_M855A1_PMAG";
 									count=6;
 									ammoLeft=30;
 								};
-								class Item3
+								class Item1
 								{
 									name="rhs_mag_30Rnd_556x45_M855A1_PMAG_Tracer_Red";
 									count=4;
 									ammoLeft=30;
 								};
-							};
-							class ItemCargo
-							{
-								items=1;
-								class Item0
+								class Item2
 								{
-									name="ACE_tourniquet";
-									count=1;
+									name="HandGrenade";
+									count=2;
+									ammoLeft=1;
 								};
 							};
 						};
@@ -6554,7 +6390,7 @@ class items
 								class Item3
 								{
 									name="SmokeShell";
-									count=3;
+									count=7;
 									ammoLeft=1;
 								};
 								class Item4
@@ -6711,7 +6547,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-0.33862305,0.0014390945,1.9838867};
+					position[]={-0.45947266,0.0014390945,2.0700684};
 				};
 				side="West";
 				flags=5;
@@ -6751,14 +6587,14 @@ class items
 								items=1;
 								class Item0
 								{
-									name="SmokeShell";
-									count=4;
-									ammoLeft=1;
+									name="rhsusf_mag_15Rnd_9x19_JHP";
+									count=1;
+									ammoLeft=15;
 								};
 							};
 							class ItemCargo
 							{
-								items=6;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -6771,20 +6607,25 @@ class items
 								};
 								class Item2
 								{
-									name="ACE_morphine";
-									count=1;
+									name="ACE_tourniquet";
+									count=2;
 								};
 								class Item3
 								{
-									name="ACE_tourniquet";
+									name="ACE_morphine";
 									count=1;
 								};
 								class Item4
 								{
-									name="rhsusf_acc_M952V";
+									name="ACE_epinephrine";
 									count=1;
 								};
 								class Item5
+								{
+									name="rhsusf_acc_M952V";
+									count=1;
+								};
+								class Item6
 								{
 									name="ACRE_PRC343";
 									count=1;
@@ -6797,7 +6638,7 @@ class items
 							isBackpack=0;
 							class MagazineCargo
 							{
-								items=3;
+								items=2;
 								class Item0
 								{
 									name="rhsusf_100Rnd_556x45_soft_pouch";
@@ -6806,24 +6647,9 @@ class items
 								};
 								class Item1
 								{
-									name="rhsusf_mag_15Rnd_9x19_JHP";
-									count=1;
-									ammoLeft=15;
-								};
-								class Item2
-								{
 									name="HandGrenade";
 									count=2;
 									ammoLeft=1;
-								};
-							};
-							class ItemCargo
-							{
-								items=1;
-								class Item0
-								{
-									name="ACE_tourniquet";
-									count=1;
 								};
 							};
 						};
@@ -6972,7 +6798,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={0.66137695,0.0014390945,1.9838867};
+					position[]={0.54052734,0.0014390945,2.0700684};
 				};
 				side="West";
 				flags=5;
@@ -7015,14 +6841,14 @@ class items
 								items=1;
 								class Item0
 								{
-									name="SmokeShell";
-									count=4;
-									ammoLeft=1;
+									name="rhsusf_mag_15Rnd_9x19_JHP";
+									count=1;
+									ammoLeft=15;
 								};
 							};
 							class ItemCargo
 							{
-								items=8;
+								items=9;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -7035,32 +6861,37 @@ class items
 								};
 								class Item2
 								{
-									name="ACE_morphine";
-									count=1;
+									name="ACE_tourniquet";
+									count=2;
 								};
 								class Item3
 								{
-									name="ACE_tourniquet";
+									name="ACE_morphine";
 									count=1;
 								};
 								class Item4
 								{
-									name="rhsusf_acc_M952V";
+									name="ACE_epinephrine";
 									count=1;
 								};
 								class Item5
 								{
-									name="ACRE_PRC343";
-									count=1;
-								};
-								class Item6
-								{
 									name="ACE_CableTie";
 									count=2;
 								};
-								class Item7
+								class Item6
 								{
 									name="ACE_MapTools";
+									count=1;
+								};
+								class Item7
+								{
+									name="rhsusf_acc_M952V";
+									count=1;
+								};
+								class Item8
+								{
+									name="ACRE_PRC343";
 									count=1;
 								};
 							};
@@ -7071,39 +6902,24 @@ class items
 							isBackpack=0;
 							class MagazineCargo
 							{
-								items=4;
+								items=3;
 								class Item0
 								{
-									name="rhsusf_mag_15Rnd_9x19_JHP";
-									count=1;
-									ammoLeft=15;
+									name="rhs_mag_30Rnd_556x45_M855A1_PMAG";
+									count=8;
+									ammoLeft=30;
 								};
 								class Item1
+								{
+									name="rhs_mag_30Rnd_556x45_M855A1_PMAG_Tracer_Red";
+									count=2;
+									ammoLeft=30;
+								};
+								class Item2
 								{
 									name="HandGrenade";
 									count=2;
 									ammoLeft=1;
-								};
-								class Item2
-								{
-									name="rhs_mag_30Rnd_556x45_M855A1_PMAG";
-									count=6;
-									ammoLeft=30;
-								};
-								class Item3
-								{
-									name="rhs_mag_30Rnd_556x45_M855A1_PMAG_Tracer_Red";
-									count=4;
-									ammoLeft=30;
-								};
-							};
-							class ItemCargo
-							{
-								items=1;
-								class Item0
-								{
-									name="ACE_tourniquet";
-									count=1;
 								};
 							};
 						};
@@ -7116,39 +6932,39 @@ class items
 								items=6;
 								class Item0
 								{
+									name="rhs_mag_30Rnd_556x45_M855A1_PMAG";
+									count=9;
+									ammoLeft=30;
+								};
+								class Item1
+								{
 									name="rhsusf_100Rnd_556x45_soft_pouch";
 									count=2;
 									ammoLeft=100;
 								};
-								class Item1
-								{
-									name="SmokeShell";
-									count=3;
-									ammoLeft=1;
-								};
 								class Item2
-								{
-									name="SmokeShellGreen";
-									count=2;
-									ammoLeft=1;
-								};
-								class Item3
-								{
-									name="SmokeShellBlue";
-									count=1;
-									ammoLeft=1;
-								};
-								class Item4
 								{
 									name="HandGrenade";
 									count=2;
 									ammoLeft=1;
 								};
+								class Item3
+								{
+									name="SmokeShell";
+									count=4;
+									ammoLeft=1;
+								};
+								class Item4
+								{
+									name="SmokeShellGreen";
+									count=2;
+									ammoLeft=1;
+								};
 								class Item5
 								{
-									name="rhs_mag_30Rnd_556x45_M855A1_PMAG";
-									count=8;
-									ammoLeft=30;
+									name="SmokeShellBlue";
+									count=1;
+									ammoLeft=1;
 								};
 							};
 							class ItemCargo
@@ -7292,7 +7108,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={1.661377,0.0014390945,1.9838867};
+					position[]={1.5405273,0.0014390945,2.0700684};
 				};
 				side="West";
 				flags=5;
@@ -7335,14 +7151,14 @@ class items
 								items=1;
 								class Item0
 								{
-									name="SmokeShell";
-									count=4;
-									ammoLeft=1;
+									name="rhsusf_mag_15Rnd_9x19_JHP";
+									count=2;
+									ammoLeft=15;
 								};
 							};
 							class ItemCargo
 							{
-								items=6;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -7355,20 +7171,25 @@ class items
 								};
 								class Item2
 								{
-									name="ACE_morphine";
-									count=1;
+									name="ACE_tourniquet";
+									count=2;
 								};
 								class Item3
 								{
-									name="ACE_tourniquet";
+									name="ACE_morphine";
 									count=1;
 								};
 								class Item4
 								{
-									name="rhsusf_acc_M952V";
+									name="ACE_epinephrine";
 									count=1;
 								};
 								class Item5
+								{
+									name="rhsusf_acc_M952V";
+									count=1;
+								};
+								class Item6
 								{
 									name="ACRE_PRC343";
 									count=1;
@@ -7384,36 +7205,27 @@ class items
 								items=4;
 								class Item0
 								{
-									name="rhsusf_mag_15Rnd_9x19_JHP";
-									count=1;
-									ammoLeft=15;
-								};
-								class Item1
-								{
-									name="HandGrenade";
-									count=2;
-									ammoLeft=1;
-								};
-								class Item2
-								{
 									name="rhs_mag_30Rnd_556x45_M855A1_PMAG";
 									count=8;
 									ammoLeft=30;
 								};
-								class Item3
+								class Item1
 								{
 									name="rhs_mag_30Rnd_556x45_M855A1_PMAG_Tracer_Red";
 									count=2;
 									ammoLeft=30;
 								};
-							};
-							class ItemCargo
-							{
-								items=1;
-								class Item0
+								class Item2
 								{
-									name="ACE_tourniquet";
-									count=1;
+									name="HandGrenade";
+									count=2;
+									ammoLeft=1;
+								};
+								class Item3
+								{
+									name="SmokeShell";
+									count=4;
+									ammoLeft=1;
 								};
 							};
 						};
@@ -7583,7 +7395,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={3.9719238,0.0014390945,5.9799805};
+					position[]={3.8510742,0.0014390945,6.0661621};
 				};
 				side="West";
 				flags=7;
@@ -7632,9 +7444,9 @@ class items
 								items=1;
 								class Item0
 								{
-									name="SmokeShell";
-									count=2;
-									ammoLeft=1;
+									name="rhsusf_mag_15Rnd_9x19_JHP";
+									count=1;
+									ammoLeft=15;
 								};
 							};
 							class ItemCargo
@@ -7652,37 +7464,37 @@ class items
 								};
 								class Item2
 								{
-									name="ACE_morphine";
-									count=1;
+									name="ACE_tourniquet";
+									count=2;
 								};
 								class Item3
 								{
-									name="ACE_tourniquet";
+									name="ACE_morphine";
 									count=1;
 								};
 								class Item4
 								{
-									name="rhsusf_acc_M952V";
+									name="ACE_epinephrine";
 									count=1;
 								};
 								class Item5
 								{
-									name="ACRE_PRC343";
-									count=1;
-								};
-								class Item6
-								{
 									name="ACE_CableTie";
 									count=2;
 								};
-								class Item7
+								class Item6
 								{
 									name="ACE_MapTools";
 									count=1;
 								};
+								class Item7
+								{
+									name="rhs_acc_2dpZenit";
+									count=1;
+								};
 								class Item8
 								{
-									name="ACRE_PRC152";
+									name="ACRE_PRC343";
 									count=1;
 								};
 							};
@@ -7693,45 +7505,24 @@ class items
 							isBackpack=0;
 							class MagazineCargo
 							{
-								items=5;
+								items=3;
 								class Item0
 								{
-									name="SmokeShell";
-									count=2;
-									ammoLeft=1;
+									name="rhs_mag_30Rnd_556x45_M855A1_PMAG";
+									count=6;
+									ammoLeft=30;
 								};
 								class Item1
 								{
-									name="rhsusf_mag_15Rnd_9x19_JHP";
-									count=1;
-									ammoLeft=15;
+									name="rhs_mag_30Rnd_556x45_M855A1_PMAG_Tracer_Red";
+									count=4;
+									ammoLeft=30;
 								};
 								class Item2
 								{
 									name="HandGrenade";
 									count=2;
 									ammoLeft=1;
-								};
-								class Item3
-								{
-									name="rhs_mag_30Rnd_556x45_M855A1_PMAG";
-									count=6;
-									ammoLeft=30;
-								};
-								class Item4
-								{
-									name="rhs_mag_30Rnd_556x45_M855A1_PMAG_Tracer_Red";
-									count=4;
-									ammoLeft=30;
-								};
-							};
-							class ItemCargo
-							{
-								items=1;
-								class Item0
-								{
-									name="ACE_tourniquet";
-									count=1;
 								};
 							};
 						};
@@ -7769,7 +7560,7 @@ class items
 								class Item4
 								{
 									name="SmokeShell";
-									count=3;
+									count=7;
 									ammoLeft=1;
 								};
 								class Item5
@@ -7787,10 +7578,15 @@ class items
 							};
 							class ItemCargo
 							{
-								items=1;
+								items=2;
 								class Item0
 								{
 									name="ACE_IR_Strobe_Item";
+									count=1;
+								};
+								class Item1
+								{
+									name="ACRE_PRC152";
 									count=1;
 								};
 							};
@@ -7959,7 +7755,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={4.9719238,0.0014390945,5.9790039};
+					position[]={4.8510742,0.0014390945,6.0651855};
 				};
 				side="West";
 				flags=5;
@@ -7998,14 +7794,14 @@ class items
 								items=1;
 								class Item0
 								{
-									name="SmokeShell";
-									count=4;
-									ammoLeft=1;
+									name="rhsusf_mag_15Rnd_9x19_JHP";
+									count=2;
+									ammoLeft=15;
 								};
 							};
 							class ItemCargo
 							{
-								items=6;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -8018,20 +7814,25 @@ class items
 								};
 								class Item2
 								{
-									name="ACE_morphine";
-									count=1;
+									name="ACE_tourniquet";
+									count=2;
 								};
 								class Item3
 								{
-									name="ACE_tourniquet";
+									name="ACE_morphine";
 									count=1;
 								};
 								class Item4
 								{
-									name="rhsusf_acc_M952V";
+									name="ACE_epinephrine";
 									count=1;
 								};
 								class Item5
+								{
+									name="rhsusf_acc_M952V";
+									count=1;
+								};
+								class Item6
 								{
 									name="ACRE_PRC343";
 									count=1;
@@ -8044,39 +7845,24 @@ class items
 							isBackpack=0;
 							class MagazineCargo
 							{
-								items=4;
+								items=3;
 								class Item0
-								{
-									name="rhsusf_mag_15Rnd_9x19_JHP";
-									count=1;
-									ammoLeft=15;
-								};
-								class Item1
-								{
-									name="HandGrenade";
-									count=2;
-									ammoLeft=1;
-								};
-								class Item2
 								{
 									name="rhs_mag_30Rnd_556x45_M855A1_PMAG";
 									count=8;
 									ammoLeft=30;
 								};
-								class Item3
+								class Item1
 								{
 									name="rhs_mag_30Rnd_556x45_M855A1_PMAG_Tracer_Red";
 									count=2;
 									ammoLeft=30;
 								};
-							};
-							class ItemCargo
-							{
-								items=1;
-								class Item0
+								class Item2
 								{
-									name="ACE_tourniquet";
-									count=1;
+									name="HandGrenade";
+									count=2;
+									ammoLeft=1;
 								};
 							};
 						};
@@ -8090,7 +7876,7 @@ class items
 								class Item0
 								{
 									name="SmokeShell";
-									count=8;
+									count=10;
 									ammoLeft=1;
 								};
 								class Item1
@@ -8272,7 +8058,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={3.9719238,0.0014390945,3.9790039};
+					position[]={3.8510742,0.0014390945,4.0651855};
 				};
 				side="West";
 				flags=5;
@@ -8321,14 +8107,14 @@ class items
 								items=1;
 								class Item0
 								{
-									name="SmokeShell";
-									count=4;
-									ammoLeft=1;
+									name="rhsusf_mag_15Rnd_9x19_JHP";
+									count=1;
+									ammoLeft=15;
 								};
 							};
 							class ItemCargo
 							{
-								items=8;
+								items=9;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -8341,32 +8127,37 @@ class items
 								};
 								class Item2
 								{
-									name="ACE_morphine";
-									count=1;
+									name="ACE_tourniquet";
+									count=2;
 								};
 								class Item3
 								{
-									name="ACE_tourniquet";
+									name="ACE_morphine";
 									count=1;
 								};
 								class Item4
 								{
-									name="rhsusf_acc_M952V";
+									name="ACE_epinephrine";
 									count=1;
 								};
 								class Item5
 								{
-									name="ACRE_PRC343";
-									count=1;
-								};
-								class Item6
-								{
 									name="ACE_CableTie";
 									count=2;
 								};
-								class Item7
+								class Item6
 								{
 									name="ACE_MapTools";
+									count=1;
+								};
+								class Item7
+								{
+									name="rhsusf_acc_M952V";
+									count=1;
+								};
+								class Item8
+								{
+									name="ACRE_PRC343";
 									count=1;
 								};
 							};
@@ -8377,39 +8168,24 @@ class items
 							isBackpack=0;
 							class MagazineCargo
 							{
-								items=4;
+								items=3;
 								class Item0
-								{
-									name="rhsusf_mag_15Rnd_9x19_JHP";
-									count=1;
-									ammoLeft=15;
-								};
-								class Item1
-								{
-									name="HandGrenade";
-									count=2;
-									ammoLeft=1;
-								};
-								class Item2
 								{
 									name="rhs_mag_30Rnd_556x45_M855A1_PMAG";
 									count=6;
 									ammoLeft=30;
 								};
-								class Item3
+								class Item1
 								{
 									name="rhs_mag_30Rnd_556x45_M855A1_PMAG_Tracer_Red";
 									count=4;
 									ammoLeft=30;
 								};
-							};
-							class ItemCargo
-							{
-								items=1;
-								class Item0
+								class Item2
 								{
-									name="ACE_tourniquet";
-									count=1;
+									name="HandGrenade";
+									count=2;
+									ammoLeft=1;
 								};
 							};
 						};
@@ -8441,7 +8217,7 @@ class items
 								class Item3
 								{
 									name="SmokeShell";
-									count=3;
+									count=7;
 									ammoLeft=1;
 								};
 								class Item4
@@ -8598,7 +8374,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={4.9719238,0.0014390945,3.9790039};
+					position[]={4.8510742,0.0014390945,4.0651855};
 				};
 				side="West";
 				flags=5;
@@ -8638,14 +8414,14 @@ class items
 								items=1;
 								class Item0
 								{
-									name="SmokeShell";
-									count=4;
-									ammoLeft=1;
+									name="rhsusf_mag_15Rnd_9x19_JHP";
+									count=1;
+									ammoLeft=15;
 								};
 							};
 							class ItemCargo
 							{
-								items=6;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -8658,20 +8434,25 @@ class items
 								};
 								class Item2
 								{
-									name="ACE_morphine";
-									count=1;
+									name="ACE_tourniquet";
+									count=2;
 								};
 								class Item3
 								{
-									name="ACE_tourniquet";
+									name="ACE_morphine";
 									count=1;
 								};
 								class Item4
 								{
-									name="rhsusf_acc_M952V";
+									name="ACE_epinephrine";
 									count=1;
 								};
 								class Item5
+								{
+									name="rhsusf_acc_M952V";
+									count=1;
+								};
+								class Item6
 								{
 									name="ACRE_PRC343";
 									count=1;
@@ -8684,7 +8465,7 @@ class items
 							isBackpack=0;
 							class MagazineCargo
 							{
-								items=3;
+								items=2;
 								class Item0
 								{
 									name="rhsusf_100Rnd_556x45_soft_pouch";
@@ -8693,24 +8474,9 @@ class items
 								};
 								class Item1
 								{
-									name="rhsusf_mag_15Rnd_9x19_JHP";
-									count=1;
-									ammoLeft=15;
-								};
-								class Item2
-								{
 									name="HandGrenade";
 									count=2;
 									ammoLeft=1;
-								};
-							};
-							class ItemCargo
-							{
-								items=1;
-								class Item0
-								{
-									name="ACE_tourniquet";
-									count=1;
 								};
 							};
 						};
@@ -8859,7 +8625,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={5.9719238,0.0014390945,3.9790039};
+					position[]={5.8510742,0.0014390945,4.0651855};
 				};
 				side="West";
 				flags=5;
@@ -8902,14 +8668,14 @@ class items
 								items=1;
 								class Item0
 								{
-									name="SmokeShell";
-									count=4;
-									ammoLeft=1;
+									name="rhsusf_mag_15Rnd_9x19_JHP";
+									count=1;
+									ammoLeft=15;
 								};
 							};
 							class ItemCargo
 							{
-								items=8;
+								items=9;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -8922,32 +8688,37 @@ class items
 								};
 								class Item2
 								{
-									name="ACE_morphine";
-									count=1;
+									name="ACE_tourniquet";
+									count=2;
 								};
 								class Item3
 								{
-									name="ACE_tourniquet";
+									name="ACE_morphine";
 									count=1;
 								};
 								class Item4
 								{
-									name="rhsusf_acc_M952V";
+									name="ACE_epinephrine";
 									count=1;
 								};
 								class Item5
 								{
-									name="ACRE_PRC343";
-									count=1;
-								};
-								class Item6
-								{
 									name="ACE_CableTie";
 									count=2;
 								};
-								class Item7
+								class Item6
 								{
 									name="ACE_MapTools";
+									count=1;
+								};
+								class Item7
+								{
+									name="rhsusf_acc_M952V";
+									count=1;
+								};
+								class Item8
+								{
+									name="ACRE_PRC343";
 									count=1;
 								};
 							};
@@ -8958,39 +8729,24 @@ class items
 							isBackpack=0;
 							class MagazineCargo
 							{
-								items=4;
+								items=3;
 								class Item0
 								{
-									name="rhsusf_mag_15Rnd_9x19_JHP";
-									count=1;
-									ammoLeft=15;
+									name="rhs_mag_30Rnd_556x45_M855A1_PMAG";
+									count=8;
+									ammoLeft=30;
 								};
 								class Item1
+								{
+									name="rhs_mag_30Rnd_556x45_M855A1_PMAG_Tracer_Red";
+									count=2;
+									ammoLeft=30;
+								};
+								class Item2
 								{
 									name="HandGrenade";
 									count=2;
 									ammoLeft=1;
-								};
-								class Item2
-								{
-									name="rhs_mag_30Rnd_556x45_M855A1_PMAG";
-									count=6;
-									ammoLeft=30;
-								};
-								class Item3
-								{
-									name="rhs_mag_30Rnd_556x45_M855A1_PMAG_Tracer_Red";
-									count=4;
-									ammoLeft=30;
-								};
-							};
-							class ItemCargo
-							{
-								items=1;
-								class Item0
-								{
-									name="ACE_tourniquet";
-									count=1;
 								};
 							};
 						};
@@ -9003,39 +8759,39 @@ class items
 								items=6;
 								class Item0
 								{
+									name="rhs_mag_30Rnd_556x45_M855A1_PMAG";
+									count=9;
+									ammoLeft=30;
+								};
+								class Item1
+								{
 									name="rhsusf_100Rnd_556x45_soft_pouch";
 									count=2;
 									ammoLeft=100;
 								};
-								class Item1
-								{
-									name="SmokeShell";
-									count=3;
-									ammoLeft=1;
-								};
 								class Item2
-								{
-									name="SmokeShellGreen";
-									count=2;
-									ammoLeft=1;
-								};
-								class Item3
-								{
-									name="SmokeShellBlue";
-									count=1;
-									ammoLeft=1;
-								};
-								class Item4
 								{
 									name="HandGrenade";
 									count=2;
 									ammoLeft=1;
 								};
+								class Item3
+								{
+									name="SmokeShell";
+									count=4;
+									ammoLeft=1;
+								};
+								class Item4
+								{
+									name="SmokeShellGreen";
+									count=2;
+									ammoLeft=1;
+								};
 								class Item5
 								{
-									name="rhs_mag_30Rnd_556x45_M855A1_PMAG";
-									count=8;
-									ammoLeft=30;
+									name="SmokeShellBlue";
+									count=1;
+									ammoLeft=1;
 								};
 							};
 							class ItemCargo
@@ -9179,7 +8935,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={6.9719238,0.0014390945,3.9790039};
+					position[]={6.8510742,0.0014390945,4.0651855};
 				};
 				side="West";
 				flags=5;
@@ -9222,14 +8978,14 @@ class items
 								items=1;
 								class Item0
 								{
-									name="SmokeShell";
-									count=4;
-									ammoLeft=1;
+									name="rhsusf_mag_15Rnd_9x19_JHP";
+									count=2;
+									ammoLeft=15;
 								};
 							};
 							class ItemCargo
 							{
-								items=6;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -9242,20 +8998,25 @@ class items
 								};
 								class Item2
 								{
-									name="ACE_morphine";
-									count=1;
+									name="ACE_tourniquet";
+									count=2;
 								};
 								class Item3
 								{
-									name="ACE_tourniquet";
+									name="ACE_morphine";
 									count=1;
 								};
 								class Item4
 								{
-									name="rhsusf_acc_M952V";
+									name="ACE_epinephrine";
 									count=1;
 								};
 								class Item5
+								{
+									name="rhsusf_acc_M952V";
+									count=1;
+								};
+								class Item6
 								{
 									name="ACRE_PRC343";
 									count=1;
@@ -9271,36 +9032,27 @@ class items
 								items=4;
 								class Item0
 								{
-									name="rhsusf_mag_15Rnd_9x19_JHP";
-									count=1;
-									ammoLeft=15;
-								};
-								class Item1
-								{
-									name="HandGrenade";
-									count=2;
-									ammoLeft=1;
-								};
-								class Item2
-								{
 									name="rhs_mag_30Rnd_556x45_M855A1_PMAG";
 									count=8;
 									ammoLeft=30;
 								};
-								class Item3
+								class Item1
 								{
 									name="rhs_mag_30Rnd_556x45_M855A1_PMAG_Tracer_Red";
 									count=2;
 									ammoLeft=30;
 								};
-							};
-							class ItemCargo
-							{
-								items=1;
-								class Item0
+								class Item2
 								{
-									name="ACE_tourniquet";
-									count=1;
+									name="HandGrenade";
+									count=2;
+									ammoLeft=1;
+								};
+								class Item3
+								{
+									name="SmokeShell";
+									count=4;
+									ammoLeft=1;
 								};
 							};
 						};
@@ -9434,7 +9186,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={3.9719238,0.0014390945,1.9790039};
+					position[]={3.8510742,0.0014390945,2.0651855};
 				};
 				side="West";
 				flags=5;
@@ -9483,14 +9235,14 @@ class items
 								items=1;
 								class Item0
 								{
-									name="SmokeShell";
-									count=4;
-									ammoLeft=1;
+									name="rhsusf_mag_15Rnd_9x19_JHP";
+									count=1;
+									ammoLeft=15;
 								};
 							};
 							class ItemCargo
 							{
-								items=8;
+								items=9;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -9503,32 +9255,37 @@ class items
 								};
 								class Item2
 								{
-									name="ACE_morphine";
-									count=1;
+									name="ACE_tourniquet";
+									count=2;
 								};
 								class Item3
 								{
-									name="ACE_tourniquet";
+									name="ACE_morphine";
 									count=1;
 								};
 								class Item4
 								{
-									name="rhsusf_acc_M952V";
+									name="ACE_epinephrine";
 									count=1;
 								};
 								class Item5
 								{
-									name="ACRE_PRC343";
-									count=1;
-								};
-								class Item6
-								{
 									name="ACE_CableTie";
 									count=2;
 								};
-								class Item7
+								class Item6
 								{
 									name="ACE_MapTools";
+									count=1;
+								};
+								class Item7
+								{
+									name="rhsusf_acc_M952V";
+									count=1;
+								};
+								class Item8
+								{
+									name="ACRE_PRC343";
 									count=1;
 								};
 							};
@@ -9539,39 +9296,24 @@ class items
 							isBackpack=0;
 							class MagazineCargo
 							{
-								items=4;
+								items=3;
 								class Item0
-								{
-									name="rhsusf_mag_15Rnd_9x19_JHP";
-									count=1;
-									ammoLeft=15;
-								};
-								class Item1
-								{
-									name="HandGrenade";
-									count=2;
-									ammoLeft=1;
-								};
-								class Item2
 								{
 									name="rhs_mag_30Rnd_556x45_M855A1_PMAG";
 									count=6;
 									ammoLeft=30;
 								};
-								class Item3
+								class Item1
 								{
 									name="rhs_mag_30Rnd_556x45_M855A1_PMAG_Tracer_Red";
 									count=4;
 									ammoLeft=30;
 								};
-							};
-							class ItemCargo
-							{
-								items=1;
-								class Item0
+								class Item2
 								{
-									name="ACE_tourniquet";
-									count=1;
+									name="HandGrenade";
+									count=2;
+									ammoLeft=1;
 								};
 							};
 						};
@@ -9603,7 +9345,7 @@ class items
 								class Item3
 								{
 									name="SmokeShell";
-									count=3;
+									count=7;
 									ammoLeft=1;
 								};
 								class Item4
@@ -9760,7 +9502,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={4.9719238,0.0014390945,1.9790039};
+					position[]={4.8510742,0.0014390945,2.0651855};
 				};
 				side="West";
 				flags=5;
@@ -9800,14 +9542,14 @@ class items
 								items=1;
 								class Item0
 								{
-									name="SmokeShell";
-									count=4;
-									ammoLeft=1;
+									name="rhsusf_mag_15Rnd_9x19_JHP";
+									count=1;
+									ammoLeft=15;
 								};
 							};
 							class ItemCargo
 							{
-								items=6;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -9820,20 +9562,25 @@ class items
 								};
 								class Item2
 								{
-									name="ACE_morphine";
-									count=1;
+									name="ACE_tourniquet";
+									count=2;
 								};
 								class Item3
 								{
-									name="ACE_tourniquet";
+									name="ACE_morphine";
 									count=1;
 								};
 								class Item4
 								{
-									name="rhsusf_acc_M952V";
+									name="ACE_epinephrine";
 									count=1;
 								};
 								class Item5
+								{
+									name="rhsusf_acc_M952V";
+									count=1;
+								};
+								class Item6
 								{
 									name="ACRE_PRC343";
 									count=1;
@@ -9846,7 +9593,7 @@ class items
 							isBackpack=0;
 							class MagazineCargo
 							{
-								items=3;
+								items=2;
 								class Item0
 								{
 									name="rhsusf_100Rnd_556x45_soft_pouch";
@@ -9855,24 +9602,9 @@ class items
 								};
 								class Item1
 								{
-									name="rhsusf_mag_15Rnd_9x19_JHP";
-									count=1;
-									ammoLeft=15;
-								};
-								class Item2
-								{
 									name="HandGrenade";
 									count=2;
 									ammoLeft=1;
-								};
-							};
-							class ItemCargo
-							{
-								items=1;
-								class Item0
-								{
-									name="ACE_tourniquet";
-									count=1;
 								};
 							};
 						};
@@ -10021,7 +9753,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={5.9719238,0.0014390945,1.9790039};
+					position[]={5.8510742,0.0014390945,2.0651855};
 				};
 				side="West";
 				flags=5;
@@ -10064,14 +9796,14 @@ class items
 								items=1;
 								class Item0
 								{
-									name="SmokeShell";
-									count=4;
-									ammoLeft=1;
+									name="rhsusf_mag_15Rnd_9x19_JHP";
+									count=1;
+									ammoLeft=15;
 								};
 							};
 							class ItemCargo
 							{
-								items=8;
+								items=9;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -10084,32 +9816,37 @@ class items
 								};
 								class Item2
 								{
-									name="ACE_morphine";
-									count=1;
+									name="ACE_tourniquet";
+									count=2;
 								};
 								class Item3
 								{
-									name="ACE_tourniquet";
+									name="ACE_morphine";
 									count=1;
 								};
 								class Item4
 								{
-									name="rhsusf_acc_M952V";
+									name="ACE_epinephrine";
 									count=1;
 								};
 								class Item5
 								{
-									name="ACRE_PRC343";
-									count=1;
-								};
-								class Item6
-								{
 									name="ACE_CableTie";
 									count=2;
 								};
-								class Item7
+								class Item6
 								{
 									name="ACE_MapTools";
+									count=1;
+								};
+								class Item7
+								{
+									name="rhsusf_acc_M952V";
+									count=1;
+								};
+								class Item8
+								{
+									name="ACRE_PRC343";
 									count=1;
 								};
 							};
@@ -10120,39 +9857,24 @@ class items
 							isBackpack=0;
 							class MagazineCargo
 							{
-								items=4;
+								items=3;
 								class Item0
 								{
-									name="rhsusf_mag_15Rnd_9x19_JHP";
-									count=1;
-									ammoLeft=15;
+									name="rhs_mag_30Rnd_556x45_M855A1_PMAG";
+									count=8;
+									ammoLeft=30;
 								};
 								class Item1
+								{
+									name="rhs_mag_30Rnd_556x45_M855A1_PMAG_Tracer_Red";
+									count=2;
+									ammoLeft=30;
+								};
+								class Item2
 								{
 									name="HandGrenade";
 									count=2;
 									ammoLeft=1;
-								};
-								class Item2
-								{
-									name="rhs_mag_30Rnd_556x45_M855A1_PMAG";
-									count=6;
-									ammoLeft=30;
-								};
-								class Item3
-								{
-									name="rhs_mag_30Rnd_556x45_M855A1_PMAG_Tracer_Red";
-									count=4;
-									ammoLeft=30;
-								};
-							};
-							class ItemCargo
-							{
-								items=1;
-								class Item0
-								{
-									name="ACE_tourniquet";
-									count=1;
 								};
 							};
 						};
@@ -10165,39 +9887,39 @@ class items
 								items=6;
 								class Item0
 								{
+									name="rhs_mag_30Rnd_556x45_M855A1_PMAG";
+									count=9;
+									ammoLeft=30;
+								};
+								class Item1
+								{
 									name="rhsusf_100Rnd_556x45_soft_pouch";
 									count=2;
 									ammoLeft=100;
 								};
-								class Item1
-								{
-									name="SmokeShell";
-									count=3;
-									ammoLeft=1;
-								};
 								class Item2
-								{
-									name="SmokeShellGreen";
-									count=2;
-									ammoLeft=1;
-								};
-								class Item3
-								{
-									name="SmokeShellBlue";
-									count=1;
-									ammoLeft=1;
-								};
-								class Item4
 								{
 									name="HandGrenade";
 									count=2;
 									ammoLeft=1;
 								};
+								class Item3
+								{
+									name="SmokeShell";
+									count=4;
+									ammoLeft=1;
+								};
+								class Item4
+								{
+									name="SmokeShellGreen";
+									count=2;
+									ammoLeft=1;
+								};
 								class Item5
 								{
-									name="rhs_mag_30Rnd_556x45_M855A1_PMAG";
-									count=8;
-									ammoLeft=30;
+									name="SmokeShellBlue";
+									count=1;
+									ammoLeft=1;
 								};
 							};
 							class ItemCargo
@@ -10341,7 +10063,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={6.9719238,0.0014390945,1.9790039};
+					position[]={6.8510742,0.0014390945,2.0651855};
 				};
 				side="West";
 				flags=5;
@@ -10384,14 +10106,14 @@ class items
 								items=1;
 								class Item0
 								{
-									name="SmokeShell";
-									count=4;
-									ammoLeft=1;
+									name="rhsusf_mag_15Rnd_9x19_JHP";
+									count=2;
+									ammoLeft=15;
 								};
 							};
 							class ItemCargo
 							{
-								items=6;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -10404,20 +10126,25 @@ class items
 								};
 								class Item2
 								{
-									name="ACE_morphine";
-									count=1;
+									name="ACE_tourniquet";
+									count=2;
 								};
 								class Item3
 								{
-									name="ACE_tourniquet";
+									name="ACE_morphine";
 									count=1;
 								};
 								class Item4
 								{
-									name="rhsusf_acc_M952V";
+									name="ACE_epinephrine";
 									count=1;
 								};
 								class Item5
+								{
+									name="rhsusf_acc_M952V";
+									count=1;
+								};
+								class Item6
 								{
 									name="ACRE_PRC343";
 									count=1;
@@ -10433,36 +10160,27 @@ class items
 								items=4;
 								class Item0
 								{
-									name="rhsusf_mag_15Rnd_9x19_JHP";
-									count=1;
-									ammoLeft=15;
-								};
-								class Item1
-								{
-									name="HandGrenade";
-									count=2;
-									ammoLeft=1;
-								};
-								class Item2
-								{
 									name="rhs_mag_30Rnd_556x45_M855A1_PMAG";
 									count=8;
 									ammoLeft=30;
 								};
-								class Item3
+								class Item1
 								{
 									name="rhs_mag_30Rnd_556x45_M855A1_PMAG_Tracer_Red";
 									count=2;
 									ammoLeft=30;
 								};
-							};
-							class ItemCargo
-							{
-								items=1;
-								class Item0
+								class Item2
 								{
-									name="ACE_tourniquet";
-									count=1;
+									name="HandGrenade";
+									count=2;
+									ammoLeft=1;
+								};
+								class Item3
+								{
+									name="SmokeShell";
+									count=4;
+									ammoLeft=1;
 								};
 							};
 						};
@@ -10632,7 +10350,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-6.0732422,0.0014390945,-1.0952148};
+					position[]={-6.1943359,0.0014390945,-1.0090332};
 				};
 				side="West";
 				flags=7;
@@ -10681,9 +10399,9 @@ class items
 								items=1;
 								class Item0
 								{
-									name="SmokeShell";
-									count=2;
-									ammoLeft=1;
+									name="rhsusf_mag_15Rnd_9x19_JHP";
+									count=1;
+									ammoLeft=15;
 								};
 							};
 							class ItemCargo
@@ -10701,37 +10419,37 @@ class items
 								};
 								class Item2
 								{
-									name="ACE_morphine";
-									count=1;
+									name="ACE_tourniquet";
+									count=2;
 								};
 								class Item3
 								{
-									name="ACE_tourniquet";
+									name="ACE_morphine";
 									count=1;
 								};
 								class Item4
 								{
-									name="rhsusf_acc_M952V";
+									name="ACE_epinephrine";
 									count=1;
 								};
 								class Item5
 								{
-									name="ACRE_PRC343";
-									count=1;
-								};
-								class Item6
-								{
 									name="ACE_CableTie";
 									count=2;
 								};
-								class Item7
+								class Item6
 								{
 									name="ACE_MapTools";
 									count=1;
 								};
+								class Item7
+								{
+									name="rhsusf_acc_M952V";
+									count=1;
+								};
 								class Item8
 								{
-									name="ACRE_PRC152";
+									name="ACRE_PRC343";
 									count=1;
 								};
 							};
@@ -10742,45 +10460,24 @@ class items
 							isBackpack=0;
 							class MagazineCargo
 							{
-								items=5;
+								items=3;
 								class Item0
 								{
-									name="SmokeShell";
-									count=2;
-									ammoLeft=1;
+									name="rhs_mag_30Rnd_556x45_M855A1_PMAG";
+									count=6;
+									ammoLeft=30;
 								};
 								class Item1
 								{
-									name="rhsusf_mag_15Rnd_9x19_JHP";
-									count=1;
-									ammoLeft=15;
+									name="rhs_mag_30Rnd_556x45_M855A1_PMAG_Tracer_Red";
+									count=4;
+									ammoLeft=30;
 								};
 								class Item2
 								{
 									name="HandGrenade";
 									count=2;
 									ammoLeft=1;
-								};
-								class Item3
-								{
-									name="rhs_mag_30Rnd_556x45_M855A1_PMAG";
-									count=6;
-									ammoLeft=30;
-								};
-								class Item4
-								{
-									name="rhs_mag_30Rnd_556x45_M855A1_PMAG_Tracer_Red";
-									count=4;
-									ammoLeft=30;
-								};
-							};
-							class ItemCargo
-							{
-								items=1;
-								class Item0
-								{
-									name="ACE_tourniquet";
-									count=1;
 								};
 							};
 						};
@@ -10794,7 +10491,7 @@ class items
 								class Item0
 								{
 									name="1Rnd_HE_Grenade_shell";
-									count=4;
+									count=3;
 									ammoLeft=1;
 								};
 								class Item1
@@ -10818,7 +10515,7 @@ class items
 								class Item4
 								{
 									name="SmokeShell";
-									count=3;
+									count=7;
 									ammoLeft=1;
 								};
 								class Item5
@@ -10836,10 +10533,15 @@ class items
 							};
 							class ItemCargo
 							{
-								items=1;
+								items=2;
 								class Item0
 								{
 									name="ACE_IR_Strobe_Item";
+									count=1;
+								};
+								class Item1
+								{
+									name="ACRE_PRC152";
 									count=1;
 								};
 							};
@@ -11008,7 +10710,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-5.072998,0.0014390945,-1.0952148};
+					position[]={-5.1938477,0.0014390945,-1.0090332};
 				};
 				side="West";
 				flags=5;
@@ -11046,14 +10748,14 @@ class items
 								items=1;
 								class Item0
 								{
-									name="SmokeShell";
-									count=4;
-									ammoLeft=1;
+									name="rhsusf_mag_15Rnd_9x19_JHP";
+									count=1;
+									ammoLeft=15;
 								};
 							};
 							class ItemCargo
 							{
-								items=6;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -11066,20 +10768,25 @@ class items
 								};
 								class Item2
 								{
-									name="ACE_morphine";
-									count=1;
+									name="ACE_tourniquet";
+									count=2;
 								};
 								class Item3
 								{
-									name="ACE_tourniquet";
+									name="ACE_morphine";
 									count=1;
 								};
 								class Item4
 								{
-									name="rhsusf_acc_M952V";
+									name="ACE_epinephrine";
 									count=1;
 								};
 								class Item5
+								{
+									name="rhsusf_acc_M952V";
+									count=1;
+								};
+								class Item6
 								{
 									name="ACRE_PRC343";
 									count=1;
@@ -11095,24 +10802,15 @@ class items
 								items=2;
 								class Item0
 								{
-									name="rhsusf_mag_15Rnd_9x19_JHP";
-									count=1;
-									ammoLeft=15;
-								};
-								class Item1
-								{
 									name="HandGrenade";
 									count=2;
 									ammoLeft=1;
 								};
-							};
-							class ItemCargo
-							{
-								items=1;
-								class Item0
+								class Item1
 								{
-									name="ACE_tourniquet";
-									count=1;
+									name="SmokeShell";
+									count=4;
+									ammoLeft=1;
 								};
 							};
 						};
@@ -11248,7 +10946,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-4.072998,0.0014390945,-1.0952148};
+					position[]={-4.1938477,0.0014390945,-1.0090332};
 				};
 				side="West";
 				flags=5;
@@ -11287,14 +10985,14 @@ class items
 								items=1;
 								class Item0
 								{
-									name="SmokeShell";
-									count=4;
-									ammoLeft=1;
+									name="rhsusf_mag_15Rnd_9x19_JHP";
+									count=2;
+									ammoLeft=15;
 								};
 							};
 							class ItemCargo
 							{
-								items=6;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -11307,20 +11005,25 @@ class items
 								};
 								class Item2
 								{
-									name="ACE_morphine";
-									count=1;
+									name="ACE_tourniquet";
+									count=2;
 								};
 								class Item3
 								{
-									name="ACE_tourniquet";
+									name="ACE_morphine";
 									count=1;
 								};
 								class Item4
 								{
-									name="rhsusf_acc_M952V";
+									name="ACE_epinephrine";
 									count=1;
 								};
 								class Item5
+								{
+									name="rhsusf_acc_M952V";
+									count=1;
+								};
+								class Item6
 								{
 									name="ACRE_PRC343";
 									count=1;
@@ -11336,36 +11039,27 @@ class items
 								items=4;
 								class Item0
 								{
-									name="rhsusf_mag_15Rnd_9x19_JHP";
-									count=1;
-									ammoLeft=15;
-								};
-								class Item1
-								{
-									name="HandGrenade";
-									count=2;
-									ammoLeft=1;
-								};
-								class Item2
-								{
 									name="rhs_mag_30Rnd_556x45_M855A1_PMAG";
 									count=8;
 									ammoLeft=30;
 								};
-								class Item3
+								class Item1
 								{
 									name="rhs_mag_30Rnd_556x45_M855A1_PMAG_Tracer_Red";
 									count=2;
 									ammoLeft=30;
 								};
-							};
-							class ItemCargo
-							{
-								items=1;
-								class Item0
+								class Item2
 								{
-									name="ACE_tourniquet";
-									count=1;
+									name="HandGrenade";
+									count=2;
+									ammoLeft=1;
+								};
+								class Item3
+								{
+									name="SmokeShell";
+									count=4;
+									ammoLeft=1;
 								};
 							};
 						};
@@ -11537,7 +11231,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-0.9621582,0.0014390945,-1.2509766};
+					position[]={-1.0830078,0.0014390945,-1.1647949};
 				};
 				side="West";
 				flags=7;
@@ -11586,9 +11280,9 @@ class items
 								items=1;
 								class Item0
 								{
-									name="SmokeShell";
-									count=2;
-									ammoLeft=1;
+									name="rhsusf_mag_15Rnd_9x19_JHP";
+									count=1;
+									ammoLeft=15;
 								};
 							};
 							class ItemCargo
@@ -11606,37 +11300,37 @@ class items
 								};
 								class Item2
 								{
-									name="ACE_morphine";
-									count=1;
+									name="ACE_tourniquet";
+									count=2;
 								};
 								class Item3
 								{
-									name="ACE_tourniquet";
+									name="ACE_morphine";
 									count=1;
 								};
 								class Item4
 								{
-									name="rhsusf_acc_M952V";
+									name="ACE_epinephrine";
 									count=1;
 								};
 								class Item5
 								{
-									name="ACRE_PRC343";
-									count=1;
-								};
-								class Item6
-								{
 									name="ACE_CableTie";
 									count=2;
 								};
-								class Item7
+								class Item6
 								{
 									name="ACE_MapTools";
 									count=1;
 								};
+								class Item7
+								{
+									name="rhsusf_acc_M952V";
+									count=1;
+								};
 								class Item8
 								{
-									name="ACRE_PRC152";
+									name="ACRE_PRC343";
 									count=1;
 								};
 							};
@@ -11647,45 +11341,24 @@ class items
 							isBackpack=0;
 							class MagazineCargo
 							{
-								items=5;
+								items=3;
 								class Item0
 								{
-									name="SmokeShell";
-									count=2;
-									ammoLeft=1;
+									name="rhs_mag_30Rnd_556x45_M855A1_PMAG";
+									count=6;
+									ammoLeft=30;
 								};
 								class Item1
 								{
-									name="rhsusf_mag_15Rnd_9x19_JHP";
-									count=1;
-									ammoLeft=15;
+									name="rhs_mag_30Rnd_556x45_M855A1_PMAG_Tracer_Red";
+									count=4;
+									ammoLeft=30;
 								};
 								class Item2
 								{
 									name="HandGrenade";
 									count=2;
 									ammoLeft=1;
-								};
-								class Item3
-								{
-									name="rhs_mag_30Rnd_556x45_M855A1_PMAG";
-									count=6;
-									ammoLeft=30;
-								};
-								class Item4
-								{
-									name="rhs_mag_30Rnd_556x45_M855A1_PMAG_Tracer_Red";
-									count=4;
-									ammoLeft=30;
-								};
-							};
-							class ItemCargo
-							{
-								items=1;
-								class Item0
-								{
-									name="ACE_tourniquet";
-									count=1;
 								};
 							};
 						};
@@ -11699,7 +11372,7 @@ class items
 								class Item0
 								{
 									name="1Rnd_HE_Grenade_shell";
-									count=4;
+									count=3;
 									ammoLeft=1;
 								};
 								class Item1
@@ -11723,7 +11396,7 @@ class items
 								class Item4
 								{
 									name="SmokeShell";
-									count=3;
+									count=7;
 									ammoLeft=1;
 								};
 								class Item5
@@ -11741,10 +11414,15 @@ class items
 							};
 							class ItemCargo
 							{
-								items=1;
+								items=2;
 								class Item0
 								{
 									name="ACE_IR_Strobe_Item";
+									count=1;
+								};
+								class Item1
+								{
+									name="ACRE_PRC152";
 									count=1;
 								};
 							};
@@ -11913,7 +11591,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={0.037353516,0.0014390945,-1.2514648};
+					position[]={-0.083496094,0.0014390945,-1.1652832};
 				};
 				side="West";
 				flags=5;
@@ -11936,11 +11614,10 @@ class items
 						};
 						class secondaryWeapon
 						{
-							name="rhs_weap_maaws";
-							optics="rhs_optic_maaws";
+							name="launch_MRAWS_olive_rail_F";
 							class primaryMuzzleMag
 							{
-								name="rhs_mag_maaws_HEAT";
+								name="MRAWS_HEAT_F";
 								ammoLeft=1;
 							};
 						};
@@ -11962,14 +11639,14 @@ class items
 								items=1;
 								class Item0
 								{
-									name="SmokeShell";
-									count=4;
-									ammoLeft=1;
+									name="rhsusf_mag_15Rnd_9x19_JHP";
+									count=2;
+									ammoLeft=15;
 								};
 							};
 							class ItemCargo
 							{
-								items=6;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -11982,20 +11659,25 @@ class items
 								};
 								class Item2
 								{
-									name="ACE_morphine";
-									count=1;
+									name="ACE_tourniquet";
+									count=2;
 								};
 								class Item3
 								{
-									name="ACE_tourniquet";
+									name="ACE_morphine";
 									count=1;
 								};
 								class Item4
 								{
-									name="rhsusf_acc_M952V";
+									name="ACE_epinephrine";
 									count=1;
 								};
 								class Item5
+								{
+									name="rhsusf_acc_M952V";
+									count=1;
+								};
+								class Item6
 								{
 									name="ACRE_PRC343";
 									count=1;
@@ -12011,36 +11693,27 @@ class items
 								items=4;
 								class Item0
 								{
-									name="rhsusf_mag_15Rnd_9x19_JHP";
-									count=1;
-									ammoLeft=15;
-								};
-								class Item1
-								{
-									name="HandGrenade";
-									count=2;
-									ammoLeft=1;
-								};
-								class Item2
-								{
 									name="rhs_mag_30Rnd_556x45_M855A1_PMAG";
 									count=8;
 									ammoLeft=30;
 								};
-								class Item3
+								class Item1
 								{
 									name="rhs_mag_30Rnd_556x45_M855A1_PMAG_Tracer_Red";
 									count=2;
 									ammoLeft=30;
 								};
-							};
-							class ItemCargo
-							{
-								items=1;
-								class Item0
+								class Item2
 								{
-									name="ACE_tourniquet";
-									count=1;
+									name="HandGrenade";
+									count=2;
+									ammoLeft=1;
+								};
+								class Item3
+								{
+									name="SmokeShell";
+									count=4;
+									ammoLeft=1;
 								};
 							};
 						};
@@ -12053,13 +11726,13 @@ class items
 								items=2;
 								class Item0
 								{
-									name="rhs_mag_maaws_HEAT";
+									name="MRAWS_HEAT_F";
 									count=2;
 									ammoLeft=1;
 								};
 								class Item1
 								{
-									name="rhs_mag_maaws_HE";
+									name="MRAWS_HE_F";
 									count=1;
 									ammoLeft=1;
 								};
@@ -12176,7 +11849,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={1.0373535,0.0014390945,-1.2514648};
+					position[]={0.91650391,0.0014390945,-1.1652832};
 				};
 				side="West";
 				flags=5;
@@ -12215,14 +11888,14 @@ class items
 								items=1;
 								class Item0
 								{
-									name="SmokeShell";
-									count=4;
-									ammoLeft=1;
+									name="rhsusf_mag_15Rnd_9x19_JHP";
+									count=2;
+									ammoLeft=15;
 								};
 							};
 							class ItemCargo
 							{
-								items=6;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -12235,20 +11908,25 @@ class items
 								};
 								class Item2
 								{
-									name="ACE_morphine";
-									count=1;
+									name="ACE_tourniquet";
+									count=2;
 								};
 								class Item3
 								{
-									name="ACE_tourniquet";
+									name="ACE_morphine";
 									count=1;
 								};
 								class Item4
 								{
-									name="rhsusf_acc_M952V";
+									name="ACE_epinephrine";
 									count=1;
 								};
 								class Item5
+								{
+									name="rhsusf_acc_M952V";
+									count=1;
+								};
+								class Item6
 								{
 									name="ACRE_PRC343";
 									count=1;
@@ -12264,36 +11942,27 @@ class items
 								items=4;
 								class Item0
 								{
-									name="rhsusf_mag_15Rnd_9x19_JHP";
-									count=1;
-									ammoLeft=15;
-								};
-								class Item1
-								{
-									name="HandGrenade";
-									count=2;
-									ammoLeft=1;
-								};
-								class Item2
-								{
 									name="rhs_mag_30Rnd_556x45_M855A1_PMAG";
 									count=8;
 									ammoLeft=30;
 								};
-								class Item3
+								class Item1
 								{
 									name="rhs_mag_30Rnd_556x45_M855A1_PMAG_Tracer_Red";
 									count=2;
 									ammoLeft=30;
 								};
-							};
-							class ItemCargo
-							{
-								items=1;
-								class Item0
+								class Item2
 								{
-									name="ACE_tourniquet";
-									count=1;
+									name="HandGrenade";
+									count=2;
+									ammoLeft=1;
+								};
+								class Item3
+								{
+									name="SmokeShell";
+									count=4;
+									ammoLeft=1;
 								};
 							};
 						};
@@ -12306,13 +11975,13 @@ class items
 								items=2;
 								class Item0
 								{
-									name="rhs_mag_maaws_HEAT";
+									name="MRAWS_HEAT_F";
 									count=2;
 									ammoLeft=1;
 								};
 								class Item1
 								{
-									name="rhs_mag_maaws_HE";
+									name="MRAWS_HE_F";
 									count=1;
 									ammoLeft=1;
 								};
@@ -12465,7 +12134,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-6.4191895,0.0014390945,-4.2421875};
+					position[]={-6.5400391,0.0014390945,-4.1560059};
 				};
 				side="West";
 				flags=6;
@@ -12510,19 +12179,9 @@ class items
 						{
 							typeName="rhs_uniform_cu_ocp";
 							isBackpack=0;
-							class MagazineCargo
-							{
-								items=1;
-								class Item0
-								{
-									name="SmokeShell";
-									count=2;
-									ammoLeft=1;
-								};
-							};
 							class ItemCargo
 							{
-								items=9;
+								items=10;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -12535,17 +12194,17 @@ class items
 								};
 								class Item2
 								{
-									name="ACE_morphine";
+									name="ACE_tourniquet";
 									count=1;
 								};
 								class Item3
 								{
-									name="ACE_tourniquet";
+									name="ACE_morphine";
 									count=1;
 								};
 								class Item4
 								{
-									name="rhsusf_acc_M952V";
+									name="ACE_epinephrine";
 									count=1;
 								};
 								class Item5
@@ -12560,10 +12219,15 @@ class items
 								};
 								class Item7
 								{
-									name="ACRE_PRC343";
+									name="rhsusf_acc_M952V";
 									count=1;
 								};
 								class Item8
+								{
+									name="ACRE_PRC343";
+									count=1;
+								};
+								class Item9
 								{
 									name="ACRE_PRC152";
 									count=1;
@@ -12576,53 +12240,59 @@ class items
 							isBackpack=0;
 							class MagazineCargo
 							{
-								items=7;
+								items=8;
 								class Item0
 								{
 									name="rhs_mag_30Rnd_556x45_M855A1_Stanag_No_Tracer";
-									count=3;
+									count=4;
 									ammoLeft=30;
 								};
 								class Item1
-								{
-									name="rhs_mag_30Rnd_556x45_M855A1_Stanag_Tracer_Red";
-									count=1;
-									ammoLeft=30;
-								};
-								class Item2
-								{
-									name="SmokeShellBlue";
-									count=1;
-									ammoLeft=1;
-								};
-								class Item3
-								{
-									name="1Rnd_SmokeRed_Grenade_shell";
-									count=2;
-									ammoLeft=1;
-								};
-								class Item4
-								{
-									name="1Rnd_SmokeGreen_Grenade_shell";
-									count=1;
-									ammoLeft=1;
-								};
-								class Item5
-								{
-									name="ACE_HuntIR_M203";
-									count=4;
-									ammoLeft=1;
-								};
-								class Item6
 								{
 									name="rhsusf_mag_15Rnd_9x19_JHP";
 									count=1;
 									ammoLeft=15;
 								};
+								class Item2
+								{
+									name="1Rnd_SmokeRed_Grenade_shell";
+									count=2;
+									ammoLeft=1;
+								};
+								class Item3
+								{
+									name="1Rnd_SmokeGreen_Grenade_shell";
+									count=1;
+									ammoLeft=1;
+								};
+								class Item4
+								{
+									name="ACE_HuntIR_M203";
+									count=4;
+									ammoLeft=1;
+								};
+								class Item5
+								{
+									name="SmokeShell";
+									count=4;
+									ammoLeft=1;
+								};
+								class Item6
+								{
+									name="SmokeShellGreen";
+									count=2;
+									ammoLeft=1;
+								};
+								class Item7
+								{
+									name="SmokeShellBlue";
+									count=1;
+									ammoLeft=1;
+								};
 							};
 							class ItemCargo
 							{
-								items=4;
+								items=3;
 								class Item0
 								{
 									name="ACE_IR_Strobe_Item";
@@ -12636,11 +12306,6 @@ class items
 								class Item2
 								{
 									name="ACE_microDAGR";
-									count=1;
-								};
-								class Item3
-								{
-									name="ACE_tourniquet";
 									count=1;
 								};
 							};
@@ -12809,7 +12474,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-5.4199219,0.0014390945,-4.2412109};
+					position[]={-5.5410156,0.0014390945,-4.1550293};
 				};
 				side="West";
 				flags=4;
@@ -12858,9 +12523,9 @@ class items
 								items=1;
 								class Item0
 								{
-									name="SmokeShell";
-									count=2;
-									ammoLeft=1;
+									name="rhsusf_mag_15Rnd_9x19_JHP";
+									count=1;
+									ammoLeft=15;
 								};
 							};
 							class ItemCargo
@@ -12878,17 +12543,17 @@ class items
 								};
 								class Item2
 								{
-									name="ACE_morphine";
-									count=1;
+									name="ACE_tourniquet";
+									count=2;
 								};
 								class Item3
 								{
-									name="ACE_tourniquet";
+									name="ACE_morphine";
 									count=1;
 								};
 								class Item4
 								{
-									name="rhsusf_acc_M952V";
+									name="ACE_epinephrine";
 									count=1;
 								};
 								class Item5
@@ -12903,17 +12568,17 @@ class items
 								};
 								class Item7
 								{
-									name="ACE_Kestrel4500";
+									name="rhsusf_acc_M952V";
 									count=1;
 								};
 								class Item8
 								{
-									name="ACE_RangeCard";
+									name="ACE_Kestrel4500";
 									count=1;
 								};
 								class Item9
 								{
-									name="ACE_microDAGR";
+									name="ACE_RangeCard";
 									count=1;
 								};
 								class Item10
@@ -12929,12 +12594,18 @@ class items
 							isBackpack=0;
 							class MagazineCargo
 							{
-								items=1;
+								items=2;
 								class Item0
 								{
 									name="rhsusf_20Rnd_762x51_SR25_m993_Mag";
 									count=4;
 									ammoLeft=20;
+								};
+								class Item1
+								{
+									name="SmokeShell";
+									count=2;
+									ammoLeft=1;
 								};
 							};
 							class ItemCargo
@@ -12947,7 +12618,7 @@ class items
 								};
 								class Item1
 								{
-									name="ACE_tourniquet";
+									name="ACE_microDAGR";
 									count=1;
 								};
 								class Item2
@@ -13143,7 +12814,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-0.97045898,0.0014390945,-4.8901367};
+					position[]={-1.0913086,0.0014390945,-4.8039551};
 				};
 				side="West";
 				flags=7;
@@ -13183,19 +12854,9 @@ class items
 						{
 							typeName="rhs_uniform_cu_ocp";
 							isBackpack=0;
-							class MagazineCargo
-							{
-								items=1;
-								class Item0
-								{
-									name="SmokeShell";
-									count=2;
-									ammoLeft=1;
-								};
-							};
 							class ItemCargo
 							{
-								items=9;
+								items=11;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -13208,23 +12869,23 @@ class items
 								};
 								class Item2
 								{
-									name="ACE_morphine";
-									count=1;
-								};
-								class Item3
-								{
 									name="ACE_tourniquet";
 									count=2;
 								};
+								class Item3
+								{
+									name="ACE_morphine";
+									count=1;
+								};
 								class Item4
 								{
-									name="rhsusf_acc_M952V";
+									name="ACE_epinephrine";
 									count=1;
 								};
 								class Item5
 								{
-									name="ACRE_PRC343";
-									count=1;
+									name="ACE_CableTie";
+									count=2;
 								};
 								class Item6
 								{
@@ -13233,10 +12894,20 @@ class items
 								};
 								class Item7
 								{
-									name="ACE_RangeTable_82mm";
+									name="rhsusf_acc_M952V";
 									count=1;
 								};
 								class Item8
+								{
+									name="ACE_RangeTable_82mm";
+									count=1;
+								};
+								class Item9
+								{
+									name="ACRE_PRC343";
+									count=1;
+								};
+								class Item10
 								{
 									name="ACRE_PRC152";
 									count=1;
@@ -13249,48 +12920,42 @@ class items
 							isBackpack=0;
 							class MagazineCargo
 							{
-								items=7;
+								items=6;
 								class Item0
 								{
-									name="SmokeShell";
-									count=2;
-									ammoLeft=1;
+									name="rhs_mag_30Rnd_556x45_M855A1_PMAG";
+									count=5;
+									ammoLeft=30;
 								};
 								class Item1
 								{
-									name="SmokeShellGreen";
-									count=2;
-									ammoLeft=1;
+									name="rhs_mag_30Rnd_556x45_M855A1_PMAG_Tracer_Red";
+									count=1;
+									ammoLeft=30;
 								};
 								class Item2
-								{
-									name="SmokeShellBlue";
-									count=1;
-									ammoLeft=1;
-								};
-								class Item3
 								{
 									name="rhsusf_mag_15Rnd_9x19_JHP";
 									count=1;
 									ammoLeft=15;
 								};
+								class Item3
+								{
+									name="SmokeShell";
+									count=4;
+									ammoLeft=1;
+								};
 								class Item4
 								{
-									name="HandGrenade";
+									name="SmokeShellGreen";
 									count=2;
 									ammoLeft=1;
 								};
 								class Item5
 								{
-									name="rhs_mag_30Rnd_556x45_M855A1_PMAG";
-									count=6;
-									ammoLeft=30;
-								};
-								class Item6
-								{
-									name="rhs_mag_30Rnd_556x45_M855A1_PMAG_Tracer_Red";
-									count=4;
-									ammoLeft=30;
+									name="SmokeShellBlue";
+									count=1;
+									ammoLeft=1;
 								};
 							};
 						};
@@ -13375,7 +13040,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={0.028564453,0.0014390945,-4.8901367};
+					position[]={-0.092285156,0.0014390945,-4.8039551};
 				};
 				side="West";
 				flags=5;
@@ -13414,14 +13079,14 @@ class items
 								items=1;
 								class Item0
 								{
-									name="SmokeShell";
-									count=4;
-									ammoLeft=1;
+									name="rhsusf_mag_15Rnd_9x19_JHP";
+									count=2;
+									ammoLeft=15;
 								};
 							};
 							class ItemCargo
 							{
-								items=8;
+								items=9;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -13434,32 +13099,37 @@ class items
 								};
 								class Item2
 								{
-									name="ACE_morphine";
-									count=1;
-								};
-								class Item3
-								{
 									name="ACE_tourniquet";
 									count=2;
 								};
+								class Item3
+								{
+									name="ACE_morphine";
+									count=1;
+								};
 								class Item4
 								{
-									name="rhsusf_acc_M952V";
+									name="ACE_epinephrine";
 									count=1;
 								};
 								class Item5
 								{
-									name="ACRE_PRC343";
+									name="ACE_MapTools";
 									count=1;
 								};
 								class Item6
 								{
-									name="ACE_MapTools";
+									name="rhsusf_acc_M952V";
 									count=1;
 								};
 								class Item7
 								{
 									name="ACE_RangeTable_82mm";
+									count=1;
+								};
+								class Item8
+								{
+									name="ACRE_PRC343";
 									count=1;
 								};
 							};
@@ -13470,30 +13140,36 @@ class items
 							isBackpack=0;
 							class MagazineCargo
 							{
-								items=4;
+								items=5;
 								class Item0
 								{
-									name="rhsusf_mag_15Rnd_9x19_JHP";
-									count=1;
-									ammoLeft=15;
+									name="rhs_mag_30Rnd_556x45_M855A1_PMAG";
+									count=5;
+									ammoLeft=30;
 								};
 								class Item1
 								{
-									name="HandGrenade";
-									count=2;
-									ammoLeft=1;
+									name="rhs_mag_30Rnd_556x45_M855A1_PMAG_Tracer_Red";
+									count=1;
+									ammoLeft=30;
 								};
 								class Item2
 								{
-									name="rhs_mag_30Rnd_556x45_M855A1_PMAG";
-									count=8;
-									ammoLeft=30;
+									name="SmokeShell";
+									count=4;
+									ammoLeft=1;
 								};
 								class Item3
 								{
-									name="rhs_mag_30Rnd_556x45_M855A1_PMAG_Tracer_Red";
+									name="SmokeShellGreen";
 									count=2;
-									ammoLeft=30;
+									ammoLeft=1;
+								};
+								class Item4
+								{
+									name="SmokeShellBlue";
+									count=1;
+									ammoLeft=1;
 								};
 							};
 						};
@@ -13613,7 +13289,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={3.994873,0.0014390945,-1.1420898};
+					position[]={3.8740234,0.0014390945,-1.0559082};
 				};
 				side="West";
 				flags=7;
@@ -13653,9 +13329,19 @@ class items
 						{
 							typeName="rhs_uniform_cu_ocp";
 							isBackpack=0;
+							class MagazineCargo
+							{
+								items=1;
+								class Item0
+								{
+									name="rhsusf_mag_15Rnd_9x19_JHP";
+									count=1;
+									ammoLeft=15;
+								};
+							};
 							class ItemCargo
 							{
-								items=8;
+								items=9;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -13668,32 +13354,37 @@ class items
 								};
 								class Item2
 								{
-									name="ACE_morphine";
-									count=1;
+									name="ACE_tourniquet";
+									count=2;
 								};
 								class Item3
 								{
-									name="ACE_tourniquet";
+									name="ACE_morphine";
 									count=1;
 								};
 								class Item4
 								{
-									name="rhsusf_acc_M952V";
+									name="ACE_epinephrine";
 									count=1;
 								};
 								class Item5
 								{
-									name="ACE_MapTools";
-									count=1;
+									name="ACE_CableTie";
+									count=2;
 								};
 								class Item6
 								{
-									name="ACRE_PRC343";
+									name="ACE_MapTools";
 									count=1;
 								};
 								class Item7
 								{
-									name="ACRE_PRC152";
+									name="rhsusf_acc_M952V";
+									count=1;
+								};
+								class Item8
+								{
+									name="ACRE_PRC343";
 									count=1;
 								};
 							};
@@ -13704,29 +13395,35 @@ class items
 							isBackpack=0;
 							class MagazineCargo
 							{
-								items=3;
+								items=4;
 								class Item0
-								{
-									name="SmokeShell";
-									count=4;
-									ammoLeft=1;
-								};
-								class Item1
-								{
-									name="HandGrenade";
-									count=2;
-									ammoLeft=1;
-								};
-								class Item2
 								{
 									name="rhs_mag_30Rnd_556x45_M855A1_PMAG";
 									count=4;
 									ammoLeft=30;
 								};
+								class Item1
+								{
+									name="rhs_mag_30Rnd_556x45_M855A1_PMAG_Tracer_Red";
+									count=2;
+									ammoLeft=30;
+								};
+								class Item2
+								{
+									name="HandGrenade";
+									count=2;
+									ammoLeft=1;
+								};
+								class Item3
+								{
+									name="SmokeShell";
+									count=4;
+									ammoLeft=1;
+								};
 							};
 							class ItemCargo
 							{
-								items=5;
+								items=4;
 								class Item0
 								{
 									name="ACE_M26_Clacker";
@@ -13747,11 +13444,6 @@ class items
 									name="ACE_wirecutter";
 									count=1;
 								};
-								class Item4
-								{
-									name="ACE_tourniquet";
-									count=1;
-								};
 							};
 						};
 						class backpack
@@ -13760,8 +13452,13 @@ class items
 							isBackpack=1;
 							class ItemCargo
 							{
-								items=1;
+								items=2;
 								class Item0
+								{
+									name="ACRE_PRC152";
+									count=1;
+								};
+								class Item1
 								{
 									name="ToolKit";
 									count=1;
@@ -13932,7 +13629,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={4.9943848,0.0014390945,-1.1430664};
+					position[]={4.8735352,0.0014390945,-1.0568848};
 				};
 				side="West";
 				flags=5;
@@ -13962,14 +13659,20 @@ class items
 								ammoLeft=15;
 							};
 						};
-						class binocular
-						{
-							name="ACE_VectorDay";
-						};
 						class uniform
 						{
 							typeName="rhs_uniform_cu_ocp";
 							isBackpack=0;
+							class MagazineCargo
+							{
+								items=1;
+								class Item0
+								{
+									name="rhsusf_mag_15Rnd_9x19_JHP";
+									count=2;
+									ammoLeft=15;
+								};
+							};
 							class ItemCargo
 							{
 								items=7;
@@ -13985,22 +13688,22 @@ class items
 								};
 								class Item2
 								{
-									name="ACE_morphine";
-									count=1;
+									name="ACE_tourniquet";
+									count=2;
 								};
 								class Item3
 								{
-									name="ACE_tourniquet";
+									name="ACE_morphine";
 									count=1;
 								};
 								class Item4
 								{
-									name="rhsusf_acc_M952V";
+									name="ACE_epinephrine";
 									count=1;
 								};
 								class Item5
 								{
-									name="ACE_MapTools";
+									name="rhsusf_acc_M952V";
 									count=1;
 								};
 								class Item6
@@ -14016,29 +13719,35 @@ class items
 							isBackpack=0;
 							class MagazineCargo
 							{
-								items=3;
+								items=4;
 								class Item0
 								{
-									name="SmokeShell";
-									count=4;
-									ammoLeft=1;
+									name="rhs_mag_30Rnd_556x45_M855A1_PMAG";
+									count=5;
+									ammoLeft=30;
 								};
 								class Item1
+								{
+									name="rhs_mag_30Rnd_556x45_M855A1_PMAG_Tracer_Red";
+									count=1;
+									ammoLeft=30;
+								};
+								class Item2
 								{
 									name="HandGrenade";
 									count=2;
 									ammoLeft=1;
 								};
-								class Item2
+								class Item3
 								{
-									name="rhs_mag_30Rnd_556x45_M855A1_PMAG";
+									name="SmokeShell";
 									count=4;
-									ammoLeft=30;
+									ammoLeft=1;
 								};
 							};
 							class ItemCargo
 							{
-								items=5;
+								items=4;
 								class Item0
 								{
 									name="ACE_M26_Clacker";
@@ -14057,11 +13766,6 @@ class items
 								class Item3
 								{
 									name="ACE_wirecutter";
-									count=1;
-								};
-								class Item4
-								{
-									name="ACE_tourniquet";
 									count=1;
 								};
 							};
@@ -14083,7 +13787,6 @@ class items
 						map="ItemMap";
 						compass="ItemCompass";
 						watch="ItemWatch";
-						gps="ItemGPS";
 						headgear="rhsusf_ach_helmet_headset_ocp_alt";
 					};
 				};
@@ -14192,7 +13895,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={5.9943848,0.0014390945,-1.1430664};
+					position[]={5.8735352,0.0014390945,-1.0568848};
 				};
 				side="West";
 				flags=5;
@@ -14222,14 +13925,20 @@ class items
 								ammoLeft=15;
 							};
 						};
-						class binocular
-						{
-							name="ACE_VectorDay";
-						};
 						class uniform
 						{
 							typeName="rhs_uniform_cu_ocp";
 							isBackpack=0;
+							class MagazineCargo
+							{
+								items=1;
+								class Item0
+								{
+									name="rhsusf_mag_15Rnd_9x19_JHP";
+									count=2;
+									ammoLeft=15;
+								};
+							};
 							class ItemCargo
 							{
 								items=7;
@@ -14245,22 +13954,22 @@ class items
 								};
 								class Item2
 								{
-									name="ACE_morphine";
-									count=1;
+									name="ACE_tourniquet";
+									count=2;
 								};
 								class Item3
 								{
-									name="ACE_tourniquet";
+									name="ACE_morphine";
 									count=1;
 								};
 								class Item4
 								{
-									name="rhsusf_acc_M952V";
+									name="ACE_epinephrine";
 									count=1;
 								};
 								class Item5
 								{
-									name="ACE_MapTools";
+									name="rhsusf_acc_M952V";
 									count=1;
 								};
 								class Item6
@@ -14276,29 +13985,35 @@ class items
 							isBackpack=0;
 							class MagazineCargo
 							{
-								items=3;
+								items=4;
 								class Item0
 								{
-									name="SmokeShell";
-									count=4;
-									ammoLeft=1;
+									name="rhs_mag_30Rnd_556x45_M855A1_PMAG";
+									count=5;
+									ammoLeft=30;
 								};
 								class Item1
+								{
+									name="rhs_mag_30Rnd_556x45_M855A1_PMAG_Tracer_Red";
+									count=1;
+									ammoLeft=30;
+								};
+								class Item2
 								{
 									name="HandGrenade";
 									count=2;
 									ammoLeft=1;
 								};
-								class Item2
+								class Item3
 								{
-									name="rhs_mag_30Rnd_556x45_M855A1_PMAG";
+									name="SmokeShell";
 									count=4;
-									ammoLeft=30;
+									ammoLeft=1;
 								};
 							};
 							class ItemCargo
 							{
-								items=5;
+								items=4;
 								class Item0
 								{
 									name="ACE_M26_Clacker";
@@ -14317,11 +14032,6 @@ class items
 								class Item3
 								{
 									name="ACE_wirecutter";
-									count=1;
-								};
-								class Item4
-								{
-									name="ACE_tourniquet";
 									count=1;
 								};
 							};
@@ -14343,7 +14053,6 @@ class items
 						map="ItemMap";
 						compass="ItemCompass";
 						watch="ItemWatch";
-						gps="ItemGPS";
 						headgear="rhsusf_ach_helmet_headset_ocp_alt";
 					};
 				};
@@ -14452,7 +14161,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={6.9943848,0.0014390945,-1.1430664};
+					position[]={6.8735352,0.0014390945,-1.0568848};
 				};
 				side="West";
 				flags=5;
@@ -14482,14 +14191,20 @@ class items
 								ammoLeft=15;
 							};
 						};
-						class binocular
-						{
-							name="ACE_VectorDay";
-						};
 						class uniform
 						{
 							typeName="rhs_uniform_cu_ocp";
 							isBackpack=0;
+							class MagazineCargo
+							{
+								items=1;
+								class Item0
+								{
+									name="rhsusf_mag_15Rnd_9x19_JHP";
+									count=2;
+									ammoLeft=15;
+								};
+							};
 							class ItemCargo
 							{
 								items=7;
@@ -14505,22 +14220,22 @@ class items
 								};
 								class Item2
 								{
-									name="ACE_morphine";
-									count=1;
+									name="ACE_tourniquet";
+									count=2;
 								};
 								class Item3
 								{
-									name="ACE_tourniquet";
+									name="ACE_morphine";
 									count=1;
 								};
 								class Item4
 								{
-									name="rhsusf_acc_M952V";
+									name="ACE_epinephrine";
 									count=1;
 								};
 								class Item5
 								{
-									name="ACE_MapTools";
+									name="rhsusf_acc_M952V";
 									count=1;
 								};
 								class Item6
@@ -14536,29 +14251,35 @@ class items
 							isBackpack=0;
 							class MagazineCargo
 							{
-								items=3;
+								items=4;
 								class Item0
 								{
-									name="SmokeShell";
-									count=4;
-									ammoLeft=1;
+									name="rhs_mag_30Rnd_556x45_M855A1_PMAG";
+									count=5;
+									ammoLeft=30;
 								};
 								class Item1
+								{
+									name="rhs_mag_30Rnd_556x45_M855A1_PMAG_Tracer_Red";
+									count=1;
+									ammoLeft=30;
+								};
+								class Item2
 								{
 									name="HandGrenade";
 									count=2;
 									ammoLeft=1;
 								};
-								class Item2
+								class Item3
 								{
-									name="rhs_mag_30Rnd_556x45_M855A1_PMAG";
+									name="SmokeShell";
 									count=4;
-									ammoLeft=30;
+									ammoLeft=1;
 								};
 							};
 							class ItemCargo
 							{
-								items=5;
+								items=4;
 								class Item0
 								{
 									name="ACE_M26_Clacker";
@@ -14577,11 +14298,6 @@ class items
 								class Item3
 								{
 									name="ACE_wirecutter";
-									count=1;
-								};
-								class Item4
-								{
-									name="ACE_tourniquet";
 									count=1;
 								};
 							};
@@ -14603,7 +14319,6 @@ class items
 						map="ItemMap";
 						compass="ItemCompass";
 						watch="ItemWatch";
-						gps="ItemGPS";
 						headgear="rhsusf_ach_helmet_headset_ocp_alt";
 					};
 				};
@@ -14748,7 +14463,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-6.6362305,0.0014390945,-8.3188477};
+					position[]={-6.7568359,0.0014390945,-8.232666};
 				};
 				side="West";
 				flags=7;
@@ -14788,43 +14503,53 @@ class items
 							isBackpack=0;
 							class ItemCargo
 							{
-								items=8;
+								items=10;
 								class Item0
 								{
-									name="ACE_quikclot";
-									count=10;
+									name="ACE_fieldDressing";
+									count=4;
 								};
 								class Item1
+								{
+									name="ACE_quikclot";
+									count=6;
+								};
+								class Item2
+								{
+									name="ACE_tourniquet";
+									count=2;
+								};
+								class Item3
 								{
 									name="ACE_morphine";
 									count=1;
 								};
-								class Item2
-								{
-									name="rhsusf_acc_M952V";
-									count=1;
-								};
-								class Item3
-								{
-									name="ACRE_PRC343";
-									count=1;
-								};
 								class Item4
 								{
-									name="ACE_MapTools";
+									name="ACE_epinephrine";
 									count=1;
 								};
 								class Item5
 								{
-									name="ACRE_PRC152";
+									name="ACE_MapTools";
 									count=1;
 								};
 								class Item6
 								{
-									name="ACE_tourniquet";
+									name="rhsusf_acc_M952V";
 									count=1;
 								};
 								class Item7
+								{
+									name="ACRE_PRC343";
+									count=1;
+								};
+								class Item8
+								{
+									name="ACRE_PRC152";
+									count=1;
+								};
+								class Item9
 								{
 									name="ACRE_PRC148";
 									count=1;
@@ -14837,45 +14562,42 @@ class items
 							isBackpack=0;
 							class MagazineCargo
 							{
-								items=5;
+								items=6;
 								class Item0
-								{
-									name="SmokeShell";
-									count=2;
-									ammoLeft=1;
-								};
-								class Item1
-								{
-									name="SmokeShellGreen";
-									count=2;
-									ammoLeft=1;
-								};
-								class Item2
-								{
-									name="SmokeShellBlue";
-									count=2;
-									ammoLeft=1;
-								};
-								class Item3
-								{
-									name="HandGrenade";
-									count=2;
-									ammoLeft=1;
-								};
-								class Item4
 								{
 									name="hlc_30Rnd_9x19_B_MP5";
 									count=4;
 									ammoLeft=30;
 								};
-							};
-							class ItemCargo
-							{
-								items=1;
-								class Item0
+								class Item1
 								{
-									name="ACE_tourniquet";
+									name="rhsusf_mag_15Rnd_9x19_JHP";
 									count=1;
+									ammoLeft=15;
+								};
+								class Item2
+								{
+									name="HandGrenade";
+									count=2;
+									ammoLeft=1;
+								};
+								class Item3
+								{
+									name="SmokeShell";
+									count=4;
+									ammoLeft=1;
+								};
+								class Item4
+								{
+									name="SmokeShellGreen";
+									count=2;
+									ammoLeft=1;
+								};
+								class Item5
+								{
+									name="SmokeShellBlue";
+									count=2;
+									ammoLeft=1;
 								};
 							};
 						};
@@ -15058,7 +14780,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-5.6374512,0.0014390945,-8.3198242};
+					position[]={-5.7583008,0.0014390945,-8.2336426};
 				};
 				side="West";
 				flags=5;
@@ -15091,32 +14813,52 @@ class items
 						{
 							typeName="NatoU_ACU";
 							isBackpack=0;
-							class ItemCargo
+							class MagazineCargo
 							{
-								items=5;
+								items=1;
 								class Item0
 								{
-									name="ACE_quikclot";
-									count=10;
+									name="rhsusf_mag_15Rnd_9x19_JHP";
+									count=1;
+									ammoLeft=15;
+								};
+							};
+							class ItemCargo
+							{
+								items=7;
+								class Item0
+								{
+									name="ACE_fieldDressing";
+									count=4;
 								};
 								class Item1
+								{
+									name="ACE_quikclot";
+									count=6;
+								};
+								class Item2
+								{
+									name="ACE_tourniquet";
+									count=2;
+								};
+								class Item3
 								{
 									name="ACE_morphine";
 									count=1;
 								};
-								class Item2
+								class Item4
+								{
+									name="ACE_epinephrine";
+									count=1;
+								};
+								class Item5
 								{
 									name="rhsusf_acc_M952V";
 									count=1;
 								};
-								class Item3
+								class Item6
 								{
 									name="ACRE_PRC343";
-									count=1;
-								};
-								class Item4
-								{
-									name="ACE_tourniquet";
 									count=1;
 								};
 							};
@@ -15130,42 +14872,33 @@ class items
 								items=5;
 								class Item0
 								{
-									name="SmokeShell";
-									count=2;
-									ammoLeft=1;
+									name="hlc_30Rnd_9x19_B_MP5";
+									count=4;
+									ammoLeft=30;
 								};
 								class Item1
-								{
-									name="SmokeShellGreen";
-									count=2;
-									ammoLeft=1;
-								};
-								class Item2
-								{
-									name="SmokeShellBlue";
-									count=2;
-									ammoLeft=1;
-								};
-								class Item3
 								{
 									name="HandGrenade";
 									count=2;
 									ammoLeft=1;
 								};
+								class Item2
+								{
+									name="SmokeShell";
+									count=4;
+									ammoLeft=1;
+								};
+								class Item3
+								{
+									name="SmokeShellGreen";
+									count=2;
+									ammoLeft=1;
+								};
 								class Item4
 								{
-									name="hlc_30Rnd_9x19_B_MP5";
-									count=4;
-									ammoLeft=30;
-								};
-							};
-							class ItemCargo
-							{
-								items=1;
-								class Item0
-								{
-									name="ACE_tourniquet";
-									count=1;
+									name="SmokeShellBlue";
+									count=2;
+									ammoLeft=1;
 								};
 							};
 						};
@@ -15279,7 +15012,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-4.6374512,0.0014390945,-8.3198242};
+					position[]={-4.7583008,0.0014390945,-8.2336426};
 				};
 				side="West";
 				flags=5;
@@ -15313,32 +15046,52 @@ class items
 						{
 							typeName="NatoU_ACU";
 							isBackpack=0;
-							class ItemCargo
+							class MagazineCargo
 							{
-								items=5;
+								items=1;
 								class Item0
 								{
-									name="ACE_quikclot";
-									count=10;
+									name="rhsusf_mag_15Rnd_9x19_JHP";
+									count=1;
+									ammoLeft=15;
+								};
+							};
+							class ItemCargo
+							{
+								items=7;
+								class Item0
+								{
+									name="ACE_fieldDressing";
+									count=4;
 								};
 								class Item1
+								{
+									name="ACE_quikclot";
+									count=6;
+								};
+								class Item2
+								{
+									name="ACE_tourniquet";
+									count=2;
+								};
+								class Item3
 								{
 									name="ACE_morphine";
 									count=1;
 								};
-								class Item2
+								class Item4
+								{
+									name="ACE_epinephrine";
+									count=1;
+								};
+								class Item5
 								{
 									name="rhsusf_acc_M952V";
 									count=1;
 								};
-								class Item3
+								class Item6
 								{
 									name="ACRE_PRC343";
-									count=1;
-								};
-								class Item4
-								{
-									name="ACE_tourniquet";
 									count=1;
 								};
 							};
@@ -15352,42 +15105,33 @@ class items
 								items=5;
 								class Item0
 								{
-									name="SmokeShell";
-									count=2;
-									ammoLeft=1;
+									name="hlc_30Rnd_9x19_B_MP5";
+									count=4;
+									ammoLeft=30;
 								};
 								class Item1
-								{
-									name="SmokeShellGreen";
-									count=2;
-									ammoLeft=1;
-								};
-								class Item2
-								{
-									name="SmokeShellBlue";
-									count=2;
-									ammoLeft=1;
-								};
-								class Item3
 								{
 									name="HandGrenade";
 									count=2;
 									ammoLeft=1;
 								};
+								class Item2
+								{
+									name="SmokeShell";
+									count=4;
+									ammoLeft=1;
+								};
+								class Item3
+								{
+									name="SmokeShellGreen";
+									count=2;
+									ammoLeft=1;
+								};
 								class Item4
 								{
-									name="hlc_30Rnd_9x19_B_MP5";
-									count=4;
-									ammoLeft=30;
-								};
-							};
-							class ItemCargo
-							{
-								items=1;
-								class Item0
-								{
-									name="ACE_tourniquet";
-									count=1;
+									name="SmokeShellBlue";
+									count=2;
+									ammoLeft=1;
 								};
 							};
 						};
@@ -15522,7 +15266,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-1.0280762,0.0014390945,-8.0200195};
+					position[]={-1.1489258,0.0014390945,-7.9338379};
 				};
 				side="West";
 				flags=7;
@@ -15562,45 +15306,55 @@ class items
 							isBackpack=0;
 							class ItemCargo
 							{
-								items=8;
+								items=10;
 								class Item0
 								{
-									name="ACE_quikclot";
-									count=10;
+									name="ACE_fieldDressing";
+									count=4;
 								};
 								class Item1
+								{
+									name="ACE_quikclot";
+									count=6;
+								};
+								class Item2
+								{
+									name="ACE_tourniquet";
+									count=2;
+								};
+								class Item3
 								{
 									name="ACE_morphine";
 									count=1;
 								};
-								class Item2
-								{
-									name="rhsusf_acc_M952V";
-									count=1;
-								};
-								class Item3
-								{
-									name="ACRE_PRC343";
-									count=1;
-								};
 								class Item4
 								{
-									name="ACE_MapTools";
+									name="ACE_epinephrine";
 									count=1;
 								};
 								class Item5
 								{
-									name="ACRE_PRC152";
+									name="ACE_MapTools";
 									count=1;
 								};
 								class Item6
 								{
-									name="ACRE_PRC148";
+									name="rhsusf_acc_M952V";
 									count=1;
 								};
 								class Item7
 								{
-									name="ACE_tourniquet";
+									name="ACRE_PRC343";
+									count=1;
+								};
+								class Item8
+								{
+									name="ACRE_PRC152";
+									count=1;
+								};
+								class Item9
+								{
+									name="ACRE_PRC148";
 									count=1;
 								};
 							};
@@ -15611,18 +15365,18 @@ class items
 							isBackpack=0;
 							class MagazineCargo
 							{
-								items=5;
+								items=6;
 								class Item0
 								{
-									name="SmokeShellGreen";
-									count=2;
-									ammoLeft=1;
+									name="hlc_30Rnd_9x19_B_MP5";
+									count=4;
+									ammoLeft=30;
 								};
 								class Item1
 								{
-									name="SmokeShellBlue";
-									count=2;
-									ammoLeft=1;
+									name="rhsusf_mag_15Rnd_9x19_JHP";
+									count=1;
+									ammoLeft=15;
 								};
 								class Item2
 								{
@@ -15633,23 +15387,20 @@ class items
 								class Item3
 								{
 									name="SmokeShell";
-									count=2;
+									count=4;
 									ammoLeft=1;
 								};
 								class Item4
 								{
-									name="hlc_30Rnd_9x19_B_MP5";
-									count=4;
-									ammoLeft=30;
+									name="SmokeShellGreen";
+									count=2;
+									ammoLeft=1;
 								};
-							};
-							class ItemCargo
-							{
-								items=1;
-								class Item0
+								class Item5
 								{
-									name="ACE_tourniquet";
-									count=1;
+									name="SmokeShellBlue";
+									count=2;
+									ammoLeft=1;
 								};
 							};
 						};
@@ -15813,7 +15564,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-0.028076172,0.0014390945,-8.0209961};
+					position[]={-0.14892578,0.0014390945,-7.9348145};
 				};
 				side="West";
 				flags=5;
@@ -15852,45 +15603,55 @@ class items
 							isBackpack=0;
 							class ItemCargo
 							{
-								items=8;
+								items=10;
 								class Item0
 								{
-									name="ACE_quikclot";
-									count=10;
+									name="ACE_fieldDressing";
+									count=4;
 								};
 								class Item1
+								{
+									name="ACE_quikclot";
+									count=6;
+								};
+								class Item2
+								{
+									name="ACE_tourniquet";
+									count=2;
+								};
+								class Item3
 								{
 									name="ACE_morphine";
 									count=1;
 								};
-								class Item2
-								{
-									name="rhsusf_acc_M952V";
-									count=1;
-								};
-								class Item3
-								{
-									name="ACRE_PRC343";
-									count=1;
-								};
 								class Item4
 								{
-									name="ACE_MapTools";
+									name="ACE_epinephrine";
 									count=1;
 								};
 								class Item5
 								{
-									name="ACRE_PRC152";
+									name="ACE_MapTools";
 									count=1;
 								};
 								class Item6
 								{
-									name="ACRE_PRC148";
+									name="rhsusf_acc_M952V";
 									count=1;
 								};
 								class Item7
 								{
-									name="ACE_tourniquet";
+									name="ACRE_PRC343";
+									count=1;
+								};
+								class Item8
+								{
+									name="ACRE_PRC152";
+									count=1;
+								};
+								class Item9
+								{
+									name="ACRE_PRC148";
 									count=1;
 								};
 							};
@@ -15901,45 +15662,42 @@ class items
 							isBackpack=0;
 							class MagazineCargo
 							{
-								items=5;
+								items=6;
 								class Item0
-								{
-									name="SmokeShell";
-									count=2;
-									ammoLeft=1;
-								};
-								class Item1
-								{
-									name="SmokeShellGreen";
-									count=2;
-									ammoLeft=1;
-								};
-								class Item2
-								{
-									name="SmokeShellBlue";
-									count=2;
-									ammoLeft=1;
-								};
-								class Item3
-								{
-									name="HandGrenade";
-									count=2;
-									ammoLeft=1;
-								};
-								class Item4
 								{
 									name="hlc_30Rnd_9x19_B_MP5";
 									count=4;
 									ammoLeft=30;
 								};
-							};
-							class ItemCargo
-							{
-								items=1;
-								class Item0
+								class Item1
 								{
-									name="ACE_tourniquet";
+									name="rhsusf_mag_15Rnd_9x19_JHP";
 									count=1;
+									ammoLeft=15;
+								};
+								class Item2
+								{
+									name="HandGrenade";
+									count=2;
+									ammoLeft=1;
+								};
+								class Item3
+								{
+									name="SmokeShell";
+									count=4;
+									ammoLeft=1;
+								};
+								class Item4
+								{
+									name="SmokeShellGreen";
+									count=2;
+									ammoLeft=1;
+								};
+								class Item5
+								{
+									name="SmokeShellBlue";
+									count=2;
+									ammoLeft=1;
 								};
 							};
 						};
@@ -16153,7 +15911,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={2.9724121,0.0014390945,-8.0200195};
+					position[]={2.8515625,0.0014390945,-7.9338379};
 				};
 				side="West";
 				flags=7;
@@ -16193,45 +15951,55 @@ class items
 							isBackpack=0;
 							class ItemCargo
 							{
-								items=8;
+								items=10;
 								class Item0
 								{
-									name="ACE_quikclot";
-									count=10;
+									name="ACE_fieldDressing";
+									count=4;
 								};
 								class Item1
+								{
+									name="ACE_quikclot";
+									count=6;
+								};
+								class Item2
+								{
+									name="ACE_tourniquet";
+									count=2;
+								};
+								class Item3
 								{
 									name="ACE_morphine";
 									count=1;
 								};
-								class Item2
-								{
-									name="rhsusf_acc_M952V";
-									count=1;
-								};
-								class Item3
-								{
-									name="ACRE_PRC343";
-									count=1;
-								};
 								class Item4
 								{
-									name="ACE_MapTools";
+									name="ACE_epinephrine";
 									count=1;
 								};
 								class Item5
 								{
-									name="ACRE_PRC152";
+									name="ACE_MapTools";
 									count=1;
 								};
 								class Item6
 								{
-									name="ACRE_PRC148";
+									name="rhsusf_acc_M952V";
 									count=1;
 								};
 								class Item7
 								{
-									name="ACE_tourniquet";
+									name="ACRE_PRC343";
+									count=1;
+								};
+								class Item8
+								{
+									name="ACRE_PRC152";
+									count=1;
+								};
+								class Item9
+								{
+									name="ACRE_PRC148";
 									count=1;
 								};
 							};
@@ -16242,45 +16010,42 @@ class items
 							isBackpack=0;
 							class MagazineCargo
 							{
-								items=5;
+								items=6;
 								class Item0
-								{
-									name="SmokeShell";
-									count=2;
-									ammoLeft=1;
-								};
-								class Item1
-								{
-									name="SmokeShellGreen";
-									count=2;
-									ammoLeft=1;
-								};
-								class Item2
-								{
-									name="SmokeShellBlue";
-									count=2;
-									ammoLeft=1;
-								};
-								class Item3
-								{
-									name="HandGrenade";
-									count=2;
-									ammoLeft=1;
-								};
-								class Item4
 								{
 									name="hlc_30Rnd_9x19_B_MP5";
 									count=4;
 									ammoLeft=30;
 								};
-							};
-							class ItemCargo
-							{
-								items=1;
-								class Item0
+								class Item1
 								{
-									name="ACE_tourniquet";
+									name="rhsusf_mag_15Rnd_9x19_JHP";
 									count=1;
+									ammoLeft=15;
+								};
+								class Item2
+								{
+									name="HandGrenade";
+									count=2;
+									ammoLeft=1;
+								};
+								class Item3
+								{
+									name="SmokeShell";
+									count=4;
+									ammoLeft=1;
+								};
+								class Item4
+								{
+									name="SmokeShellGreen";
+									count=2;
+									ammoLeft=1;
+								};
+								class Item5
+								{
+									name="SmokeShellBlue";
+									count=2;
+									ammoLeft=1;
 								};
 							};
 						};
@@ -16522,7 +16287,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={3.9943848,0.0014390945,-4.8896484};
+					position[]={3.8735352,0.0014390945,-4.8034668};
 				};
 				side="West";
 				flags=7;
@@ -16547,40 +16312,55 @@ class items
 						{
 							typeName="rhs_uniform_cu_ocp";
 							isBackpack=0;
-							class MagazineCargo
-							{
-								items=1;
-								class Item0
-								{
-									name="rhsusf_mag_15Rnd_9x19_JHP";
-									count=2;
-									ammoLeft=15;
-								};
-							};
 							class ItemCargo
 							{
-								items=5;
+								items=10;
 								class Item0
+								{
+									name="ACE_fieldDressing";
+									count=4;
+								};
+								class Item1
+								{
+									name="ACE_quikclot";
+									count=6;
+								};
+								class Item2
+								{
+									name="ACE_tourniquet";
+									count=2;
+								};
+								class Item3
+								{
+									name="ACE_morphine";
+									count=1;
+								};
+								class Item4
+								{
+									name="ACE_epinephrine";
+									count=1;
+								};
+								class Item5
 								{
 									name="ACE_MapTools";
 									count=1;
 								};
-								class Item1
+								class Item6
 								{
 									name="rhsusf_acc_M952V";
 									count=1;
 								};
-								class Item2
+								class Item7
 								{
 									name="ACRE_PRC343";
 									count=1;
 								};
-								class Item3
+								class Item8
 								{
 									name="ACRE_PRC152";
 									count=1;
 								};
-								class Item4
+								class Item9
 								{
 									name="ACRE_PRC148";
 									count=1;
@@ -16785,7 +16565,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={4.9943848,0.0014390945,-4.8896484};
+					position[]={4.8735352,0.0014390945,-4.8034668};
 				};
 				side="West";
 				flags=5;
@@ -16810,40 +16590,55 @@ class items
 						{
 							typeName="rhs_uniform_cu_ocp";
 							isBackpack=0;
-							class MagazineCargo
-							{
-								items=1;
-								class Item0
-								{
-									name="rhsusf_mag_15Rnd_9x19_JHP";
-									count=2;
-									ammoLeft=15;
-								};
-							};
 							class ItemCargo
 							{
-								items=5;
+								items=10;
 								class Item0
+								{
+									name="ACE_fieldDressing";
+									count=4;
+								};
+								class Item1
+								{
+									name="ACE_quikclot";
+									count=6;
+								};
+								class Item2
+								{
+									name="ACE_tourniquet";
+									count=2;
+								};
+								class Item3
+								{
+									name="ACE_morphine";
+									count=1;
+								};
+								class Item4
+								{
+									name="ACE_epinephrine";
+									count=1;
+								};
+								class Item5
 								{
 									name="ACE_MapTools";
 									count=1;
 								};
-								class Item1
+								class Item6
 								{
 									name="rhsusf_acc_M952V";
 									count=1;
 								};
-								class Item2
+								class Item7
 								{
 									name="ACRE_PRC343";
 									count=1;
 								};
-								class Item3
+								class Item8
 								{
 									name="ACRE_PRC152";
 									count=1;
 								};
-								class Item4
+								class Item9
 								{
 									name="ACRE_PRC148";
 									count=1;
@@ -17077,7 +16872,7 @@ class items
 		dataType="Logic";
 		class PositionInfo
 		{
-			position[]={0.38500977,0,-0.32568359};
+			position[]={0.26416016,0,-0.23950195};
 		};
 		areaSize[]={200,-1,200};
 		areaIsRectangle=1;
@@ -17151,7 +16946,7 @@ class items
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={4.973877,0.18872452,-9.784668};
+			position[]={4.8530273,0.18872452,-9.6987915};
 		};
 		side="Empty";
 		flags=4;
@@ -17180,7 +16975,7 @@ class items
 								"STRING"
 							};
 						};
-						value="[[[[],[]],[[],[]],[[""ACE_MapTools"",""ACE_RangeTable_82mm""],[2,2]],[[""RHS_Podnos_Gun_Bag"",""RHS_Podnos_Bipod_Bag""],[2,2]]],false]";
+						value="[[[[],[]],[[],[]],[[""ACE_MapTools"",""ACE_RangeTable_82mm""],[2,2]],[[""rhs_M252_Gun_Bag"",""rhs_M252_Bipod_Bag""],[2,2]]],false]";
 					};
 				};
 			};

--- a/reference/US%20Army/composition.sqe
+++ b/reference/US%20Army/composition.sqe
@@ -1,22 +1,24 @@
 version=53;
-center[]={3165.5469,5,6656.4858};
+center[]={3166.6851,5,6658.1196};
 class items
 {
-	items=21;
+	items=22;
 	class Item0
 	{
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={7.7348633,0.28405476,-6.8066406};
+			position[]={7.6958008,0.28405476,-6.8476563};
 		};
 		side="Empty";
 		flags=4;
 		class Attributes
 		{
 			init="call{[this, 200] call a3aa_fnc_boxGuard}";
+			name="Fireteam_Supply_Box";
+			description="Fireteam Supply Box";
 		};
-		id=234;
+		id=0;
 		type="Box_NATO_Ammo_F";
 		class CustomAttributes
 		{
@@ -47,15 +49,17 @@ class items
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={5.8144531,0.14963102,-7.8305664};
+			position[]={5.7749023,0.14963102,-7.8720703};
 			angles[]={-0,1.5258367,0};
 		};
 		side="Empty";
 		flags=4;
 		class Attributes
 		{
+			name="MAT_Supply_Box";
+			description="MAT Supply Box";
 		};
-		id=235;
+		id=1;
 		type="Box_NATO_WpsLaunch_F";
 		class CustomAttributes
 		{
@@ -86,15 +90,17 @@ class items
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={7.918457,0.89242268,-9.2807617};
+			position[]={7.8789063,0.89242268,-9.3217773};
 		};
 		side="Empty";
 		flags=4;
 		class Attributes
 		{
 			init="call{[this, 200] call a3aa_fnc_boxGuard}";
+			name="Platoon_Supply_Crate";
+			description="Platoon Supply Crate";
 		};
-		id=236;
+		id=2;
 		type="B_supplyCrate_F";
 		class CustomAttributes
 		{
@@ -123,33 +129,33 @@ class items
 	class Item3
 	{
 		dataType="Marker";
-		position[]={2.1176758,2.4371225e+032,-4.7553711};
+		position[]={2.0783691,2.4371225e+032,-4.7963867};
 		name="respawn_west";
 		type="respawn_unknown";
 		angle=359.38086;
-		id=237;
+		id=3;
 		atlOffset=2.4371225e+032;
 	};
 	class Item4
 	{
 		dataType="Marker";
-		position[]={6.9760742,0,-7.925293};
+		position[]={6.9367676,0,-7.9663086};
 		name="resupply_marker_4";
 		text="Resupply";
 		type="mil_triangle";
 		colorName="ColorGreen";
-		id=238;
+		id=4;
 	};
 	class Item5
 	{
 		dataType="Comment";
 		class PositionInfo
 		{
-			position[]={4.1967773,0.001999855,-6.0107422};
+			position[]={4.1574707,0.001999855,-6.0517578};
 		};
 		title="v1.14.1";
 		description="-v1.14.1" \n " - A3EE box guard updated to A3AA." \n " - Custom location re-added." \n "" \n "- v1.14.0" \n "PL: " \n "- Backpack changed from vanilla ""Assault Pack MTP"" to vanilla ""Assault Pack Coyote"" for more visual contrast. Carry capacity remains the same. " \n "- Rifle changed from RHS ""M4A1 (M203s)"" to RHS ""M16A4 (Carryhandle/M203)"" for increased for increased weapon diversity in the platoon. PL has now a more accurate long-range shooting platform. " \n "- Mags changed from RHS ""30Rnd STANAG M855A1"" to RHS ""30Rnd PMAG M855A1"" and from RHS ""30Rnd STANAG M856A1 (tracer)"" to RHS ""30Rnd PMAG M856A1 (tracer)"" for increased visual fidelity. " \n " " \n "Platoon Sergeant: " \n "- Helmet changed from vanilla ""Enhanced Combat Helmet (desert)"" to RHS ""ACH (tan/headset/ESS)"" to indicate association with platoon lead element and for more visual diversity in the platoon. " \n "- Backpack added 3CB ""Radio Backpack MR3000"" and filled it with the ACRE2 ""AN/PRC-117F"" backpack radio. This gives more incentive to bring the PLT Sgt along since he is the only one who can act as a max range radio man for the platoon. " \n "- Mags changed from RHS ""30Rnd STANAG M855A1"" to RHS ""30Rnd PMAG M855A1"" and from RHS ""30Rnd STANAG M856A1 (tracer)"" to RHS ""30Rnd PMAG M856A1 (tracer)"" for increased visual fidelity. " \n " " \n "Platoon Medic: " \n "- Helmet changed from vanilla ""Enhanced Combat Helmet (desert)"" to RHS ""ACH (tan)"" to indicate association with platoon lead element and for more visual diversity in the platoon. " \n "- Backpack changed from vanilla ""Kitbag MTP"" to vanilla ""Kitbag Coyote"" for more visual contrast. Carry capacity remains the same. " \n "- Mags changed from RHS ""30Rnd STANAG M855A1"" to RHS ""30Rnd PMAG M855A1"" and from RHS ""30Rnd STANAG M856A1 (tracer)"" to RHS ""30Rnd PMAG M856A1 (tracer)"" for increased visual fidelity. " \n " " \n "Platoon Rifleman: " \n "- Helmet changed from vanilla ""Enhanced Combat Helmet (desert)"" to RHS ""ACH (tan/ESS)"" to indicate association with platoon lead element and for more visual diversity in the platoon. " \n "- Rifle changed from RHS ""M4A1 PIP"" to RHS ""M16A4 (Carryhandle)"" for increased weapon diversity in the platoon. More accurate shooting platform to compensate the lack of interesting weaponry such as a LAT, an AR or a grenade launcher. " \n "- Mags changed from RHS ""30Rnd STANAG M855A1"" to RHS ""30Rnd PMAG M855A1"" and from RHS ""30Rnd STANAG M856A1 (tracer)"" to RHS ""30Rnd PMAG M856A1 (tracer)"" for increased visual fidelity. " \n " " \n "SL: " \n "- Helmet changed from vanilla ""Enhanced Combat Helmet (desert)"" to RHS ""ACH OEF-CP (Headset/ESS/Alt)"". " \n "- Backpack changed from vanilla ""Assault Pack MTP"" to vanilla ""Assault Pack Coyote"" for more visual contrast. Carry capacity remains the same. " \n "- Rifle changed from RHS ""M4A1 (M203s)"" to RHS ""M16A4 (Carryhandle/M203)"" for increased for increased weapon diversity in the platoon. SL has now a more accurate long-range shooting platform. " \n "- Mags changed from RHS ""30Rnd STANAG M855A1"" to RHS ""30Rnd PMAG M855A1"" and from RHS ""30Rnd STANAG M856A1 (tracer)"" to RHS ""30Rnd PMAG M856A1 (tracer)"" for increased visual fidelity. " \n " " \n "Medic: " \n "- Helmet changed from vanilla ""Enhanced Combat Helmet (desert)"" to RHS ""ACH OEF-CP (Alt)"". " \n "- Backpack changed from vanilla ""Kitbag MTP"" to vanilla ""Kitbag Coyote"" for more visual contrast. Carry capacity remains the same. " \n "- Mags changed from RHS ""30Rnd STANAG M855A1"" to RHS ""30Rnd PMAG M855A1"" and from RHS ""30Rnd STANAG M856A1 (tracer)"" to RHS ""30Rnd PMAG M856A1 (tracer)"" for increased visual fidelity. " \n " " \n "FTL: " \n "- Helmet changed from vanilla ""Enhanced Combat Helmet (desert)"" to RHS ""ACH OEF-CP (Headset/ESS/Alt)"". " \n "- Vest changed from RHS ""SPCS (Team Leader Alt/OEF-CP)"" to RHS ""SPCS (Grenadier/OEF-CP)"" for more visual diversity in the platoon. Carry capacity remains the same. " \n "- Backpack changed from vanilla ""Assault Pack MTP"" to vanilla ""Assault Pack Coyote"" for more visual contrast. Carry capacity remains the same. " \n "- Mags changed from RHS ""30Rnd STANAG M855A1"" to RHS ""30Rnd PMAG M855A1"" and from RHS ""30Rnd STANAG M856A1 (tracer)"" to RHS ""30Rnd PMAG M856A1 (tracer)"" for increased visual fidelity. " \n " " \n "AR: " \n "- Helmet changed from vanilla ""Enhanced Combat Helmet (desert)"" to RHS ""ACH OEF-CP (ESS/Alt)"" or RHS ""ACH OEF-CP (Alt)"". Both helmets are given out semi-randomly to increase visual variety in the platoon. " \n "- Backpack changed from vanilla ""Assault Pack MTP"" to vanilla ""Assault Pack Coyote"" for more visual contrast. Carry capacity remains the same. " \n "- Added muzzle attachment RHS ""SFMB-556 1/2-28"". " \n " " \n "AAR: " \n "- Helmet changed from vanilla ""Enhanced Combat Helmet (desert)"" to RHS ""ACH OEF-CP (Headset/Alt)"". " \n "- Vest changed from RHS ""SPCS (Rifleman Alt/OEF-CP)"" to RHS ""SPCS (Team Leader/OEF-CP)"" for more visual diversity in the platoon. Carry capacity remains the same. " \n "- Backpack changed from vanilla ""Kitbag MTP"" to vanilla ""Kitbag Coyote"" for more visual contrast. Carry capacity remains the same. " \n "- Rifle changed from RHS ""M4A1 PIP"" to RHS ""M16A4 (Carryhandle)"" for increased weapon diversity in the platoon. More accurate shooting platform to compensate the lack of interesting weaponry such as a LAT, an AR or a grenade launcher. " \n "- Mags changed from RHS ""30Rnd STANAG M855A1"" to RHS ""30Rnd PMAG M855A1"" and from RHS ""30Rnd STANAG M856A1 (tracer)"" to RHS ""30Rnd PMAG M856A1 (tracer)"" for increased visual fidelity. " \n " " \n "LAT: " \n "- Helmet changed from vanilla ""Enhanced Combat Helmet (desert)"" to RHS ""ACH OEF-CP (ESS/Alt)"" or RHS ""ACH OEF-CP (Alt)"". Both helmets are given out semi-randomly to increase visual variety in the platoon. " \n "- Mags changed from RHS ""30Rnd STANAG M855A1"" to RHS ""30Rnd PMAG M855A1"" and from RHS ""30Rnd STANAG M856A1 (tracer)"" to RHS ""30Rnd PMAG M856A1 (tracer)"" for increased visual fidelity. " \n " " \n "MMG Teamleader: " \n "- Helmet changed from vanilla ""Enhanced Combat Helmet (desert)"" to RHS ""ACH OEF-CP (Headset/Alt)"". " \n "- Backpack changed from vanilla ""Assault Pack MTP"" to vanilla ""Assault Pack Coyote"" for more visual contrast. Carry capacity remains the same. " \n "- Mags changed from RHS ""30Rnd STANAG M855A1"" to RHS ""30Rnd PMAG M855A1"" and from RHS ""30Rnd STANAG M856A1 (tracer)"" to RHS ""30Rnd PMAG M856A1 (tracer)"" for increased visual fidelity. " \n " " \n "MMG Gunner: " \n "- Helmet changed from vanilla ""Enhanced Combat Helmet (desert)"" to RHS ""ACH OEF-CP (ESS/Alt)""." \n "- Backpack changed from vanilla ""Kitbag MTP"" to vanilla ""Kitbag Coyote"" for more visual contrast. Carry capacity remains the same. " \n "- Added muzzle attachment RHS ""ARDEC 4-Prong"". " \n " " \n "MMG Asst. Gunner: " \n "- Helmet changed from vanilla ""Enhanced Combat Helmet (desert)"" to RHS ""ACH OEF-CP (Alt)"". " \n "- Backpack changed from vanilla ""Kitbag MTP"" to vanilla ""Kitbag Coyote"" for more visual contrast. Carry capacity remains the same. " \n "- Mags changed from RHS ""30Rnd STANAG M855A1"" to RHS ""30Rnd PMAG M855A1"" and from RHS ""30Rnd STANAG M856A1 (tracer)"" to RHS ""30Rnd PMAG M856A1 (tracer)"" for increased visual fidelity. " \n " " \n "MAT Teamleader: " \n "- Helmet changed from vanilla ""Enhanced Combat Helmet (desert)"" to RHS ""ACH OEF-CP (Headset/Alt)"". " \n "- Backpack changed from vanilla ""Assault Pack MTP"" to vanilla ""Assault Pack Coyote"" for more visual contrast. Carry capacity remains the same. " \n "- Mags changed from RHS ""30Rnd STANAG M855A1"" to RHS ""30Rnd PMAG M855A1"" and from RHS ""30Rnd STANAG M856A1 (tracer)"" to RHS ""30Rnd PMAG M856A1 (tracer)"" for increased visual fidelity. " \n " " \n "MAT Gunner: " \n "- Helmet changed from vanilla ""Enhanced Combat Helmet (desert)"" to RHS ""ACH OEF-CP (ESS/Alt)""." \n "- Vest changed from RHS ""SPCS (Rifleman Alt/OEF-CP)"" to RHS ""SPCS (OEF-CP)"" for more visual diversity in the platoon. Carry capacity remains the same. " \n "- Backpack changed from vanilla ""Kitbag MTP"" to vanilla ""Kitbag Coyote"" for more visual contrast. Carry capacity remains the same. " \n "- Mags changed from RHS ""30Rnd STANAG M855A1"" to RHS ""30Rnd PMAG M855A1"" and from RHS ""30Rnd STANAG M856A1 (tracer)"" to RHS ""30Rnd PMAG M856A1 (tracer)"" for increased visual fidelity. " \n " " \n "MAT Asst. Gunner: " \n "- Helmet changed from vanilla ""Enhanced Combat Helmet (desert)"" to RHS ""ACH OEF-CP (Alt)"". " \n "- Backpack changed from vanilla ""Kitbag MTP"" to vanilla ""Kitbag Coyote"" for more visual contrast. Carry capacity remains the same. " \n "- Mags changed from RHS ""30Rnd STANAG M855A1"" to RHS ""30Rnd PMAG M855A1"" and from RHS ""30Rnd STANAG M856A1 (tracer)"" to RHS ""30Rnd PMAG M856A1 (tracer)"" for increased visual fidelity. " \n " " \n "ENG Leader: " \n "- Helmet changed from vanilla ""Enhanced Combat Helmet (desert)"" to RHS ""ACH OEF-CP (Headset/ESS/Alt)"". " \n "- Vest changed from RHS ""SPCS (Team Leader Alt/OEF-CP)"" to vanilla ""Carrier GL Rig (green)"" for a bulkier look to visually distinguish EOD/ENG from the rest of the platoon. " \n "- Backpack changed from vanilla ""Carryall MTP"" to vanilla ""Carryall Coyote"" for more visual contrast. Carry capacity remains the same. " \n "- Mags changed from RHS ""30Rnd STANAG M855A1"" to RHS ""30Rnd PMAG M855A1"" and from RHS ""30Rnd STANAG M856A1 (tracer)"" to RHS ""30Rnd PMAG M856A1 (tracer)"" for increased visual fidelity. " \n " " \n "ENG Rifleman: " \n "- Helmet changed from vanilla ""Enhanced Combat Helmet (desert)"" to RHS ""ACH OEF-CP (Headset/Alt)"". " \n "- Vest changed from RHS ""SPCS (Team Leader Alt/OEF-CP)"" to vanilla ""Carrier GL Rig (green)"" for a bulkier look to visually distinguish EOD/ENG from the rest of the platoon. " \n "- Backpack changed from vanilla ""Carryall MTP"" to vanilla ""Carryall Coyote"" for more visual contrast. Carry capacity remains the same. " \n "- Mags changed from RHS ""30Rnd STANAG M855A1"" to RHS ""30Rnd PMAG M855A1"" and from RHS ""30Rnd STANAG M856A1 (tracer)"" to RHS ""30Rnd PMAG M856A1 (tracer)"" for increased visual fidelity. " \n " " \n "Mortar Leader: " \n "- Helmet changed from vanilla ""Enhanced Combat Helmet (desert)"" to RHS ""ACH OEF-CP (Headset/Alt)"". " \n "- Mags changed from RHS ""30Rnd STANAG M855A1"" to RHS ""30Rnd PMAG M855A1"" and from RHS ""30Rnd STANAG M856A1 (tracer)"" to RHS ""30Rnd PMAG M856A1 (tracer)"" for increased visual fidelity. " \n " " \n "Mortar Gunner: " \n "- Helmet changed from vanilla ""Enhanced Combat Helmet (desert)"" to RHS ""ACH OEF-CP (Alt)"". " \n "- Vest changed from RHS ""SPCS (Rifleman Alt/OEF-CP)"" to RHS ""SPCS (SAW/OEF-CP)"" for more visual diversity in the platoon. Carry capacity remains the same. " \n "- Mags changed from RHS ""30Rnd STANAG M855A1"" to RHS ""30Rnd PMAG M855A1"" and from RHS ""30Rnd STANAG M856A1 (tracer)"" to RHS ""30Rnd PMAG M856A1 (tracer)"" for increased visual fidelity. " \n " " \n "DGR Commander: " \n "- Helmet changed from RHS ""ACVC-H MK-1697"" to RHS ""ACVC-H MK-1697 (ESS)"" to better visually indicate the element leader. " \n "- Rifle changed from vanilla ""Scorpion Evo 3 A1"" to NiArms ""H&K MP5A3"" to bring weaponry visually more in line with the rest of the platoon.  " \n " " \n "DGR Gunner & Driver: " \n "- Rifle changed from vanilla ""Scorpion Evo 3 A1"" to NiArms ""H&K MP5A3"" to bring weaponry visually more in line with the rest of the platoon.  " \n " " \n "DMT Marksman " \n "- Rifle scope changed from RH ""Leopold Mark 4 LR/T"" to RHS ""M8541A SSDS"" for more visual conformity with NVG variant of the same scope. Note: max. zoom is reduced from x20 to x15 however the Marksman gains a MRDS sight for CQB. " \n "- Added scope RHS ""M8541A + AN/PVS-27"" to the vest gear. This is the NVG version of the regular scope. " \n " " \n "Nightbird Pilot & Co-Pilot: " \n "- Rifle changed from vanilla ""Scorpion Evo 3 A1"" to NiArms ""H&K MP5A3"" to bring weaponry visually more in line with the rest of the platoon.  " \n " " \n "Falcon Pilot: " \n "- Rifle changed from vanilla ""Scorpion Evo 3 A1"" to NiArms ""H&K MP5A3"" to bring weaponry visually more in line with the rest of the platoon.  " \n " " \n "Zeus & Co-Zeus " \n "- Uniform changed from vanilla ""VR Suit NATO"" to RHS ""Combat Uniform OCP"" to make Zeus look a bit more like an HQ commander than a Tron character. " \n "- Headgear added RHS ""Patrol Cap OEF-CP"". " \n "- Facewear changed from vanilla ""VR Goggles"" to vanilla ""Aviator Glasses"". " \n "- Insignia added ""Zeus"". " \n " " \n "All Units: " \n "- Disabled LAMBS AI " \n " " \n "Alpha SL: " \n "- Enabled ""is Player"". This makes it easier for Mission Makers to quickly test a mission in the editor by just hitting ""play"" instead of having to select a specific unit every time beforehand to avoid ending up in spectator mode by default.  " \n " " \n "Crates: " \n "- Added an ACE3 medical crate with our usual base script." \n "" \n "" \n "-v1.13.6" \n "  - ALL Added persistent Call-Signs for all GM's (where not included in v1.13.4)" \n "  - ALL Added the code`this disableAI ""MOVE""; this setSpeaker ""NoVoice""; enableRadio false;` to all playable units to prevent them from running off and spamming the vanilla-radio during local testing." \n "  - ALL Changed persistent call-signs (map markers) to a consistent formula: ≤ 2 syllables = written out call-sing. ≥ 3 syllables = abbreviated call-sign." \n "  - ALL Added full changelog to all factions for quick in-game reference" \n "  - TFN Added new yellow owl insignia patches to all uniforms" \n "" \n "- v1.13.5" \n "  - ALL Added respective GM's to Standard Faction Compositions for convenience / time saving " \n "  - ALL Added base clean-up module to Standard Faction Compositions to ensure Mission Makers don't forget it in the future - radius set to 200x200 meters" \n "" \n "- v1.13.4 " \n "  - ALL Added @ Squad/Team names to leaders so that Team name appears in role select" \n "  - TFN Changed M249 to the FN MINIMI" \n "" \n "- v1.13.3" \n "  - US Added Improved Bipod/SAW Grip to AR M249" \n "  - US Removed M14 Mags" \n "  - TFN Added Bipod to M249" \n "" \n "- v1.13.2" \n "  - ALL Added 1 Extra Tourniquet to every Unit" \n "  - TFN DMT Lead Rifle Changed to D10 Version" \n "  - TFN DMT given extra pistol mag to bring in line with other units" \n "  - TFN AAR Weapon changed to HK416 D14.5" \n "  - TFN Lead Elements Given AN/PEQ-16A's" \n "  - US Alpha Fireteam 2 AAR vest changed to ALT variant to match rest of faction" \n "  - US Lead Elements Given AN/PEQ-16A's" \n "  - US DMT given extra pistol mag to bring in line with other units" \n "  - US DMT Sniper Rifle Given SU-260/P (MDO) to bring zoom level to the same as Russian and TFN factions" \n "  - US DMT Bipod Changed to Harris Bipod" \n "  - US DMT Marksman Rifle changed to black version of same rifle" \n "  - US DMT Marksman Magazines changed to SR-25 version, as RHS hotfix made M14 mags incompatible with MK11" \n "  - RUS DMT given extra pistol mag to bring in line with other units" \n "  - RUS DGR Helmets changed to TSH-4 to make distinct from US Helmets" \n "  - RUS NB Helmets changed to ZSH-7A to make distinct from US and TFN helmets" \n "  - RUS Removed RIS Rail adaptors from AK rifles" \n "  - RUS Added PG-7V rocket to MAT ammo crate. This rocket is lighter and packs less payload than the PG-7VL. This gives it an  increased effective range but is less powerful due to decreased payload" \n "" \n "- v1.12.2" \n "  - Hotfixed US Vests across the Squads to match V.12 changes. Whoops." \n "  - Added Angled Grip to TFN HK416s where possible. " \n "" \n "- v1.12" \n "  - Fixed TFN MMG Ammo preloaded into Rifle to 100RND mag from 50rnd." \n "  - Fixed TFN DMT Marksman Ammo loaded into Rifle to correct SBLR mag." \n "  - Changed TFN DMT Lead Suppressor to QDSS NT4 Black from Rotex-5 Grey" \n "  - Changed TFN Dagger Uniforms from Gorka R Green to FFCP Green Fatigues [RS]" \n "  - Changed US PLT Commander + Squad Leader Vest from SPCS Rifleman/OEF- CP to SPCS Squad Lead/OEF-CP" \n "  - Changed US Medic Vest from SPCS Rifleman/OEF-CP to SPCS Medic/OEF-CP" \n "  - Changed US PLT Rifleman Vest from SPCS OEF-CP to SPCS Rifleman Alt/OEF-CP" \n "  - Changed US FTL Vest from SPCS Rifleman/OEF-CP to SPCS Team Leader Alt/OEF-CP" \n "  - Changed US AR Vest from SPCS Rifleman/OEF-CP to SPCS SAW/OEF-CP" \n "  - Changed US AAR Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP" \n "  - Changed US Rifleman AT Vest from SPCS OEF-CP to SPCS Rifleman Alt/OEF-CP" \n "  - Changed US MAT/MMG/DMT/ENG/MTR Lead Vest from SPCS Rifleman/OEF-CP to SPCS Team Leader Alt/OEF-CP" \n "  - Changed US MMG Gunner Vest from SPCS Rifleman/OEF-CP to SPCS Machinegunner/OEF-CP" \n "  - Changed US MMG/MAT Ammo Bearer Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP" \n "  - Changed US MAT Gunner Vest from SPCS OEF-CP to SPCS Rifleman Alt/OEF-CP" \n "  - Changed US DMT Marksman vest from SPCS OEF-CP to SPCS Sniper/OEF-CP" \n "  - Fixed US DMT Marksman Rifle Loaded Mag to correct varient." \n "  - Changed US Engineer Rifleman Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP." \n "  - Changed US MTR Gunner Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP." \n "  - Changed US DGR Uniforms from FFCP ACU Fatigues to FFCP ACU Fatigues [RS]" \n "  - Changed US DGR Driver Backpack from Assault Pack Green to Assault Pack Black" \n "  - Changed US Heli Pilot/Copilot Uniforms from Heli pilot Coveralls to FFCP Nomad Fatigues [RS]" \n "  - Fixed US Heli/Jet Pilot Vest White Smoke grenade count to 2." \n "  - Changed US Heli Pilot/Copilot Helmet from Heli Pilot NATO to HGU-56/P (Black/Visor)" \n "  - Changed US Jet Pilot Uniform from Pilot Coveralls NATO to  FFCP Nomad Fatigues" \n "  - Changed RUS Vic/Heli/Jet Crew Weapons to PP-2000" \n "  - Upped RUS PP-2000 Ammo counts to 6x Mag to bring in line with ammo counts for TFN and US." \n "  - Changed RUS Heli Pilot Uniforms from Pilot Coveralls CSAT to FFCP-Fatigues EMR [RS]" \n "  - Changed RUS Heli Pilot Vest from 6B23 (6Sh116) to FFCP Tactical Vest TigerVRS" \n "  - Changed RUS Jet Pilot Uniforms from Pilot Coveralls CSAT to FFCP-Fatigues EMR [RS]" \n "  - Changed RUS Jet Pilot Vest from 6B23 (6Sh116) to FFCP Tactical Vest TigerVRS" \n "" \n "- v1.11" \n "  - changed m40 mini grenades to m67 fragmentation" \n "  - replaced mp7 weapons with mp5k-pdw" \n "  - changed ak105 to ak74m (plum) " \n "  - changed PKM to PKP" \n "  - changed RUS PKM ammo boxes. MMG now loads with 7TZ (AP rounds)" \n "  - added vert grip to us weapons" \n "  - replaced m14 with HK PSG1A1" \n "  - replaced m260e4 with mg3" \n "  - updated all ammo boxes respectively. " \n "" \n "- v1.10" \n "  - changed Medic loadouts from 6 x 1000ml blood bags to 2 x 1000ml and 8 x 500ml." \n "" \n "- v1.09" \n "  - updated Fireteam colours A1 Red A2 Yellow, B1 Green B2 Blue, C1 Red C2 Yellow." \n "" \n "- v1.08" \n "  - changed ""Reaper"" to ""Nightbird"", ""RPR"" to ""NB""" \n "  - changed ""Paladin"" to ""Falcon"", ""PAL"" to ""FC""" \n "  - changed ""DAGGER"" to ""DGR""" \n "" \n "- v1.07" \n "  - US and RU faction bumped to v1.07 to avoid confusion regarding version numbers (US and RU was 1.05, TFN was 1.06)" \n "  - overhauled the RU faction: updated helmets, uniforms, weapons to a more modern look" \n "  - overhauled the US faction: updated helmets and vests to armour rating of IV" \n "  - corrected some mistakes in all factions (grenade ammount of MMG gunner, ENG not having tourniquetes, DGR not having GPS-s)" \n "  - overhauled the medics of all factions to reflect recent cahnges to ACE medical (less QuikClots, more Elastic Bandages, etc.)" \n "" \n "- v1.05" \n "  - Added a MAT ammo box on spawn." \n "" \n "- v1.04" \n "  - All MAT Teams carrying RPG's got the ver3 scopes with ranges for all types" \n "    of ammo." \n "  - All Callsigns were changed to be uniformed throught no matter the faction." \n "" \n "- v1.03" \n "  - set crew driver/gunner and pilot/copilot/jetpilot as Engineers through the" \n "    Object: ACE Options menu in unit attributes" \n "  - overhauled the TFN faction (weapons, helmets, etc.), changes not applicable" \n "    to derived factions" \n "" \n "- v1.02" \n "  - loadout overhaul for DMT, made them lighter + gave them tools for recon" \n "  - specified preset ACRE2 radio channels for most units" \n "" \n "- v1.01" \n "  - updated team colors func to `a3ee_team_colors_fnc_setColor`, just load+save" \n "    the composition in editor, this fixes it" \n "  - changed RPG-7 using MAT teams to carry Kitbags" \n "  - removed one PKM ammo box from AAR, MMG gunner, MMG bearer (fixes overload)" \n "  - moved 1-2 AR boxes from AAR to AR, gave AR an Assaultpack" \n "  - added 1-2 more AR boxes to AR's Assaultpack (if enough space)" \n "  - changed HEDP to HE rockets for Carl Gustav (M3MAAWS)" \n "  - changed US crew uniform and helmet to match grey color scheme of US pilots" \n "  - changed backpacks of driver/copilot to use less contrasting colors compared" \n "    to their respective uniform/vest colors" \n "  - changed Carryall backpacks of TFN Engineers to use custom Flecktarn Carryall" \n "  - changed all (GP-25 and normal) AK74m rifles to be the non-NPZ variants" \n "  - removed secondary long-range (PRC148) from Engineers" \n "" \n "- v1.00 (and before)" \n "  - added a Comment object with version number (`v1.00`)" \n "  - added `respawn_west`, `respawn_east`, `respawn_guerrila` markers" \n "  - added `[this, 200] call a3ee_fnc_boxGuard` to init lines of resupply boxes" \n "  - added `Resupply` green triangle markers on the position of resupply boxes";
-		id=239;
+		id=5;
 		atlOffset=0.001999855;
 	};
 	class Item6
@@ -157,15 +163,17 @@ class items
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={7.6918945,0,-4.7124023};
+			position[]={7.652832,0,-4.7539063};
 		};
 		side="Empty";
 		flags=4;
 		class Attributes
 		{
 			init="call{[this, 200] call a3aa_fnc_boxGuard}";
+			name="Medical_Supply_Crate";
+			description="Medical Supply Crate";
 		};
-		id=240;
+		id=6;
 		type="ACE_medicalSupplyCrate";
 		class CustomAttributes
 		{
@@ -203,7 +211,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-5.8334961,0.0014390945,8.9770508};
+					position[]={-5.873291,0.0014390945,8.9360352};
 				};
 				side="West";
 				flags=7;
@@ -405,7 +413,7 @@ class items
 						headgear="rhsusf_ach_helmet_headset_ocp_alt";
 					};
 				};
-				id=242;
+				id=8;
 				type="B_officer_F";
 				class CustomAttributes
 				{
@@ -449,6 +457,70 @@ class items
 					};
 					class Attribute2
 					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=3;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="4";
+										};
+									};
+									class Item1
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+									class Item2
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="5";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute3
+					{
 						property="lambs_danger_dangerRadio";
 						expression="if (_value) then { _this setVariable ['lambs_danger_dangerRadio', _value, true]; }";
 						class Value
@@ -466,7 +538,45 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					class Attribute4
+					{
+						property="speaker";
+						expression="_this setspeaker _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="Male08ENG";
+							};
+						};
+					};
+					class Attribute5
+					{
+						property="pitch";
+						expression="_this setpitch _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"SCALAR"
+									};
+								};
+								value=0.95999998;
+							};
+						};
+					};
+					nAttributes=6;
 				};
 			};
 			class Item1
@@ -474,7 +584,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-4.8334961,0.0014390945,8.9760742};
+					position[]={-4.873291,0.0014390945,8.9350586};
 				};
 				side="West";
 				flags=5;
@@ -637,7 +747,7 @@ class items
 						headgear="rhsusf_ach_helmet_headset_ocp_alt";
 					};
 				};
-				id=243;
+				id=9;
 				type="B_Soldier_TL_F";
 				class CustomAttributes
 				{
@@ -681,6 +791,70 @@ class items
 					};
 					class Attribute2
 					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=3;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="4";
+										};
+									};
+									class Item1
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+									class Item2
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="3";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute3
+					{
 						property="lambs_danger_dangerRadio";
 						expression="if (_value) then { _this setVariable ['lambs_danger_dangerRadio', _value, true]; }";
 						class Value
@@ -698,7 +872,45 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					class Attribute4
+					{
+						property="speaker";
+						expression="_this setspeaker _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="Male09ENG";
+							};
+						};
+					};
+					class Attribute5
+					{
+						property="pitch";
+						expression="_this setpitch _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"SCALAR"
+									};
+								};
+								value=0.98000002;
+							};
+						};
+					};
+					nAttributes=6;
 				};
 			};
 			class Item2
@@ -706,7 +918,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-3.8334961,0.0014390945,8.9760742};
+					position[]={-3.8728027,0.0014390945,8.9350586};
 				};
 				side="West";
 				flags=5;
@@ -904,7 +1116,7 @@ class items
 						headgear="rhsusf_ach_helmet_ocp_alt";
 					};
 				};
-				id=244;
+				id=10;
 				type="B_medic_F";
 				class CustomAttributes
 				{
@@ -948,6 +1160,42 @@ class items
 					};
 					class Attribute2
 					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="4";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute3
+					{
 						property="lambs_danger_dangerRadio";
 						expression="if (_value) then { _this setVariable ['lambs_danger_dangerRadio', _value, true]; }";
 						class Value
@@ -965,7 +1213,7 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					nAttributes=4;
 				};
 			};
 			class Item3
@@ -973,7 +1221,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-2.8334961,0.0014390945,8.9760742};
+					position[]={-2.8728027,0.0014390945,8.9350586};
 				};
 				side="West";
 				flags=5;
@@ -1095,7 +1343,7 @@ class items
 						headgear="rhsusf_ach_helmet_ESS_ocp_alt";
 					};
 				};
-				id=245;
+				id=11;
 				type="B_Soldier_F";
 				class CustomAttributes
 				{
@@ -1139,6 +1387,42 @@ class items
 					};
 					class Attribute2
 					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="4";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute3
+					{
 						property="lambs_danger_dangerRadio";
 						expression="if (_value) then { _this setVariable ['lambs_danger_dangerRadio', _value, true]; }";
 						class Value
@@ -1156,14 +1440,14 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					nAttributes=4;
 				};
 			};
 		};
 		class Attributes
 		{
 		};
-		id=241;
+		id=7;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -1200,7 +1484,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-5.7956543,0.0014390945,6.0600586};
+					position[]={-5.8352051,0.0014390945,6.019043};
 				};
 				side="West";
 				flags=7;
@@ -1420,7 +1704,7 @@ class items
 						headgear="rhsusf_ach_helmet_headset_ess_ocp_alt";
 					};
 				};
-				id=247;
+				id=13;
 				type="B_Soldier_SL_F";
 				class CustomAttributes
 				{
@@ -1519,7 +1803,57 @@ class items
 							};
 						};
 					};
-					nAttributes=5;
+					class Attribute5
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=2;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+									class Item1
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=6;
 				};
 			};
 			class Item1
@@ -1527,7 +1861,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-4.7944336,0.0014390945,6.059082};
+					position[]={-4.8337402,0.0014390945,6.0180664};
 				};
 				side="West";
 				flags=5;
@@ -1735,7 +2069,7 @@ class items
 						headgear="rhsusf_ach_helmet_ocp_alt";
 					};
 				};
-				id=248;
+				id=14;
 				type="B_medic_F";
 				class CustomAttributes
 				{
@@ -1779,6 +2113,42 @@ class items
 					};
 					class Attribute2
 					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute3
+					{
 						property="lambs_danger_dangerRadio";
 						expression="if (_value) then { _this setVariable ['lambs_danger_dangerRadio', _value, true]; }";
 						class Value
@@ -1796,7 +2166,7 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					nAttributes=4;
 				};
 			};
 			class Item2
@@ -1804,7 +2174,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-5.7944336,0.0014390945,4.059082};
+					position[]={-5.8337402,0.0014390945,4.0180664};
 				};
 				side="West";
 				flags=5;
@@ -2006,7 +2376,7 @@ class items
 						headgear="rhsusf_ach_helmet_headset_ess_ocp_alt";
 					};
 				};
-				id=249;
+				id=15;
 				type="B_Soldier_TL_F";
 				class CustomAttributes
 				{
@@ -2069,6 +2439,42 @@ class items
 					};
 					class Attribute3
 					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute4
+					{
 						property="lambs_danger_dangerRadio";
 						expression="if (_value) then { _this setVariable ['lambs_danger_dangerRadio', _value, true]; }";
 						class Value
@@ -2086,7 +2492,7 @@ class items
 							};
 						};
 					};
-					nAttributes=4;
+					nAttributes=5;
 				};
 			};
 			class Item3
@@ -2094,7 +2500,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-4.7944336,0.0014390945,4.059082};
+					position[]={-4.8337402,0.0014390945,4.0180664};
 				};
 				side="West";
 				flags=5;
@@ -2231,7 +2637,7 @@ class items
 						headgear="rhsusf_ach_helmet_ESS_ocp_alt";
 					};
 				};
-				id=250;
+				id=16;
 				type="B_soldier_AR_F";
 				class CustomAttributes
 				{
@@ -2294,6 +2700,42 @@ class items
 					};
 					class Attribute3
 					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute4
+					{
 						property="lambs_danger_dangerRadio";
 						expression="if (_value) then { _this setVariable ['lambs_danger_dangerRadio', _value, true]; }";
 						class Value
@@ -2311,7 +2753,7 @@ class items
 							};
 						};
 					};
-					nAttributes=4;
+					nAttributes=5;
 				};
 			};
 			class Item4
@@ -2319,7 +2761,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-3.7944336,0.0014390945,4.059082};
+					position[]={-3.8337402,0.0014390945,4.0180664};
 				};
 				side="West";
 				flags=5;
@@ -2515,7 +2957,7 @@ class items
 						headgear="rhsusf_ach_helmet_headset_ocp_alt";
 					};
 				};
-				id=251;
+				id=17;
 				type="B_soldier_AAR_F";
 				class CustomAttributes
 				{
@@ -2578,6 +3020,42 @@ class items
 					};
 					class Attribute3
 					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute4
+					{
 						property="lambs_danger_dangerRadio";
 						expression="if (_value) then { _this setVariable ['lambs_danger_dangerRadio', _value, true]; }";
 						class Value
@@ -2595,7 +3073,7 @@ class items
 							};
 						};
 					};
-					nAttributes=4;
+					nAttributes=5;
 				};
 			};
 			class Item5
@@ -2603,7 +3081,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-2.7944336,0.0014390945,4.059082};
+					position[]={-2.8337402,0.0014390945,4.0180664};
 				};
 				side="West";
 				flags=5;
@@ -2734,7 +3212,7 @@ class items
 						headgear="rhsusf_ach_helmet_ocp_alt";
 					};
 				};
-				id=252;
+				id=18;
 				type="B_soldier_LAT_F";
 				class CustomAttributes
 				{
@@ -2797,6 +3275,42 @@ class items
 					};
 					class Attribute3
 					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute4
+					{
 						property="lambs_danger_dangerRadio";
 						expression="if (_value) then { _this setVariable ['lambs_danger_dangerRadio', _value, true]; }";
 						class Value
@@ -2814,7 +3328,7 @@ class items
 							};
 						};
 					};
-					nAttributes=4;
+					nAttributes=5;
 				};
 			};
 			class Item6
@@ -2822,7 +3336,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-5.7944336,0.0014390945,2.059082};
+					position[]={-5.8337402,0.0014390945,2.0180664};
 				};
 				side="West";
 				flags=5;
@@ -3024,7 +3538,7 @@ class items
 						headgear="rhsusf_ach_helmet_headset_ess_ocp_alt";
 					};
 				};
-				id=253;
+				id=19;
 				type="B_Soldier_TL_F";
 				class CustomAttributes
 				{
@@ -3087,6 +3601,42 @@ class items
 					};
 					class Attribute3
 					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute4
+					{
 						property="lambs_danger_dangerRadio";
 						expression="if (_value) then { _this setVariable ['lambs_danger_dangerRadio', _value, true]; }";
 						class Value
@@ -3104,7 +3654,7 @@ class items
 							};
 						};
 					};
-					nAttributes=4;
+					nAttributes=5;
 				};
 			};
 			class Item7
@@ -3112,7 +3662,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-4.7944336,0.0014390945,2.059082};
+					position[]={-4.8337402,0.0014390945,2.0180664};
 				};
 				side="West";
 				flags=5;
@@ -3249,7 +3799,7 @@ class items
 						headgear="rhsusf_ach_helmet_ocp_alt";
 					};
 				};
-				id=254;
+				id=20;
 				type="B_soldier_AR_F";
 				class CustomAttributes
 				{
@@ -3312,6 +3862,42 @@ class items
 					};
 					class Attribute3
 					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute4
+					{
 						property="lambs_danger_dangerRadio";
 						expression="if (_value) then { _this setVariable ['lambs_danger_dangerRadio', _value, true]; }";
 						class Value
@@ -3329,7 +3915,7 @@ class items
 							};
 						};
 					};
-					nAttributes=4;
+					nAttributes=5;
 				};
 			};
 			class Item8
@@ -3337,7 +3923,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-3.7944336,0.0014390945,2.059082};
+					position[]={-3.8337402,0.0014390945,2.0180664};
 				};
 				side="West";
 				flags=5;
@@ -3533,7 +4119,7 @@ class items
 						headgear="rhsusf_ach_helmet_headset_ocp_alt";
 					};
 				};
-				id=255;
+				id=21;
 				type="B_soldier_AAR_F";
 				class CustomAttributes
 				{
@@ -3596,6 +4182,42 @@ class items
 					};
 					class Attribute3
 					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute4
+					{
 						property="lambs_danger_dangerRadio";
 						expression="if (_value) then { _this setVariable ['lambs_danger_dangerRadio', _value, true]; }";
 						class Value
@@ -3613,7 +4235,7 @@ class items
 							};
 						};
 					};
-					nAttributes=4;
+					nAttributes=5;
 				};
 			};
 			class Item9
@@ -3621,7 +4243,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-2.7944336,0.0014390945,2.059082};
+					position[]={-2.8337402,0.0014390945,2.0180664};
 				};
 				side="West";
 				flags=5;
@@ -3752,7 +4374,7 @@ class items
 						headgear="rhsusf_ach_helmet_ESS_ocp_alt";
 					};
 				};
-				id=256;
+				id=22;
 				type="B_soldier_LAT_F";
 				class CustomAttributes
 				{
@@ -3815,6 +4437,42 @@ class items
 					};
 					class Attribute3
 					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute4
+					{
 						property="lambs_danger_dangerRadio";
 						expression="if (_value) then { _this setVariable ['lambs_danger_dangerRadio', _value, true]; }";
 						class Value
@@ -3832,14 +4490,14 @@ class items
 							};
 						};
 					};
-					nAttributes=4;
+					nAttributes=5;
 				};
 			};
 		};
 		class Attributes
 		{
 		};
-		id=246;
+		id=12;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -3876,7 +4534,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-1.2993164,0.0014390945,6.0249023};
+					position[]={-1.3381348,0.0014390945,5.9838867};
 				};
 				side="West";
 				flags=7;
@@ -4095,7 +4753,7 @@ class items
 						headgear="rhsusf_ach_helmet_headset_ess_ocp_alt";
 					};
 				};
-				id=258;
+				id=24;
 				type="B_Soldier_SL_F";
 				class CustomAttributes
 				{
@@ -4139,6 +4797,56 @@ class items
 					};
 					class Attribute2
 					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=2;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="2";
+										};
+									};
+									class Item1
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute3
+					{
 						property="lambs_danger_dangerRadio";
 						expression="if (_value) then { _this setVariable ['lambs_danger_dangerRadio', _value, true]; }";
 						class Value
@@ -4156,7 +4864,45 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					class Attribute4
+					{
+						property="speaker";
+						expression="_this setspeaker _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="Male04ENG";
+							};
+						};
+					};
+					class Attribute5
+					{
+						property="pitch";
+						expression="_this setpitch _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"SCALAR"
+									};
+								};
+								value=0.95999998;
+							};
+						};
+					};
+					nAttributes=6;
 				};
 			};
 			class Item1
@@ -4164,7 +4910,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-0.29931641,0.0014390945,6.0249023};
+					position[]={-0.33862305,0.0014390945,5.9838867};
 				};
 				side="West";
 				flags=5;
@@ -4372,7 +5118,7 @@ class items
 						headgear="rhsusf_ach_helmet_ocp_alt";
 					};
 				};
-				id=259;
+				id=25;
 				type="B_medic_F";
 				class CustomAttributes
 				{
@@ -4416,6 +5162,42 @@ class items
 					};
 					class Attribute2
 					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="2";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute3
+					{
 						property="lambs_danger_dangerRadio";
 						expression="if (_value) then { _this setVariable ['lambs_danger_dangerRadio', _value, true]; }";
 						class Value
@@ -4433,7 +5215,7 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					nAttributes=4;
 				};
 			};
 			class Item2
@@ -4441,7 +5223,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-1.2993164,0.0014390945,4.0249023};
+					position[]={-1.338623,0.0014390945,3.9838867};
 				};
 				side="West";
 				flags=5;
@@ -4643,7 +5425,7 @@ class items
 						headgear="rhsusf_ach_helmet_headset_ess_ocp_alt";
 					};
 				};
-				id=260;
+				id=26;
 				type="B_Soldier_TL_F";
 				class CustomAttributes
 				{
@@ -4706,6 +5488,42 @@ class items
 					};
 					class Attribute3
 					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="2";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute4
+					{
 						property="lambs_danger_dangerRadio";
 						expression="if (_value) then { _this setVariable ['lambs_danger_dangerRadio', _value, true]; }";
 						class Value
@@ -4723,7 +5541,7 @@ class items
 							};
 						};
 					};
-					nAttributes=4;
+					nAttributes=5;
 				};
 			};
 			class Item3
@@ -4731,7 +5549,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-0.29931641,0.0014390945,4.0249023};
+					position[]={-0.33862305,0.0014390945,3.9838867};
 				};
 				side="West";
 				flags=5;
@@ -4868,7 +5686,7 @@ class items
 						headgear="rhsusf_ach_helmet_ocp_alt";
 					};
 				};
-				id=261;
+				id=27;
 				type="B_soldier_AR_F";
 				class CustomAttributes
 				{
@@ -4931,6 +5749,42 @@ class items
 					};
 					class Attribute3
 					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="2";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute4
+					{
 						property="lambs_danger_dangerRadio";
 						expression="if (_value) then { _this setVariable ['lambs_danger_dangerRadio', _value, true]; }";
 						class Value
@@ -4948,7 +5802,7 @@ class items
 							};
 						};
 					};
-					nAttributes=4;
+					nAttributes=5;
 				};
 			};
 			class Item4
@@ -4956,7 +5810,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={0.70068359,0.0014390945,4.0249023};
+					position[]={0.66137695,0.0014390945,3.9838867};
 				};
 				side="West";
 				flags=5;
@@ -5152,7 +6006,7 @@ class items
 						headgear="rhsusf_ach_helmet_headset_ocp_alt";
 					};
 				};
-				id=262;
+				id=28;
 				type="B_soldier_AAR_F";
 				class CustomAttributes
 				{
@@ -5215,6 +6069,42 @@ class items
 					};
 					class Attribute3
 					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="2";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute4
+					{
 						property="lambs_danger_dangerRadio";
 						expression="if (_value) then { _this setVariable ['lambs_danger_dangerRadio', _value, true]; }";
 						class Value
@@ -5232,7 +6122,7 @@ class items
 							};
 						};
 					};
-					nAttributes=4;
+					nAttributes=5;
 				};
 			};
 			class Item5
@@ -5240,7 +6130,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={1.7006836,0.0014390945,4.0249023};
+					position[]={1.661377,0.0014390945,3.9838867};
 				};
 				side="West";
 				flags=5;
@@ -5371,7 +6261,7 @@ class items
 						headgear="rhsusf_ach_helmet_ESS_ocp_alt";
 					};
 				};
-				id=263;
+				id=29;
 				type="B_soldier_LAT_F";
 				class CustomAttributes
 				{
@@ -5434,6 +6324,42 @@ class items
 					};
 					class Attribute3
 					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="2";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute4
+					{
 						property="lambs_danger_dangerRadio";
 						expression="if (_value) then { _this setVariable ['lambs_danger_dangerRadio', _value, true]; }";
 						class Value
@@ -5451,7 +6377,7 @@ class items
 							};
 						};
 					};
-					nAttributes=4;
+					nAttributes=5;
 				};
 			};
 			class Item6
@@ -5459,7 +6385,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-1.2993164,0.0014390945,2.0249023};
+					position[]={-1.338623,0.0014390945,1.9838867};
 				};
 				side="West";
 				flags=5;
@@ -5661,7 +6587,7 @@ class items
 						headgear="rhsusf_ach_helmet_headset_ess_ocp_alt";
 					};
 				};
-				id=264;
+				id=30;
 				type="B_Soldier_TL_F";
 				class CustomAttributes
 				{
@@ -5724,6 +6650,42 @@ class items
 					};
 					class Attribute3
 					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="2";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute4
+					{
 						property="lambs_danger_dangerRadio";
 						expression="if (_value) then { _this setVariable ['lambs_danger_dangerRadio', _value, true]; }";
 						class Value
@@ -5741,7 +6703,7 @@ class items
 							};
 						};
 					};
-					nAttributes=4;
+					nAttributes=5;
 				};
 			};
 			class Item7
@@ -5749,7 +6711,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-0.29931641,0.0014390945,2.0249023};
+					position[]={-0.33862305,0.0014390945,1.9838867};
 				};
 				side="West";
 				flags=5;
@@ -5886,7 +6848,7 @@ class items
 						headgear="rhsusf_ach_helmet_ESS_ocp_alt";
 					};
 				};
-				id=265;
+				id=31;
 				type="B_soldier_AR_F";
 				class CustomAttributes
 				{
@@ -5949,6 +6911,42 @@ class items
 					};
 					class Attribute3
 					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="2";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute4
+					{
 						property="lambs_danger_dangerRadio";
 						expression="if (_value) then { _this setVariable ['lambs_danger_dangerRadio', _value, true]; }";
 						class Value
@@ -5966,7 +6964,7 @@ class items
 							};
 						};
 					};
-					nAttributes=4;
+					nAttributes=5;
 				};
 			};
 			class Item8
@@ -5974,7 +6972,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={0.70068359,0.0014390945,2.0249023};
+					position[]={0.66137695,0.0014390945,1.9838867};
 				};
 				side="West";
 				flags=5;
@@ -6170,7 +7168,7 @@ class items
 						headgear="rhsusf_ach_helmet_headset_ocp_alt";
 					};
 				};
-				id=266;
+				id=32;
 				type="B_soldier_AAR_F";
 				class CustomAttributes
 				{
@@ -6233,6 +7231,42 @@ class items
 					};
 					class Attribute3
 					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="2";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute4
+					{
 						property="lambs_danger_dangerRadio";
 						expression="if (_value) then { _this setVariable ['lambs_danger_dangerRadio', _value, true]; }";
 						class Value
@@ -6250,7 +7284,7 @@ class items
 							};
 						};
 					};
-					nAttributes=4;
+					nAttributes=5;
 				};
 			};
 			class Item9
@@ -6258,7 +7292,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={1.7006836,0.0014390945,2.0249023};
+					position[]={1.661377,0.0014390945,1.9838867};
 				};
 				side="West";
 				flags=5;
@@ -6389,7 +7423,7 @@ class items
 						headgear="rhsusf_ach_helmet_ocp_alt";
 					};
 				};
-				id=267;
+				id=33;
 				type="B_soldier_LAT_F";
 				class CustomAttributes
 				{
@@ -6452,6 +7486,42 @@ class items
 					};
 					class Attribute3
 					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="2";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute4
+					{
 						property="lambs_danger_dangerRadio";
 						expression="if (_value) then { _this setVariable ['lambs_danger_dangerRadio', _value, true]; }";
 						class Value
@@ -6469,14 +7539,14 @@ class items
 							};
 						};
 					};
-					nAttributes=4;
+					nAttributes=5;
 				};
 			};
 		};
 		class Attributes
 		{
 		};
-		id=257;
+		id=23;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -6513,7 +7583,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={4.0112305,0.0014390945,6.0209961};
+					position[]={3.9719238,0.0014390945,5.9799805};
 				};
 				side="West";
 				flags=7;
@@ -6732,7 +7802,7 @@ class items
 						headgear="rhsusf_ach_helmet_headset_ess_ocp_alt";
 					};
 				};
-				id=269;
+				id=35;
 				type="B_Soldier_SL_F";
 				class CustomAttributes
 				{
@@ -6776,6 +7846,56 @@ class items
 					};
 					class Attribute2
 					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=2;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="3";
+										};
+									};
+									class Item1
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute3
+					{
 						property="lambs_danger_dangerRadio";
 						expression="if (_value) then { _this setVariable ['lambs_danger_dangerRadio', _value, true]; }";
 						class Value
@@ -6793,7 +7913,45 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					class Attribute4
+					{
+						property="speaker";
+						expression="_this setspeaker _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="Male12ENG";
+							};
+						};
+					};
+					class Attribute5
+					{
+						property="pitch";
+						expression="_this setpitch _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"SCALAR"
+									};
+								};
+								value=1;
+							};
+						};
+					};
+					nAttributes=6;
 				};
 			};
 			class Item1
@@ -6801,7 +7959,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={5.0112305,0.0014390945,6.0200195};
+					position[]={4.9719238,0.0014390945,5.9790039};
 				};
 				side="West";
 				flags=5;
@@ -7009,7 +8167,7 @@ class items
 						headgear="rhsusf_ach_helmet_ocp_alt";
 					};
 				};
-				id=270;
+				id=36;
 				type="B_medic_F";
 				class CustomAttributes
 				{
@@ -7053,6 +8211,42 @@ class items
 					};
 					class Attribute2
 					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="3";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute3
+					{
 						property="lambs_danger_dangerRadio";
 						expression="if (_value) then { _this setVariable ['lambs_danger_dangerRadio', _value, true]; }";
 						class Value
@@ -7070,7 +8264,7 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					nAttributes=4;
 				};
 			};
 			class Item2
@@ -7078,7 +8272,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={4.0112305,0.0014390945,4.0200195};
+					position[]={3.9719238,0.0014390945,3.9790039};
 				};
 				side="West";
 				flags=5;
@@ -7280,7 +8474,7 @@ class items
 						headgear="rhsusf_ach_helmet_headset_ess_ocp_alt";
 					};
 				};
-				id=271;
+				id=37;
 				type="B_Soldier_TL_F";
 				class CustomAttributes
 				{
@@ -7343,6 +8537,42 @@ class items
 					};
 					class Attribute3
 					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="3";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute4
+					{
 						property="lambs_danger_dangerRadio";
 						expression="if (_value) then { _this setVariable ['lambs_danger_dangerRadio', _value, true]; }";
 						class Value
@@ -7360,7 +8590,7 @@ class items
 							};
 						};
 					};
-					nAttributes=4;
+					nAttributes=5;
 				};
 			};
 			class Item3
@@ -7368,7 +8598,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={5.0112305,0.0014390945,4.0200195};
+					position[]={4.9719238,0.0014390945,3.9790039};
 				};
 				side="West";
 				flags=5;
@@ -7505,7 +8735,7 @@ class items
 						headgear="rhsusf_ach_helmet_ESS_ocp_alt";
 					};
 				};
-				id=272;
+				id=38;
 				type="B_soldier_AR_F";
 				class CustomAttributes
 				{
@@ -7568,6 +8798,42 @@ class items
 					};
 					class Attribute3
 					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="3";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute4
+					{
 						property="lambs_danger_dangerRadio";
 						expression="if (_value) then { _this setVariable ['lambs_danger_dangerRadio', _value, true]; }";
 						class Value
@@ -7585,7 +8851,7 @@ class items
 							};
 						};
 					};
-					nAttributes=4;
+					nAttributes=5;
 				};
 			};
 			class Item4
@@ -7593,7 +8859,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={6.0112305,0.0014390945,4.0200195};
+					position[]={5.9719238,0.0014390945,3.9790039};
 				};
 				side="West";
 				flags=5;
@@ -7789,7 +9055,7 @@ class items
 						headgear="rhsusf_ach_helmet_headset_ocp_alt";
 					};
 				};
-				id=273;
+				id=39;
 				type="B_soldier_AAR_F";
 				class CustomAttributes
 				{
@@ -7852,6 +9118,42 @@ class items
 					};
 					class Attribute3
 					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="3";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute4
+					{
 						property="lambs_danger_dangerRadio";
 						expression="if (_value) then { _this setVariable ['lambs_danger_dangerRadio', _value, true]; }";
 						class Value
@@ -7869,7 +9171,7 @@ class items
 							};
 						};
 					};
-					nAttributes=4;
+					nAttributes=5;
 				};
 			};
 			class Item5
@@ -7877,7 +9179,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={7.0112305,0.0014390945,4.0200195};
+					position[]={6.9719238,0.0014390945,3.9790039};
 				};
 				side="West";
 				flags=5;
@@ -8008,7 +9310,7 @@ class items
 						headgear="rhsusf_ach_helmet_ocp_alt";
 					};
 				};
-				id=274;
+				id=40;
 				type="B_soldier_LAT_F";
 				class CustomAttributes
 				{
@@ -8071,6 +9373,42 @@ class items
 					};
 					class Attribute3
 					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="3";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute4
+					{
 						property="lambs_danger_dangerRadio";
 						expression="if (_value) then { _this setVariable ['lambs_danger_dangerRadio', _value, true]; }";
 						class Value
@@ -8088,7 +9426,7 @@ class items
 							};
 						};
 					};
-					nAttributes=4;
+					nAttributes=5;
 				};
 			};
 			class Item6
@@ -8096,7 +9434,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={4.0112305,0.0014390945,2.0200195};
+					position[]={3.9719238,0.0014390945,1.9790039};
 				};
 				side="West";
 				flags=5;
@@ -8298,7 +9636,7 @@ class items
 						headgear="rhsusf_ach_helmet_headset_ess_ocp_alt";
 					};
 				};
-				id=275;
+				id=41;
 				type="B_Soldier_TL_F";
 				class CustomAttributes
 				{
@@ -8361,6 +9699,42 @@ class items
 					};
 					class Attribute3
 					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="3";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute4
+					{
 						property="lambs_danger_dangerRadio";
 						expression="if (_value) then { _this setVariable ['lambs_danger_dangerRadio', _value, true]; }";
 						class Value
@@ -8378,7 +9752,7 @@ class items
 							};
 						};
 					};
-					nAttributes=4;
+					nAttributes=5;
 				};
 			};
 			class Item7
@@ -8386,7 +9760,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={5.0112305,0.0014390945,2.0200195};
+					position[]={4.9719238,0.0014390945,1.9790039};
 				};
 				side="West";
 				flags=5;
@@ -8523,7 +9897,7 @@ class items
 						headgear="rhsusf_ach_helmet_ocp_alt";
 					};
 				};
-				id=276;
+				id=42;
 				type="B_soldier_AR_F";
 				class CustomAttributes
 				{
@@ -8586,6 +9960,42 @@ class items
 					};
 					class Attribute3
 					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="3";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute4
+					{
 						property="lambs_danger_dangerRadio";
 						expression="if (_value) then { _this setVariable ['lambs_danger_dangerRadio', _value, true]; }";
 						class Value
@@ -8603,7 +10013,7 @@ class items
 							};
 						};
 					};
-					nAttributes=4;
+					nAttributes=5;
 				};
 			};
 			class Item8
@@ -8611,7 +10021,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={6.0112305,0.0014390945,2.0200195};
+					position[]={5.9719238,0.0014390945,1.9790039};
 				};
 				side="West";
 				flags=5;
@@ -8807,7 +10217,7 @@ class items
 						headgear="rhsusf_ach_helmet_headset_ocp_alt";
 					};
 				};
-				id=277;
+				id=43;
 				type="B_soldier_AAR_F";
 				class CustomAttributes
 				{
@@ -8870,6 +10280,42 @@ class items
 					};
 					class Attribute3
 					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="3";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute4
+					{
 						property="lambs_danger_dangerRadio";
 						expression="if (_value) then { _this setVariable ['lambs_danger_dangerRadio', _value, true]; }";
 						class Value
@@ -8887,7 +10333,7 @@ class items
 							};
 						};
 					};
-					nAttributes=4;
+					nAttributes=5;
 				};
 			};
 			class Item9
@@ -8895,7 +10341,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={7.0112305,0.0014390945,2.0200195};
+					position[]={6.9719238,0.0014390945,1.9790039};
 				};
 				side="West";
 				flags=5;
@@ -9026,7 +10472,7 @@ class items
 						headgear="rhsusf_ach_helmet_ESS_ocp_alt";
 					};
 				};
-				id=278;
+				id=44;
 				type="B_soldier_LAT_F";
 				class CustomAttributes
 				{
@@ -9089,6 +10535,42 @@ class items
 					};
 					class Attribute3
 					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="3";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute4
+					{
 						property="lambs_danger_dangerRadio";
 						expression="if (_value) then { _this setVariable ['lambs_danger_dangerRadio', _value, true]; }";
 						class Value
@@ -9106,14 +10588,14 @@ class items
 							};
 						};
 					};
-					nAttributes=4;
+					nAttributes=5;
 				};
 			};
 		};
 		class Attributes
 		{
 		};
-		id=268;
+		id=34;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -9150,7 +10632,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-6.0336914,0.0014390945,-1.0541992};
+					position[]={-6.0732422,0.0014390945,-1.0952148};
 				};
 				side="West";
 				flags=7;
@@ -9369,7 +10851,7 @@ class items
 						headgear="rhsusf_ach_helmet_headset_ocp_alt";
 					};
 				};
-				id=280;
+				id=46;
 				type="B_Soldier_TL_F";
 				class CustomAttributes
 				{
@@ -9413,6 +10895,56 @@ class items
 					};
 					class Attribute2
 					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=2;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="5";
+										};
+									};
+									class Item1
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute3
+					{
 						property="lambs_danger_dangerRadio";
 						expression="if (_value) then { _this setVariable ['lambs_danger_dangerRadio', _value, true]; }";
 						class Value
@@ -9430,7 +10962,45 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					class Attribute4
+					{
+						property="speaker";
+						expression="_this setspeaker _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="Male02ENG";
+							};
+						};
+					};
+					class Attribute5
+					{
+						property="pitch";
+						expression="_this setpitch _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"SCALAR"
+									};
+								};
+								value=1.03;
+							};
+						};
+					};
+					nAttributes=6;
 				};
 			};
 			class Item1
@@ -9438,7 +11008,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-5.0336914,0.0014390945,-1.0541992};
+					position[]={-5.072998,0.0014390945,-1.0952148};
 				};
 				side="West";
 				flags=5;
@@ -9573,7 +11143,7 @@ class items
 						headgear="rhsusf_ach_helmet_ESS_ocp_alt";
 					};
 				};
-				id=281;
+				id=47;
 				type="B_soldier_AR_F";
 				class CustomAttributes
 				{
@@ -9617,6 +11187,42 @@ class items
 					};
 					class Attribute2
 					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="5";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute3
+					{
 						property="lambs_danger_dangerRadio";
 						expression="if (_value) then { _this setVariable ['lambs_danger_dangerRadio', _value, true]; }";
 						class Value
@@ -9634,7 +11240,7 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					nAttributes=4;
 				};
 			};
 			class Item2
@@ -9642,7 +11248,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-4.0336914,0.0014390945,-1.0541992};
+					position[]={-4.072998,0.0014390945,-1.0952148};
 				};
 				side="West";
 				flags=5;
@@ -9790,7 +11396,7 @@ class items
 						headgear="rhsusf_ach_helmet_ocp_alt";
 					};
 				};
-				id=282;
+				id=48;
 				type="B_soldier_AAR_F";
 				class CustomAttributes
 				{
@@ -9834,6 +11440,42 @@ class items
 					};
 					class Attribute2
 					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="5";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute3
+					{
 						property="lambs_danger_dangerRadio";
 						expression="if (_value) then { _this setVariable ['lambs_danger_dangerRadio', _value, true]; }";
 						class Value
@@ -9851,14 +11493,14 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					nAttributes=4;
 				};
 			};
 		};
 		class Attributes
 		{
 		};
-		id=279;
+		id=45;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -9895,7 +11537,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-0.92333984,0.0014390945,-1.2104492};
+					position[]={-0.9621582,0.0014390945,-1.2509766};
 				};
 				side="West";
 				flags=7;
@@ -10114,7 +11756,7 @@ class items
 						headgear="rhsusf_ach_helmet_headset_ocp_alt";
 					};
 				};
-				id=284;
+				id=50;
 				type="B_Soldier_TL_F";
 				class CustomAttributes
 				{
@@ -10158,6 +11800,56 @@ class items
 					};
 					class Attribute2
 					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=2;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="6";
+										};
+									};
+									class Item1
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute3
+					{
 						property="lambs_danger_dangerRadio";
 						expression="if (_value) then { _this setVariable ['lambs_danger_dangerRadio', _value, true]; }";
 						class Value
@@ -10175,7 +11867,45 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					class Attribute4
+					{
+						property="speaker";
+						expression="_this setspeaker _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="Male02ENG";
+							};
+						};
+					};
+					class Attribute5
+					{
+						property="pitch";
+						expression="_this setpitch _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"SCALAR"
+									};
+								};
+								value=1.01;
+							};
+						};
+					};
+					nAttributes=6;
 				};
 			};
 			class Item1
@@ -10183,7 +11913,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={0.076660156,0.0014390945,-1.2104492};
+					position[]={0.037353516,0.0014390945,-1.2514648};
 				};
 				side="West";
 				flags=5;
@@ -10341,7 +12071,7 @@ class items
 						headgear="rhsusf_ach_helmet_ESS_ocp_alt";
 					};
 				};
-				id=285;
+				id=51;
 				type="B_soldier_AT_F";
 				class CustomAttributes
 				{
@@ -10385,6 +12115,42 @@ class items
 					};
 					class Attribute2
 					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="6";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute3
+					{
 						property="lambs_danger_dangerRadio";
 						expression="if (_value) then { _this setVariable ['lambs_danger_dangerRadio', _value, true]; }";
 						class Value
@@ -10402,7 +12168,7 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					nAttributes=4;
 				};
 			};
 			class Item2
@@ -10410,7 +12176,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={1.0766602,0.0014390945,-1.2104492};
+					position[]={1.0373535,0.0014390945,-1.2514648};
 				};
 				side="West";
 				flags=5;
@@ -10558,7 +12324,7 @@ class items
 						headgear="rhsusf_ach_helmet_ocp_alt";
 					};
 				};
-				id=286;
+				id=52;
 				type="B_soldier_AAT_F";
 				class CustomAttributes
 				{
@@ -10602,6 +12368,42 @@ class items
 					};
 					class Attribute2
 					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="6";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute3
+					{
 						property="lambs_danger_dangerRadio";
 						expression="if (_value) then { _this setVariable ['lambs_danger_dangerRadio', _value, true]; }";
 						class Value
@@ -10619,14 +12421,14 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					nAttributes=4;
 				};
 			};
 		};
 		class Attributes
 		{
 		};
-		id=283;
+		id=49;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -10663,7 +12465,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-6.3803711,0.0014390945,-4.2006836};
+					position[]={-6.4191895,0.0014390945,-4.2421875};
 				};
 				side="West";
 				flags=6;
@@ -10850,7 +12652,7 @@ class items
 						headgear="rhs_Booniehat_ocp";
 					};
 				};
-				id=288;
+				id=54;
 				type="B_spotter_F";
 				class CustomAttributes
 				{
@@ -10894,6 +12696,56 @@ class items
 					};
 					class Attribute2
 					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=2;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="8";
+										};
+									};
+									class Item1
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute3
+					{
 						property="lambs_danger_dangerRadio";
 						expression="if (_value) then { _this setVariable ['lambs_danger_dangerRadio', _value, true]; }";
 						class Value
@@ -10911,7 +12763,45 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					class Attribute4
+					{
+						property="speaker";
+						expression="_this setspeaker _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="Male08ENG";
+							};
+						};
+					};
+					class Attribute5
+					{
+						property="pitch";
+						expression="_this setpitch _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"SCALAR"
+									};
+								};
+								value=0.97000003;
+							};
+						};
+					};
+					nAttributes=6;
 				};
 			};
 			class Item1
@@ -10919,7 +12809,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-5.3806152,0.0014390945,-4.2001953};
+					position[]={-5.4199219,0.0014390945,-4.2412109};
 				};
 				side="West";
 				flags=4;
@@ -11074,7 +12964,7 @@ class items
 						headgear="rhs_Booniehat_ocp";
 					};
 				};
-				id=289;
+				id=55;
 				type="B_soldier_M_F";
 				class CustomAttributes
 				{
@@ -11173,14 +13063,50 @@ class items
 							};
 						};
 					};
-					nAttributes=5;
+					class Attribute5
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="8";
+										};
+									};
+								};
+							};
+						};
+					};
+					nAttributes=6;
 				};
 			};
 		};
 		class Attributes
 		{
 		};
-		id=287;
+		id=53;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -11217,7 +13143,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-0.93115234,0.0014390945,-4.8491211};
+					position[]={-0.97045898,0.0014390945,-4.8901367};
 				};
 				side="West";
 				flags=7;
@@ -11380,7 +13306,7 @@ class items
 						headgear="rhsusf_ach_helmet_headset_ocp_alt";
 					};
 				};
-				id=291;
+				id=57;
 				type="B_support_AMort_F";
 				class CustomAttributes
 				{
@@ -11449,7 +13375,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={0.067871094,0.0014390945,-4.8491211};
+					position[]={0.028564453,0.0014390945,-4.8901367};
 				};
 				side="West";
 				flags=5;
@@ -11582,7 +13508,7 @@ class items
 						headgear="rhsusf_ach_helmet_ESS_ocp_alt";
 					};
 				};
-				id=292;
+				id=58;
 				type="B_support_Mort_F";
 				class CustomAttributes
 				{
@@ -11650,7 +13576,7 @@ class items
 		class Attributes
 		{
 		};
-		id=290;
+		id=56;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -11687,7 +13613,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={4.0336914,0.0014390945,-1.1010742};
+					position[]={3.994873,0.0014390945,-1.1420898};
 				};
 				side="West";
 				flags=7;
@@ -11849,7 +13775,7 @@ class items
 						headgear="rhsusf_ach_helmet_headset_ess_ocp_alt";
 					};
 				};
-				id=294;
+				id=60;
 				type="B_engineer_F";
 				class CustomAttributes
 				{
@@ -11893,6 +13819,56 @@ class items
 					};
 					class Attribute2
 					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=2;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="7";
+										};
+									};
+									class Item1
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute3
+					{
 						property="lambs_danger_dangerRadio";
 						expression="if (_value) then { _this setVariable ['lambs_danger_dangerRadio', _value, true]; }";
 						class Value
@@ -11910,7 +13886,45 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					class Attribute4
+					{
+						property="speaker";
+						expression="_this setspeaker _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="Male05ENG";
+							};
+						};
+					};
+					class Attribute5
+					{
+						property="pitch";
+						expression="_this setpitch _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"SCALAR"
+									};
+								};
+								value=1.04;
+							};
+						};
+					};
+					nAttributes=6;
 				};
 			};
 			class Item1
@@ -11918,7 +13932,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={5.0336914,0.0014390945,-1.1020508};
+					position[]={4.9943848,0.0014390945,-1.1430664};
 				};
 				side="West";
 				flags=5;
@@ -12073,7 +14087,7 @@ class items
 						headgear="rhsusf_ach_helmet_headset_ocp_alt";
 					};
 				};
-				id=295;
+				id=61;
 				type="B_engineer_F";
 				class CustomAttributes
 				{
@@ -12117,6 +14131,42 @@ class items
 					};
 					class Attribute2
 					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="7";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute3
+					{
 						property="lambs_danger_dangerRadio";
 						expression="if (_value) then { _this setVariable ['lambs_danger_dangerRadio', _value, true]; }";
 						class Value
@@ -12134,7 +14184,7 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					nAttributes=4;
 				};
 			};
 			class Item2
@@ -12142,7 +14192,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={6.0336914,0.0014390945,-1.1020508};
+					position[]={5.9943848,0.0014390945,-1.1430664};
 				};
 				side="West";
 				flags=5;
@@ -12297,7 +14347,7 @@ class items
 						headgear="rhsusf_ach_helmet_headset_ocp_alt";
 					};
 				};
-				id=296;
+				id=62;
 				type="B_engineer_F";
 				class CustomAttributes
 				{
@@ -12341,6 +14391,42 @@ class items
 					};
 					class Attribute2
 					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="7";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute3
+					{
 						property="lambs_danger_dangerRadio";
 						expression="if (_value) then { _this setVariable ['lambs_danger_dangerRadio', _value, true]; }";
 						class Value
@@ -12358,7 +14444,7 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					nAttributes=4;
 				};
 			};
 			class Item3
@@ -12366,7 +14452,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={7.0336914,0.0014390945,-1.1020508};
+					position[]={6.9943848,0.0014390945,-1.1430664};
 				};
 				side="West";
 				flags=5;
@@ -12521,7 +14607,7 @@ class items
 						headgear="rhsusf_ach_helmet_headset_ocp_alt";
 					};
 				};
-				id=297;
+				id=63;
 				type="B_engineer_F";
 				class CustomAttributes
 				{
@@ -12565,6 +14651,42 @@ class items
 					};
 					class Attribute2
 					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=1;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="7";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute3
+					{
 						property="lambs_danger_dangerRadio";
 						expression="if (_value) then { _this setVariable ['lambs_danger_dangerRadio', _value, true]; }";
 						class Value
@@ -12582,14 +14704,14 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					nAttributes=4;
 				};
 			};
 		};
 		class Attributes
 		{
 		};
-		id=293;
+		id=59;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -12626,7 +14748,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-6.597168,0.0014390945,-8.277832};
+					position[]={-6.6362305,0.0014390945,-8.3188477};
 				};
 				side="West";
 				flags=7;
@@ -12765,7 +14887,7 @@ class items
 						headgear="rhsusf_cvc_green_ess";
 					};
 				};
-				id=299;
+				id=65;
 				type="B_crew_F";
 				class CustomAttributes
 				{
@@ -12809,6 +14931,70 @@ class items
 					};
 					class Attribute2
 					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=3;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="0";
+										};
+									};
+									class Item1
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+									class Item2
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="2";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute3
+					{
 						property="lambs_danger_dangerRadio";
 						expression="if (_value) then { _this setVariable ['lambs_danger_dangerRadio', _value, true]; }";
 						class Value
@@ -12826,7 +15012,45 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					class Attribute4
+					{
+						property="speaker";
+						expression="_this setspeaker _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="Male08ENG";
+							};
+						};
+					};
+					class Attribute5
+					{
+						property="pitch";
+						expression="_this setpitch _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"SCALAR"
+									};
+								};
+								value=0.95999998;
+							};
+						};
+					};
+					nAttributes=6;
 				};
 			};
 			class Item1
@@ -12834,7 +15058,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-5.5981445,0.0014390945,-8.2788086};
+					position[]={-5.6374512,0.0014390945,-8.3198242};
 				};
 				side="West";
 				flags=5;
@@ -12967,7 +15191,7 @@ class items
 						headgear="rhsusf_cvc_green_alt_helmet";
 					};
 				};
-				id=300;
+				id=66;
 				type="B_crew_F";
 				class CustomAttributes
 				{
@@ -13055,7 +15279,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-4.5981445,0.0014390945,-8.2788086};
+					position[]={-4.6374512,0.0014390945,-8.3198242};
 				};
 				side="West";
 				flags=5;
@@ -13174,7 +15398,7 @@ class items
 						headgear="rhsusf_cvc_green_helmet";
 					};
 				};
-				id=301;
+				id=67;
 				type="B_crew_F";
 				class CustomAttributes
 				{
@@ -13261,7 +15485,7 @@ class items
 		class Attributes
 		{
 		};
-		id=298;
+		id=64;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -13298,7 +15522,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-0.98876953,0.0014390945,-7.9790039};
+					position[]={-1.0280762,0.0014390945,-8.0200195};
 				};
 				side="West";
 				flags=7;
@@ -13437,7 +15661,7 @@ class items
 						headgear="rhsusf_hgu56p_visor_black";
 					};
 				};
-				id=303;
+				id=69;
 				type="B_Pilot_F";
 				class CustomAttributes
 				{
@@ -13500,6 +15724,70 @@ class items
 					};
 					class Attribute3
 					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=3;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="0";
+										};
+									};
+									class Item1
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+									class Item2
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="3";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute4
+					{
 						property="lambs_danger_dangerRadio";
 						expression="if (_value) then { _this setVariable ['lambs_danger_dangerRadio', _value, true]; }";
 						class Value
@@ -13517,7 +15805,7 @@ class items
 							};
 						};
 					};
-					nAttributes=4;
+					nAttributes=5;
 				};
 			};
 			class Item1
@@ -13525,7 +15813,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={0.011230469,0.0014390945,-7.9799805};
+					position[]={-0.028076172,0.0014390945,-8.0209961};
 				};
 				side="West";
 				flags=5;
@@ -13677,7 +15965,7 @@ class items
 						headgear="rhsusf_hgu56p_visor_black";
 					};
 				};
-				id=304;
+				id=70;
 				type="B_Pilot_F";
 				class CustomAttributes
 				{
@@ -13740,6 +16028,70 @@ class items
 					};
 					class Attribute3
 					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=3;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="0";
+										};
+									};
+									class Item1
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+									class Item2
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="3";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute4
+					{
 						property="lambs_danger_dangerRadio";
 						expression="if (_value) then { _this setVariable ['lambs_danger_dangerRadio', _value, true]; }";
 						class Value
@@ -13757,14 +16109,14 @@ class items
 							};
 						};
 					};
-					nAttributes=4;
+					nAttributes=5;
 				};
 			};
 		};
 		class Attributes
 		{
 		};
-		id=302;
+		id=68;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -13801,7 +16153,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={3.0117188,0.0014390945,-7.9790039};
+					position[]={2.9724121,0.0014390945,-8.0200195};
 				};
 				side="West";
 				flags=7;
@@ -13944,11 +16296,75 @@ class items
 						headgear="H_PilotHelmetFighter_B";
 					};
 				};
-				id=306;
+				id=72;
 				type="B_Pilot_F";
 				class CustomAttributes
 				{
 					class Attribute0
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=3;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="0";
+										};
+									};
+									class Item1
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+									class Item2
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="3";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute1
 					{
 						property="ace_isEngineer";
 						expression="if !(_value == ([0,1] select (_this getUnitTrait 'engineer'))|| {_value == -1}) then {_this setVariable ['ace_isEngineer', _value, true]}";
@@ -13967,64 +16383,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
-					{
-						property="lambs_danger_disableAI";
-						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
-						class Value
-						{
-							class data
-							{
-								class type
-								{
-									type[]=
-									{
-										"BOOL"
-									};
-								};
-								value=1;
-							};
-						};
-					};
 					class Attribute2
-					{
-						property="a3aa_ee_extended_gear_insignia";
-						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
-						class Value
-						{
-							class data
-							{
-								class type
-								{
-									type[]=
-									{
-										"STRING"
-									};
-								};
-								value="";
-							};
-						};
-					};
-					class Attribute3
-					{
-						property="speaker";
-						expression="_this setspeaker _value;";
-						class Value
-						{
-							class data
-							{
-								class type
-								{
-									type[]=
-									{
-										"STRING"
-									};
-								};
-								value="Male12ENG";
-							};
-						};
-					};
-					class Attribute4
 					{
 						property="lambs_danger_dangerRadio";
 						expression="if (_value) then { _this setVariable ['lambs_danger_dangerRadio', _value, true]; }";
@@ -14043,7 +16402,26 @@ class items
 							};
 						};
 					};
-					class Attribute5
+					class Attribute3
+					{
+						property="lambs_danger_disableAI";
+						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"BOOL"
+									};
+								};
+								value=1;
+							};
+						};
+					};
+					class Attribute4
 					{
 						property="pitch";
 						expression="_this setpitch _value;";
@@ -14062,14 +16440,52 @@ class items
 							};
 						};
 					};
-					nAttributes=6;
+					class Attribute5
+					{
+						property="speaker";
+						expression="_this setspeaker _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="Male12ENG";
+							};
+						};
+					};
+					class Attribute6
+					{
+						property="a3aa_ee_extended_gear_insignia";
+						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="";
+							};
+						};
+					};
+					nAttributes=7;
 				};
 			};
 		};
 		class Attributes
 		{
 		};
-		id=305;
+		id=71;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -14106,7 +16522,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={4.0336914,0.0014390945,-4.8486328};
+					position[]={3.9943848,0.0014390945,-4.8896484};
 				};
 				side="West";
 				flags=7;
@@ -14179,106 +16595,11 @@ class items
 						headgear="rhsusf_patrolcap_ocp";
 					};
 				};
-				id=308;
+				id=74;
 				type="B_Protagonist_VR_F";
 				class CustomAttributes
 				{
 					class Attribute0
-					{
-						property="lambs_danger_disableAI";
-						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
-						class Value
-						{
-							class data
-							{
-								class type
-								{
-									type[]=
-									{
-										"BOOL"
-									};
-								};
-								value=1;
-							};
-						};
-					};
-					class Attribute1
-					{
-						property="speaker";
-						expression="_this setspeaker _value;";
-						class Value
-						{
-							class data
-							{
-								class type
-								{
-									type[]=
-									{
-										"STRING"
-									};
-								};
-								value="Male12ENG";
-							};
-						};
-					};
-					class Attribute2
-					{
-						property="pitch";
-						expression="_this setpitch _value;";
-						class Value
-						{
-							class data
-							{
-								class type
-								{
-									type[]=
-									{
-										"SCALAR"
-									};
-								};
-								value=0.95999998;
-							};
-						};
-					};
-					class Attribute3
-					{
-						property="lambs_danger_dangerRadio";
-						expression="if (_value) then { _this setVariable ['lambs_danger_dangerRadio', _value, true]; }";
-						class Value
-						{
-							class data
-							{
-								class type
-								{
-									type[]=
-									{
-										"BOOL"
-									};
-								};
-								value=0;
-							};
-						};
-					};
-					class Attribute4
-					{
-						property="a3aa_ee_extended_gear_insignia";
-						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
-						class Value
-						{
-							class data
-							{
-								class type
-								{
-									type[]=
-									{
-										"STRING"
-									};
-								};
-								value="Curator";
-							};
-						};
-					};
-					class Attribute5
 					{
 						property="a3aa_insta_zeus_unit_curator";
 						expression="[_this, _value] call a3aa_insta_zeus_fnc_createUnitCurator";
@@ -14297,7 +16618,166 @@ class items
 							};
 						};
 					};
-					nAttributes=6;
+					class Attribute1
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=3;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="0";
+										};
+									};
+									class Item1
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+									class Item2
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="3";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute2
+					{
+						property="lambs_danger_dangerRadio";
+						expression="if (_value) then { _this setVariable ['lambs_danger_dangerRadio', _value, true]; }";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"BOOL"
+									};
+								};
+								value=0;
+							};
+						};
+					};
+					class Attribute3
+					{
+						property="lambs_danger_disableAI";
+						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"BOOL"
+									};
+								};
+								value=1;
+							};
+						};
+					};
+					class Attribute4
+					{
+						property="pitch";
+						expression="_this setpitch _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"SCALAR"
+									};
+								};
+								value=0.95999998;
+							};
+						};
+					};
+					class Attribute5
+					{
+						property="speaker";
+						expression="_this setspeaker _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="Male12ENG";
+							};
+						};
+					};
+					class Attribute6
+					{
+						property="a3aa_ee_extended_gear_insignia";
+						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="Curator";
+							};
+						};
+					};
+					nAttributes=7;
 				};
 			};
 			class Item1
@@ -14305,7 +16785,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={5.0336914,0.0014390945,-4.8486328};
+					position[]={4.9943848,0.0014390945,-4.8896484};
 				};
 				side="West";
 				flags=5;
@@ -14378,106 +16858,11 @@ class items
 						headgear="rhsusf_patrolcap_ocp";
 					};
 				};
-				id=309;
+				id=75;
 				type="B_Protagonist_VR_F";
 				class CustomAttributes
 				{
 					class Attribute0
-					{
-						property="lambs_danger_disableAI";
-						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
-						class Value
-						{
-							class data
-							{
-								class type
-								{
-									type[]=
-									{
-										"BOOL"
-									};
-								};
-								value=1;
-							};
-						};
-					};
-					class Attribute1
-					{
-						property="speaker";
-						expression="_this setspeaker _value;";
-						class Value
-						{
-							class data
-							{
-								class type
-								{
-									type[]=
-									{
-										"STRING"
-									};
-								};
-								value="Male03ENG";
-							};
-						};
-					};
-					class Attribute2
-					{
-						property="pitch";
-						expression="_this setpitch _value;";
-						class Value
-						{
-							class data
-							{
-								class type
-								{
-									type[]=
-									{
-										"SCALAR"
-									};
-								};
-								value=0.95999998;
-							};
-						};
-					};
-					class Attribute3
-					{
-						property="lambs_danger_dangerRadio";
-						expression="if (_value) then { _this setVariable ['lambs_danger_dangerRadio', _value, true]; }";
-						class Value
-						{
-							class data
-							{
-								class type
-								{
-									type[]=
-									{
-										"BOOL"
-									};
-								};
-								value=0;
-							};
-						};
-					};
-					class Attribute4
-					{
-						property="a3aa_ee_extended_gear_insignia";
-						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
-						class Value
-						{
-							class data
-							{
-								class type
-								{
-									type[]=
-									{
-										"STRING"
-									};
-								};
-								value="Curator";
-							};
-						};
-					};
-					class Attribute5
 					{
 						property="a3aa_insta_zeus_unit_curator";
 						expression="[_this, _value] call a3aa_insta_zeus_fnc_createUnitCurator";
@@ -14496,14 +16881,173 @@ class items
 							};
 						};
 					};
-					nAttributes=6;
+					class Attribute1
+					{
+						property="a3aa_ee_acre_channels_chlist";
+						expression="_this setVariable [""a3aa_ee_acre_channels_chlist"",_value,true]";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"ARRAY"
+									};
+								};
+								class value
+								{
+									items=3;
+									class Item0
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="0";
+										};
+									};
+									class Item1
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="1";
+										};
+									};
+									class Item2
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="3";
+										};
+									};
+								};
+							};
+						};
+					};
+					class Attribute2
+					{
+						property="lambs_danger_dangerRadio";
+						expression="if (_value) then { _this setVariable ['lambs_danger_dangerRadio', _value, true]; }";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"BOOL"
+									};
+								};
+								value=0;
+							};
+						};
+					};
+					class Attribute3
+					{
+						property="lambs_danger_disableAI";
+						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"BOOL"
+									};
+								};
+								value=1;
+							};
+						};
+					};
+					class Attribute4
+					{
+						property="pitch";
+						expression="_this setpitch _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"SCALAR"
+									};
+								};
+								value=0.95999998;
+							};
+						};
+					};
+					class Attribute5
+					{
+						property="speaker";
+						expression="_this setspeaker _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="Male03ENG";
+							};
+						};
+					};
+					class Attribute6
+					{
+						property="a3aa_ee_extended_gear_insignia";
+						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="Curator";
+							};
+						};
+					};
+					nAttributes=7;
 				};
 			};
 		};
 		class Attributes
 		{
 		};
-		id=307;
+		id=73;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -14533,12 +17077,12 @@ class items
 		dataType="Logic";
 		class PositionInfo
 		{
-			position[]={0.42431641,0,-0.28466797};
+			position[]={0.38500977,0,-0.32568359};
 		};
 		areaSize[]={200,-1,200};
 		areaIsRectangle=1;
 		flags=1;
-		id=310;
+		id=76;
 		type="a3aa_ee_custom_location";
 		class CustomAttributes
 		{
@@ -14600,6 +17144,47 @@ class items
 				};
 			};
 			nAttributes=3;
+		};
+	};
+	class Item21
+	{
+		dataType="Object";
+		class PositionInfo
+		{
+			position[]={4.973877,0.18872452,-9.784668};
+		};
+		side="Empty";
+		flags=4;
+		class Attributes
+		{
+			init="call{[this, 200] call a3aa_fnc_boxGuard}";
+			name="Mortar_Supply_Box";
+			description="Mortar Supply Box";
+		};
+		id=77;
+		type="Box_NATO_Wps_F";
+		class CustomAttributes
+		{
+			class Attribute0
+			{
+				property="ammoBox";
+				expression="[_this,_value] call bis_fnc_initAmmoBox;";
+				class Value
+				{
+					class data
+					{
+						class type
+						{
+							type[]=
+							{
+								"STRING"
+							};
+						};
+						value="[[[[],[]],[[],[]],[[""ACE_MapTools"",""ACE_RangeTable_82mm""],[2,2]],[[""RHS_Podnos_Gun_Bag"",""RHS_Podnos_Bipod_Bag""],[2,2]]],false]";
+					};
+				};
+			};
+			nAttributes=1;
 		};
 	};
 };

--- a/reference/US%20Army/composition.sqe
+++ b/reference/US%20Army/composition.sqe
@@ -1,5 +1,5 @@
 version=53;
-center[]={5962.061,5,5263.5747};
+center[]={3165.5469,5,6656.4858};
 class items
 {
 	items=21;
@@ -8,7 +8,7 @@ class items
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={7.7353516,0.28405476,-6.8037109};
+			position[]={7.7348633,0.28405476,-6.8066406};
 		};
 		side="Empty";
 		flags=4;
@@ -16,7 +16,7 @@ class items
 		{
 			init="call{[this, 200] call a3aa_fnc_boxGuard}";
 		};
-		id=0;
+		id=234;
 		type="Box_NATO_Ammo_F";
 		class CustomAttributes
 		{
@@ -47,7 +47,7 @@ class items
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={5.8149414,0.14963102,-7.8276367};
+			position[]={5.8144531,0.14963102,-7.8305664};
 			angles[]={-0,1.5258367,0};
 		};
 		side="Empty";
@@ -55,7 +55,7 @@ class items
 		class Attributes
 		{
 		};
-		id=1;
+		id=235;
 		type="Box_NATO_WpsLaunch_F";
 		class CustomAttributes
 		{
@@ -86,7 +86,7 @@ class items
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={7.9189453,0.89242268,-9.277832};
+			position[]={7.918457,0.89242268,-9.2807617};
 		};
 		side="Empty";
 		flags=4;
@@ -94,7 +94,7 @@ class items
 		{
 			init="call{[this, 200] call a3aa_fnc_boxGuard}";
 		};
-		id=2;
+		id=236;
 		type="B_supplyCrate_F";
 		class CustomAttributes
 		{
@@ -123,33 +123,33 @@ class items
 	class Item3
 	{
 		dataType="Marker";
-		position[]={2.1181641,2.4371225e+032,-4.7524414};
+		position[]={2.1176758,2.4371225e+032,-4.7553711};
 		name="respawn_west";
 		type="respawn_unknown";
 		angle=359.38086;
-		id=3;
+		id=237;
 		atlOffset=2.4371225e+032;
 	};
 	class Item4
 	{
 		dataType="Marker";
-		position[]={6.9765625,0,-7.9223633};
+		position[]={6.9760742,0,-7.925293};
 		name="resupply_marker_4";
 		text="Resupply";
 		type="mil_triangle";
 		colorName="ColorGreen";
-		id=4;
+		id=238;
 	};
 	class Item5
 	{
 		dataType="Comment";
 		class PositionInfo
 		{
-			position[]={4.1972656,0.001999855,-6.0078125};
+			position[]={4.1967773,0.001999855,-6.0107422};
 		};
 		title="v1.14.1";
 		description="-v1.14.1" \n " - A3EE box guard updated to A3AA." \n " - Custom location re-added." \n "" \n "- v1.14.0" \n "PL: " \n "- Backpack changed from vanilla ""Assault Pack MTP"" to vanilla ""Assault Pack Coyote"" for more visual contrast. Carry capacity remains the same. " \n "- Rifle changed from RHS ""M4A1 (M203s)"" to RHS ""M16A4 (Carryhandle/M203)"" for increased for increased weapon diversity in the platoon. PL has now a more accurate long-range shooting platform. " \n "- Mags changed from RHS ""30Rnd STANAG M855A1"" to RHS ""30Rnd PMAG M855A1"" and from RHS ""30Rnd STANAG M856A1 (tracer)"" to RHS ""30Rnd PMAG M856A1 (tracer)"" for increased visual fidelity. " \n " " \n "Platoon Sergeant: " \n "- Helmet changed from vanilla ""Enhanced Combat Helmet (desert)"" to RHS ""ACH (tan/headset/ESS)"" to indicate association with platoon lead element and for more visual diversity in the platoon. " \n "- Backpack added 3CB ""Radio Backpack MR3000"" and filled it with the ACRE2 ""AN/PRC-117F"" backpack radio. This gives more incentive to bring the PLT Sgt along since he is the only one who can act as a max range radio man for the platoon. " \n "- Mags changed from RHS ""30Rnd STANAG M855A1"" to RHS ""30Rnd PMAG M855A1"" and from RHS ""30Rnd STANAG M856A1 (tracer)"" to RHS ""30Rnd PMAG M856A1 (tracer)"" for increased visual fidelity. " \n " " \n "Platoon Medic: " \n "- Helmet changed from vanilla ""Enhanced Combat Helmet (desert)"" to RHS ""ACH (tan)"" to indicate association with platoon lead element and for more visual diversity in the platoon. " \n "- Backpack changed from vanilla ""Kitbag MTP"" to vanilla ""Kitbag Coyote"" for more visual contrast. Carry capacity remains the same. " \n "- Mags changed from RHS ""30Rnd STANAG M855A1"" to RHS ""30Rnd PMAG M855A1"" and from RHS ""30Rnd STANAG M856A1 (tracer)"" to RHS ""30Rnd PMAG M856A1 (tracer)"" for increased visual fidelity. " \n " " \n "Platoon Rifleman: " \n "- Helmet changed from vanilla ""Enhanced Combat Helmet (desert)"" to RHS ""ACH (tan/ESS)"" to indicate association with platoon lead element and for more visual diversity in the platoon. " \n "- Rifle changed from RHS ""M4A1 PIP"" to RHS ""M16A4 (Carryhandle)"" for increased weapon diversity in the platoon. More accurate shooting platform to compensate the lack of interesting weaponry such as a LAT, an AR or a grenade launcher. " \n "- Mags changed from RHS ""30Rnd STANAG M855A1"" to RHS ""30Rnd PMAG M855A1"" and from RHS ""30Rnd STANAG M856A1 (tracer)"" to RHS ""30Rnd PMAG M856A1 (tracer)"" for increased visual fidelity. " \n " " \n "SL: " \n "- Helmet changed from vanilla ""Enhanced Combat Helmet (desert)"" to RHS ""ACH OEF-CP (Headset/ESS/Alt)"". " \n "- Backpack changed from vanilla ""Assault Pack MTP"" to vanilla ""Assault Pack Coyote"" for more visual contrast. Carry capacity remains the same. " \n "- Rifle changed from RHS ""M4A1 (M203s)"" to RHS ""M16A4 (Carryhandle/M203)"" for increased for increased weapon diversity in the platoon. SL has now a more accurate long-range shooting platform. " \n "- Mags changed from RHS ""30Rnd STANAG M855A1"" to RHS ""30Rnd PMAG M855A1"" and from RHS ""30Rnd STANAG M856A1 (tracer)"" to RHS ""30Rnd PMAG M856A1 (tracer)"" for increased visual fidelity. " \n " " \n "Medic: " \n "- Helmet changed from vanilla ""Enhanced Combat Helmet (desert)"" to RHS ""ACH OEF-CP (Alt)"". " \n "- Backpack changed from vanilla ""Kitbag MTP"" to vanilla ""Kitbag Coyote"" for more visual contrast. Carry capacity remains the same. " \n "- Mags changed from RHS ""30Rnd STANAG M855A1"" to RHS ""30Rnd PMAG M855A1"" and from RHS ""30Rnd STANAG M856A1 (tracer)"" to RHS ""30Rnd PMAG M856A1 (tracer)"" for increased visual fidelity. " \n " " \n "FTL: " \n "- Helmet changed from vanilla ""Enhanced Combat Helmet (desert)"" to RHS ""ACH OEF-CP (Headset/ESS/Alt)"". " \n "- Vest changed from RHS ""SPCS (Team Leader Alt/OEF-CP)"" to RHS ""SPCS (Grenadier/OEF-CP)"" for more visual diversity in the platoon. Carry capacity remains the same. " \n "- Backpack changed from vanilla ""Assault Pack MTP"" to vanilla ""Assault Pack Coyote"" for more visual contrast. Carry capacity remains the same. " \n "- Mags changed from RHS ""30Rnd STANAG M855A1"" to RHS ""30Rnd PMAG M855A1"" and from RHS ""30Rnd STANAG M856A1 (tracer)"" to RHS ""30Rnd PMAG M856A1 (tracer)"" for increased visual fidelity. " \n " " \n "AR: " \n "- Helmet changed from vanilla ""Enhanced Combat Helmet (desert)"" to RHS ""ACH OEF-CP (ESS/Alt)"" or RHS ""ACH OEF-CP (Alt)"". Both helmets are given out semi-randomly to increase visual variety in the platoon. " \n "- Backpack changed from vanilla ""Assault Pack MTP"" to vanilla ""Assault Pack Coyote"" for more visual contrast. Carry capacity remains the same. " \n "- Added muzzle attachment RHS ""SFMB-556 1/2-28"". " \n " " \n "AAR: " \n "- Helmet changed from vanilla ""Enhanced Combat Helmet (desert)"" to RHS ""ACH OEF-CP (Headset/Alt)"". " \n "- Vest changed from RHS ""SPCS (Rifleman Alt/OEF-CP)"" to RHS ""SPCS (Team Leader/OEF-CP)"" for more visual diversity in the platoon. Carry capacity remains the same. " \n "- Backpack changed from vanilla ""Kitbag MTP"" to vanilla ""Kitbag Coyote"" for more visual contrast. Carry capacity remains the same. " \n "- Rifle changed from RHS ""M4A1 PIP"" to RHS ""M16A4 (Carryhandle)"" for increased weapon diversity in the platoon. More accurate shooting platform to compensate the lack of interesting weaponry such as a LAT, an AR or a grenade launcher. " \n "- Mags changed from RHS ""30Rnd STANAG M855A1"" to RHS ""30Rnd PMAG M855A1"" and from RHS ""30Rnd STANAG M856A1 (tracer)"" to RHS ""30Rnd PMAG M856A1 (tracer)"" for increased visual fidelity. " \n " " \n "LAT: " \n "- Helmet changed from vanilla ""Enhanced Combat Helmet (desert)"" to RHS ""ACH OEF-CP (ESS/Alt)"" or RHS ""ACH OEF-CP (Alt)"". Both helmets are given out semi-randomly to increase visual variety in the platoon. " \n "- Mags changed from RHS ""30Rnd STANAG M855A1"" to RHS ""30Rnd PMAG M855A1"" and from RHS ""30Rnd STANAG M856A1 (tracer)"" to RHS ""30Rnd PMAG M856A1 (tracer)"" for increased visual fidelity. " \n " " \n "MMG Teamleader: " \n "- Helmet changed from vanilla ""Enhanced Combat Helmet (desert)"" to RHS ""ACH OEF-CP (Headset/Alt)"". " \n "- Backpack changed from vanilla ""Assault Pack MTP"" to vanilla ""Assault Pack Coyote"" for more visual contrast. Carry capacity remains the same. " \n "- Mags changed from RHS ""30Rnd STANAG M855A1"" to RHS ""30Rnd PMAG M855A1"" and from RHS ""30Rnd STANAG M856A1 (tracer)"" to RHS ""30Rnd PMAG M856A1 (tracer)"" for increased visual fidelity. " \n " " \n "MMG Gunner: " \n "- Helmet changed from vanilla ""Enhanced Combat Helmet (desert)"" to RHS ""ACH OEF-CP (ESS/Alt)""." \n "- Backpack changed from vanilla ""Kitbag MTP"" to vanilla ""Kitbag Coyote"" for more visual contrast. Carry capacity remains the same. " \n "- Added muzzle attachment RHS ""ARDEC 4-Prong"". " \n " " \n "MMG Asst. Gunner: " \n "- Helmet changed from vanilla ""Enhanced Combat Helmet (desert)"" to RHS ""ACH OEF-CP (Alt)"". " \n "- Backpack changed from vanilla ""Kitbag MTP"" to vanilla ""Kitbag Coyote"" for more visual contrast. Carry capacity remains the same. " \n "- Mags changed from RHS ""30Rnd STANAG M855A1"" to RHS ""30Rnd PMAG M855A1"" and from RHS ""30Rnd STANAG M856A1 (tracer)"" to RHS ""30Rnd PMAG M856A1 (tracer)"" for increased visual fidelity. " \n " " \n "MAT Teamleader: " \n "- Helmet changed from vanilla ""Enhanced Combat Helmet (desert)"" to RHS ""ACH OEF-CP (Headset/Alt)"". " \n "- Backpack changed from vanilla ""Assault Pack MTP"" to vanilla ""Assault Pack Coyote"" for more visual contrast. Carry capacity remains the same. " \n "- Mags changed from RHS ""30Rnd STANAG M855A1"" to RHS ""30Rnd PMAG M855A1"" and from RHS ""30Rnd STANAG M856A1 (tracer)"" to RHS ""30Rnd PMAG M856A1 (tracer)"" for increased visual fidelity. " \n " " \n "MAT Gunner: " \n "- Helmet changed from vanilla ""Enhanced Combat Helmet (desert)"" to RHS ""ACH OEF-CP (ESS/Alt)""." \n "- Vest changed from RHS ""SPCS (Rifleman Alt/OEF-CP)"" to RHS ""SPCS (OEF-CP)"" for more visual diversity in the platoon. Carry capacity remains the same. " \n "- Backpack changed from vanilla ""Kitbag MTP"" to vanilla ""Kitbag Coyote"" for more visual contrast. Carry capacity remains the same. " \n "- Mags changed from RHS ""30Rnd STANAG M855A1"" to RHS ""30Rnd PMAG M855A1"" and from RHS ""30Rnd STANAG M856A1 (tracer)"" to RHS ""30Rnd PMAG M856A1 (tracer)"" for increased visual fidelity. " \n " " \n "MAT Asst. Gunner: " \n "- Helmet changed from vanilla ""Enhanced Combat Helmet (desert)"" to RHS ""ACH OEF-CP (Alt)"". " \n "- Backpack changed from vanilla ""Kitbag MTP"" to vanilla ""Kitbag Coyote"" for more visual contrast. Carry capacity remains the same. " \n "- Mags changed from RHS ""30Rnd STANAG M855A1"" to RHS ""30Rnd PMAG M855A1"" and from RHS ""30Rnd STANAG M856A1 (tracer)"" to RHS ""30Rnd PMAG M856A1 (tracer)"" for increased visual fidelity. " \n " " \n "ENG Leader: " \n "- Helmet changed from vanilla ""Enhanced Combat Helmet (desert)"" to RHS ""ACH OEF-CP (Headset/ESS/Alt)"". " \n "- Vest changed from RHS ""SPCS (Team Leader Alt/OEF-CP)"" to vanilla ""Carrier GL Rig (green)"" for a bulkier look to visually distinguish EOD/ENG from the rest of the platoon. " \n "- Backpack changed from vanilla ""Carryall MTP"" to vanilla ""Carryall Coyote"" for more visual contrast. Carry capacity remains the same. " \n "- Mags changed from RHS ""30Rnd STANAG M855A1"" to RHS ""30Rnd PMAG M855A1"" and from RHS ""30Rnd STANAG M856A1 (tracer)"" to RHS ""30Rnd PMAG M856A1 (tracer)"" for increased visual fidelity. " \n " " \n "ENG Rifleman: " \n "- Helmet changed from vanilla ""Enhanced Combat Helmet (desert)"" to RHS ""ACH OEF-CP (Headset/Alt)"". " \n "- Vest changed from RHS ""SPCS (Team Leader Alt/OEF-CP)"" to vanilla ""Carrier GL Rig (green)"" for a bulkier look to visually distinguish EOD/ENG from the rest of the platoon. " \n "- Backpack changed from vanilla ""Carryall MTP"" to vanilla ""Carryall Coyote"" for more visual contrast. Carry capacity remains the same. " \n "- Mags changed from RHS ""30Rnd STANAG M855A1"" to RHS ""30Rnd PMAG M855A1"" and from RHS ""30Rnd STANAG M856A1 (tracer)"" to RHS ""30Rnd PMAG M856A1 (tracer)"" for increased visual fidelity. " \n " " \n "Mortar Leader: " \n "- Helmet changed from vanilla ""Enhanced Combat Helmet (desert)"" to RHS ""ACH OEF-CP (Headset/Alt)"". " \n "- Mags changed from RHS ""30Rnd STANAG M855A1"" to RHS ""30Rnd PMAG M855A1"" and from RHS ""30Rnd STANAG M856A1 (tracer)"" to RHS ""30Rnd PMAG M856A1 (tracer)"" for increased visual fidelity. " \n " " \n "Mortar Gunner: " \n "- Helmet changed from vanilla ""Enhanced Combat Helmet (desert)"" to RHS ""ACH OEF-CP (Alt)"". " \n "- Vest changed from RHS ""SPCS (Rifleman Alt/OEF-CP)"" to RHS ""SPCS (SAW/OEF-CP)"" for more visual diversity in the platoon. Carry capacity remains the same. " \n "- Mags changed from RHS ""30Rnd STANAG M855A1"" to RHS ""30Rnd PMAG M855A1"" and from RHS ""30Rnd STANAG M856A1 (tracer)"" to RHS ""30Rnd PMAG M856A1 (tracer)"" for increased visual fidelity. " \n " " \n "DGR Commander: " \n "- Helmet changed from RHS ""ACVC-H MK-1697"" to RHS ""ACVC-H MK-1697 (ESS)"" to better visually indicate the element leader. " \n "- Rifle changed from vanilla ""Scorpion Evo 3 A1"" to NiArms ""H&K MP5A3"" to bring weaponry visually more in line with the rest of the platoon.  " \n " " \n "DGR Gunner & Driver: " \n "- Rifle changed from vanilla ""Scorpion Evo 3 A1"" to NiArms ""H&K MP5A3"" to bring weaponry visually more in line with the rest of the platoon.  " \n " " \n "DMT Marksman " \n "- Rifle scope changed from RH ""Leopold Mark 4 LR/T"" to RHS ""M8541A SSDS"" for more visual conformity with NVG variant of the same scope. Note: max. zoom is reduced from x20 to x15 however the Marksman gains a MRDS sight for CQB. " \n "- Added scope RHS ""M8541A + AN/PVS-27"" to the vest gear. This is the NVG version of the regular scope. " \n " " \n "Nightbird Pilot & Co-Pilot: " \n "- Rifle changed from vanilla ""Scorpion Evo 3 A1"" to NiArms ""H&K MP5A3"" to bring weaponry visually more in line with the rest of the platoon.  " \n " " \n "Falcon Pilot: " \n "- Rifle changed from vanilla ""Scorpion Evo 3 A1"" to NiArms ""H&K MP5A3"" to bring weaponry visually more in line with the rest of the platoon.  " \n " " \n "Zeus & Co-Zeus " \n "- Uniform changed from vanilla ""VR Suit NATO"" to RHS ""Combat Uniform OCP"" to make Zeus look a bit more like an HQ commander than a Tron character. " \n "- Headgear added RHS ""Patrol Cap OEF-CP"". " \n "- Facewear changed from vanilla ""VR Goggles"" to vanilla ""Aviator Glasses"". " \n "- Insignia added ""Zeus"". " \n " " \n "All Units: " \n "- Disabled LAMBS AI " \n " " \n "Alpha SL: " \n "- Enabled ""is Player"". This makes it easier for Mission Makers to quickly test a mission in the editor by just hitting ""play"" instead of having to select a specific unit every time beforehand to avoid ending up in spectator mode by default.  " \n " " \n "Crates: " \n "- Added an ACE3 medical crate with our usual base script." \n "" \n "" \n "-v1.13.6" \n "  - ALL Added persistent Call-Signs for all GM's (where not included in v1.13.4)" \n "  - ALL Added the code`this disableAI ""MOVE""; this setSpeaker ""NoVoice""; enableRadio false;` to all playable units to prevent them from running off and spamming the vanilla-radio during local testing." \n "  - ALL Changed persistent call-signs (map markers) to a consistent formula: ≤ 2 syllables = written out call-sing. ≥ 3 syllables = abbreviated call-sign." \n "  - ALL Added full changelog to all factions for quick in-game reference" \n "  - TFN Added new yellow owl insignia patches to all uniforms" \n "" \n "- v1.13.5" \n "  - ALL Added respective GM's to Standard Faction Compositions for convenience / time saving " \n "  - ALL Added base clean-up module to Standard Faction Compositions to ensure Mission Makers don't forget it in the future - radius set to 200x200 meters" \n "" \n "- v1.13.4 " \n "  - ALL Added @ Squad/Team names to leaders so that Team name appears in role select" \n "  - TFN Changed M249 to the FN MINIMI" \n "" \n "- v1.13.3" \n "  - US Added Improved Bipod/SAW Grip to AR M249" \n "  - US Removed M14 Mags" \n "  - TFN Added Bipod to M249" \n "" \n "- v1.13.2" \n "  - ALL Added 1 Extra Tourniquet to every Unit" \n "  - TFN DMT Lead Rifle Changed to D10 Version" \n "  - TFN DMT given extra pistol mag to bring in line with other units" \n "  - TFN AAR Weapon changed to HK416 D14.5" \n "  - TFN Lead Elements Given AN/PEQ-16A's" \n "  - US Alpha Fireteam 2 AAR vest changed to ALT variant to match rest of faction" \n "  - US Lead Elements Given AN/PEQ-16A's" \n "  - US DMT given extra pistol mag to bring in line with other units" \n "  - US DMT Sniper Rifle Given SU-260/P (MDO) to bring zoom level to the same as Russian and TFN factions" \n "  - US DMT Bipod Changed to Harris Bipod" \n "  - US DMT Marksman Rifle changed to black version of same rifle" \n "  - US DMT Marksman Magazines changed to SR-25 version, as RHS hotfix made M14 mags incompatible with MK11" \n "  - RUS DMT given extra pistol mag to bring in line with other units" \n "  - RUS DGR Helmets changed to TSH-4 to make distinct from US Helmets" \n "  - RUS NB Helmets changed to ZSH-7A to make distinct from US and TFN helmets" \n "  - RUS Removed RIS Rail adaptors from AK rifles" \n "  - RUS Added PG-7V rocket to MAT ammo crate. This rocket is lighter and packs less payload than the PG-7VL. This gives it an  increased effective range but is less powerful due to decreased payload" \n "" \n "- v1.12.2" \n "  - Hotfixed US Vests across the Squads to match V.12 changes. Whoops." \n "  - Added Angled Grip to TFN HK416s where possible. " \n "" \n "- v1.12" \n "  - Fixed TFN MMG Ammo preloaded into Rifle to 100RND mag from 50rnd." \n "  - Fixed TFN DMT Marksman Ammo loaded into Rifle to correct SBLR mag." \n "  - Changed TFN DMT Lead Suppressor to QDSS NT4 Black from Rotex-5 Grey" \n "  - Changed TFN Dagger Uniforms from Gorka R Green to FFCP Green Fatigues [RS]" \n "  - Changed US PLT Commander + Squad Leader Vest from SPCS Rifleman/OEF- CP to SPCS Squad Lead/OEF-CP" \n "  - Changed US Medic Vest from SPCS Rifleman/OEF-CP to SPCS Medic/OEF-CP" \n "  - Changed US PLT Rifleman Vest from SPCS OEF-CP to SPCS Rifleman Alt/OEF-CP" \n "  - Changed US FTL Vest from SPCS Rifleman/OEF-CP to SPCS Team Leader Alt/OEF-CP" \n "  - Changed US AR Vest from SPCS Rifleman/OEF-CP to SPCS SAW/OEF-CP" \n "  - Changed US AAR Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP" \n "  - Changed US Rifleman AT Vest from SPCS OEF-CP to SPCS Rifleman Alt/OEF-CP" \n "  - Changed US MAT/MMG/DMT/ENG/MTR Lead Vest from SPCS Rifleman/OEF-CP to SPCS Team Leader Alt/OEF-CP" \n "  - Changed US MMG Gunner Vest from SPCS Rifleman/OEF-CP to SPCS Machinegunner/OEF-CP" \n "  - Changed US MMG/MAT Ammo Bearer Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP" \n "  - Changed US MAT Gunner Vest from SPCS OEF-CP to SPCS Rifleman Alt/OEF-CP" \n "  - Changed US DMT Marksman vest from SPCS OEF-CP to SPCS Sniper/OEF-CP" \n "  - Fixed US DMT Marksman Rifle Loaded Mag to correct varient." \n "  - Changed US Engineer Rifleman Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP." \n "  - Changed US MTR Gunner Vest from SPCS Rifleman/OEF-CP to SPCS Rifleman Alt/OEF-CP." \n "  - Changed US DGR Uniforms from FFCP ACU Fatigues to FFCP ACU Fatigues [RS]" \n "  - Changed US DGR Driver Backpack from Assault Pack Green to Assault Pack Black" \n "  - Changed US Heli Pilot/Copilot Uniforms from Heli pilot Coveralls to FFCP Nomad Fatigues [RS]" \n "  - Fixed US Heli/Jet Pilot Vest White Smoke grenade count to 2." \n "  - Changed US Heli Pilot/Copilot Helmet from Heli Pilot NATO to HGU-56/P (Black/Visor)" \n "  - Changed US Jet Pilot Uniform from Pilot Coveralls NATO to  FFCP Nomad Fatigues" \n "  - Changed RUS Vic/Heli/Jet Crew Weapons to PP-2000" \n "  - Upped RUS PP-2000 Ammo counts to 6x Mag to bring in line with ammo counts for TFN and US." \n "  - Changed RUS Heli Pilot Uniforms from Pilot Coveralls CSAT to FFCP-Fatigues EMR [RS]" \n "  - Changed RUS Heli Pilot Vest from 6B23 (6Sh116) to FFCP Tactical Vest TigerVRS" \n "  - Changed RUS Jet Pilot Uniforms from Pilot Coveralls CSAT to FFCP-Fatigues EMR [RS]" \n "  - Changed RUS Jet Pilot Vest from 6B23 (6Sh116) to FFCP Tactical Vest TigerVRS" \n "" \n "- v1.11" \n "  - changed m40 mini grenades to m67 fragmentation" \n "  - replaced mp7 weapons with mp5k-pdw" \n "  - changed ak105 to ak74m (plum) " \n "  - changed PKM to PKP" \n "  - changed RUS PKM ammo boxes. MMG now loads with 7TZ (AP rounds)" \n "  - added vert grip to us weapons" \n "  - replaced m14 with HK PSG1A1" \n "  - replaced m260e4 with mg3" \n "  - updated all ammo boxes respectively. " \n "" \n "- v1.10" \n "  - changed Medic loadouts from 6 x 1000ml blood bags to 2 x 1000ml and 8 x 500ml." \n "" \n "- v1.09" \n "  - updated Fireteam colours A1 Red A2 Yellow, B1 Green B2 Blue, C1 Red C2 Yellow." \n "" \n "- v1.08" \n "  - changed ""Reaper"" to ""Nightbird"", ""RPR"" to ""NB""" \n "  - changed ""Paladin"" to ""Falcon"", ""PAL"" to ""FC""" \n "  - changed ""DAGGER"" to ""DGR""" \n "" \n "- v1.07" \n "  - US and RU faction bumped to v1.07 to avoid confusion regarding version numbers (US and RU was 1.05, TFN was 1.06)" \n "  - overhauled the RU faction: updated helmets, uniforms, weapons to a more modern look" \n "  - overhauled the US faction: updated helmets and vests to armour rating of IV" \n "  - corrected some mistakes in all factions (grenade ammount of MMG gunner, ENG not having tourniquetes, DGR not having GPS-s)" \n "  - overhauled the medics of all factions to reflect recent cahnges to ACE medical (less QuikClots, more Elastic Bandages, etc.)" \n "" \n "- v1.05" \n "  - Added a MAT ammo box on spawn." \n "" \n "- v1.04" \n "  - All MAT Teams carrying RPG's got the ver3 scopes with ranges for all types" \n "    of ammo." \n "  - All Callsigns were changed to be uniformed throught no matter the faction." \n "" \n "- v1.03" \n "  - set crew driver/gunner and pilot/copilot/jetpilot as Engineers through the" \n "    Object: ACE Options menu in unit attributes" \n "  - overhauled the TFN faction (weapons, helmets, etc.), changes not applicable" \n "    to derived factions" \n "" \n "- v1.02" \n "  - loadout overhaul for DMT, made them lighter + gave them tools for recon" \n "  - specified preset ACRE2 radio channels for most units" \n "" \n "- v1.01" \n "  - updated team colors func to `a3ee_team_colors_fnc_setColor`, just load+save" \n "    the composition in editor, this fixes it" \n "  - changed RPG-7 using MAT teams to carry Kitbags" \n "  - removed one PKM ammo box from AAR, MMG gunner, MMG bearer (fixes overload)" \n "  - moved 1-2 AR boxes from AAR to AR, gave AR an Assaultpack" \n "  - added 1-2 more AR boxes to AR's Assaultpack (if enough space)" \n "  - changed HEDP to HE rockets for Carl Gustav (M3MAAWS)" \n "  - changed US crew uniform and helmet to match grey color scheme of US pilots" \n "  - changed backpacks of driver/copilot to use less contrasting colors compared" \n "    to their respective uniform/vest colors" \n "  - changed Carryall backpacks of TFN Engineers to use custom Flecktarn Carryall" \n "  - changed all (GP-25 and normal) AK74m rifles to be the non-NPZ variants" \n "  - removed secondary long-range (PRC148) from Engineers" \n "" \n "- v1.00 (and before)" \n "  - added a Comment object with version number (`v1.00`)" \n "  - added `respawn_west`, `respawn_east`, `respawn_guerrila` markers" \n "  - added `[this, 200] call a3ee_fnc_boxGuard` to init lines of resupply boxes" \n "  - added `Resupply` green triangle markers on the position of resupply boxes";
-		id=5;
+		id=239;
 		atlOffset=0.001999855;
 	};
 	class Item6
@@ -157,7 +157,7 @@ class items
 		dataType="Object";
 		class PositionInfo
 		{
-			position[]={7.6923828,0,-4.7094727};
+			position[]={7.6918945,0,-4.7124023};
 		};
 		side="Empty";
 		flags=4;
@@ -165,7 +165,7 @@ class items
 		{
 			init="call{[this, 200] call a3aa_fnc_boxGuard}";
 		};
-		id=6;
+		id=240;
 		type="ACE_medicalSupplyCrate";
 		class CustomAttributes
 		{
@@ -203,7 +203,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-5.8330078,0.0014390945,8.9799805};
+					position[]={-5.8334961,0.0014390945,8.9770508};
 				};
 				side="West";
 				flags=7;
@@ -247,9 +247,19 @@ class items
 						{
 							typeName="rhs_uniform_cu_ocp";
 							isBackpack=0;
+							class MagazineCargo
+							{
+								items=1;
+								class Item0
+								{
+									name="rhsusf_mag_15Rnd_9x19_JHP";
+									count=1;
+									ammoLeft=15;
+								};
+							};
 							class ItemCargo
 							{
-								items=10;
+								items=9;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -262,42 +272,37 @@ class items
 								};
 								class Item2
 								{
-									name="ACE_morphine";
-									count=1;
+									name="ACE_tourniquet";
+									count=2;
 								};
 								class Item3
 								{
-									name="ACE_tourniquet";
+									name="ACE_morphine";
 									count=1;
 								};
 								class Item4
 								{
-									name="rhsusf_acc_M952V";
+									name="ACE_epinephrine";
 									count=1;
 								};
 								class Item5
 								{
-									name="ACRE_PRC343";
-									count=1;
-								};
-								class Item6
-								{
 									name="ACE_CableTie";
 									count=2;
 								};
-								class Item7
+								class Item6
 								{
 									name="ACE_MapTools";
 									count=1;
 								};
-								class Item8
+								class Item7
 								{
-									name="ACRE_PRC152";
+									name="rhs_acc_2dpZenit";
 									count=1;
 								};
-								class Item9
+								class Item8
 								{
-									name="ACRE_PRC148";
+									name="ACRE_PRC343";
 									count=1;
 								};
 							};
@@ -308,45 +313,24 @@ class items
 							isBackpack=0;
 							class MagazineCargo
 							{
-								items=5;
+								items=3;
 								class Item0
 								{
-									name="SmokeShell";
-									count=4;
-									ammoLeft=1;
+									name="rhs_mag_30Rnd_556x45_M855A1_PMAG";
+									count=6;
+									ammoLeft=30;
 								};
 								class Item1
 								{
-									name="rhsusf_mag_15Rnd_9x19_JHP";
-									count=1;
-									ammoLeft=15;
+									name="rhs_mag_30Rnd_556x45_M855A1_PMAG_Tracer_Red";
+									count=4;
+									ammoLeft=30;
 								};
 								class Item2
 								{
 									name="HandGrenade";
 									count=2;
 									ammoLeft=1;
-								};
-								class Item3
-								{
-									name="rhs_mag_30Rnd_556x45_M855A1_PMAG";
-									count=6;
-									ammoLeft=30;
-								};
-								class Item4
-								{
-									name="rhs_mag_30Rnd_556x45_M855A1_PMAG_Tracer_Red";
-									count=4;
-									ammoLeft=30;
-								};
-							};
-							class ItemCargo
-							{
-								items=1;
-								class Item0
-								{
-									name="ACE_tourniquet";
-									count=1;
 								};
 							};
 						};
@@ -378,7 +362,7 @@ class items
 								class Item3
 								{
 									name="SmokeShell";
-									count=3;
+									count=7;
 									ammoLeft=1;
 								};
 								class Item4
@@ -396,10 +380,20 @@ class items
 							};
 							class ItemCargo
 							{
-								items=1;
+								items=3;
 								class Item0
 								{
 									name="ACE_IR_Strobe_Item";
+									count=1;
+								};
+								class Item1
+								{
+									name="ACRE_PRC152";
+									count=1;
+								};
+								class Item2
+								{
+									name="ACRE_PRC148";
 									count=1;
 								};
 							};
@@ -408,10 +402,10 @@ class items
 						compass="ItemCompass";
 						watch="ItemWatch";
 						gps="ItemGPS";
-						headgear="rhsusf_patrolcap_ocp";
+						headgear="rhsusf_ach_helmet_headset_ocp_alt";
 					};
 				};
-				id=8;
+				id=242;
 				type="B_officer_F";
 				class CustomAttributes
 				{
@@ -449,7 +443,7 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
@@ -480,7 +474,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-4.8330078,0.0014390945,8.9790039};
+					position[]={-4.8334961,0.0014390945,8.9760742};
 				};
 				side="West";
 				flags=5;
@@ -534,32 +528,32 @@ class items
 								};
 								class Item2
 								{
-									name="ACE_morphine";
-									count=1;
+									name="ACE_tourniquet";
+									count=2;
 								};
 								class Item3
 								{
-									name="ACE_tourniquet";
+									name="ACE_morphine";
 									count=1;
 								};
 								class Item4
 								{
-									name="rhsusf_acc_M952V";
+									name="ACE_epinephrine";
 									count=1;
 								};
 								class Item5
 								{
-									name="ACRE_PRC343";
+									name="ACE_MapTools";
 									count=1;
 								};
 								class Item6
 								{
-									name="ACE_CableTie";
-									count=2;
+									name="rhs_acc_2dpZenit";
+									count=1;
 								};
 								class Item7
 								{
-									name="ACE_MapTools";
+									name="ACRE_PRC343";
 									count=1;
 								};
 								class Item8
@@ -583,33 +577,33 @@ class items
 								items=5;
 								class Item0
 								{
-									name="SmokeShell";
-									count=4;
-									ammoLeft=1;
+									name="rhs_mag_30Rnd_556x45_M855A1_PMAG";
+									count=6;
+									ammoLeft=30;
 								};
 								class Item1
+								{
+									name="rhs_mag_30Rnd_556x45_M855A1_PMAG_Tracer_Red";
+									count=4;
+									ammoLeft=30;
+								};
+								class Item2
 								{
 									name="rhsusf_mag_15Rnd_9x19_JHP";
 									count=1;
 									ammoLeft=15;
 								};
-								class Item2
+								class Item3
 								{
 									name="HandGrenade";
 									count=2;
 									ammoLeft=1;
 								};
-								class Item3
-								{
-									name="rhs_mag_30Rnd_556x45_M855A1_PMAG";
-									count=6;
-									ammoLeft=30;
-								};
 								class Item4
 								{
-									name="rhs_mag_30Rnd_556x45_M855_PMAG_Tracer_Red";
+									name="SmokeShell";
 									count=4;
-									ammoLeft=30;
+									ammoLeft=1;
 								};
 							};
 							class ItemCargo
@@ -617,8 +611,8 @@ class items
 								items=1;
 								class Item0
 								{
-									name="ACE_tourniquet";
-									count=1;
+									name="ACE_CableTie";
+									count=2;
 								};
 							};
 						};
@@ -640,10 +634,10 @@ class items
 						compass="ItemCompass";
 						watch="ItemWatch";
 						gps="ItemGPS";
-						headgear="rhsusf_ach_bare_tan_headset_ess";
+						headgear="rhsusf_ach_helmet_headset_ocp_alt";
 					};
 				};
-				id=9;
+				id=243;
 				type="B_Soldier_TL_F";
 				class CustomAttributes
 				{
@@ -681,7 +675,7 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
@@ -712,7 +706,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-3.8330078,0.0014390945,8.9790039};
+					position[]={-3.8334961,0.0014390945,8.9760742};
 				};
 				side="West";
 				flags=5;
@@ -751,14 +745,14 @@ class items
 								items=1;
 								class Item0
 								{
-									name="SmokeShell";
-									count=4;
-									ammoLeft=1;
+									name="rhsusf_mag_15Rnd_9x19_JHP";
+									count=2;
+									ammoLeft=15;
 								};
 							};
 							class ItemCargo
 							{
-								items=6;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -771,20 +765,25 @@ class items
 								};
 								class Item2
 								{
-									name="ACE_morphine";
-									count=1;
+									name="ACE_tourniquet";
+									count=2;
 								};
 								class Item3
 								{
-									name="ACE_tourniquet";
+									name="ACE_morphine";
 									count=1;
 								};
 								class Item4
 								{
-									name="rhsusf_acc_M952V";
+									name="ACE_epinephrine";
 									count=1;
 								};
 								class Item5
+								{
+									name="rhs_acc_2dpZenit";
+									count=1;
+								};
+								class Item6
 								{
 									name="ACRE_PRC343";
 									count=1;
@@ -797,39 +796,24 @@ class items
 							isBackpack=0;
 							class MagazineCargo
 							{
-								items=4;
+								items=3;
 								class Item0
-								{
-									name="rhsusf_mag_15Rnd_9x19_JHP";
-									count=1;
-									ammoLeft=15;
-								};
-								class Item1
-								{
-									name="HandGrenade";
-									count=2;
-									ammoLeft=1;
-								};
-								class Item2
 								{
 									name="rhs_mag_30Rnd_556x45_M855A1_PMAG";
 									count=8;
 									ammoLeft=30;
 								};
-								class Item3
+								class Item1
 								{
 									name="rhs_mag_30Rnd_556x45_M855A1_PMAG_Tracer_Red";
 									count=2;
 									ammoLeft=30;
 								};
-							};
-							class ItemCargo
-							{
-								items=1;
-								class Item0
+								class Item2
 								{
-									name="ACE_tourniquet";
-									count=1;
+									name="HandGrenade";
+									count=2;
+									ammoLeft=1;
 								};
 							};
 						};
@@ -843,7 +827,7 @@ class items
 								class Item0
 								{
 									name="SmokeShell";
-									count=8;
+									count=10;
 									ammoLeft=1;
 								};
 								class Item1
@@ -917,10 +901,10 @@ class items
 						compass="ItemCompass";
 						watch="ItemWatch";
 						gps="ItemGPS";
-						headgear="rhsusf_ach_bare_tan";
+						headgear="rhsusf_ach_helmet_ocp_alt";
 					};
 				};
-				id=10;
+				id=244;
 				type="B_medic_F";
 				class CustomAttributes
 				{
@@ -958,7 +942,7 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
@@ -989,7 +973,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-2.8330078,0.0014390945,8.9790039};
+					position[]={-2.8334961,0.0014390945,8.9760742};
 				};
 				side="West";
 				flags=5;
@@ -1027,14 +1011,14 @@ class items
 								items=1;
 								class Item0
 								{
-									name="SmokeShell";
-									count=4;
-									ammoLeft=1;
+									name="rhsusf_mag_15Rnd_9x19_JHP";
+									count=2;
+									ammoLeft=15;
 								};
 							};
 							class ItemCargo
 							{
-								items=6;
+								items=7;
 								class Item0
 								{
 									name="ACE_fieldDressing";
@@ -1047,20 +1031,25 @@ class items
 								};
 								class Item2
 								{
-									name="ACE_morphine";
-									count=1;
+									name="ACE_tourniquet";
+									count=2;
 								};
 								class Item3
 								{
-									name="ACE_tourniquet";
+									name="ACE_morphine";
 									count=1;
 								};
 								class Item4
 								{
-									name="rhsusf_acc_M952V";
+									name="ACE_epinephrine";
 									count=1;
 								};
 								class Item5
+								{
+									name="rhs_acc_2dpZenit";
+									count=1;
+								};
+								class Item6
 								{
 									name="ACRE_PRC343";
 									count=1;
@@ -1076,46 +1065,37 @@ class items
 								items=4;
 								class Item0
 								{
-									name="rhsusf_mag_15Rnd_9x19_JHP";
-									count=1;
-									ammoLeft=15;
-								};
-								class Item1
-								{
-									name="HandGrenade";
-									count=2;
-									ammoLeft=1;
-								};
-								class Item2
-								{
 									name="rhs_mag_30Rnd_556x45_M855A1_PMAG";
 									count=8;
 									ammoLeft=30;
 								};
-								class Item3
+								class Item1
 								{
 									name="rhs_mag_30Rnd_556x45_M855A1_PMAG_Tracer_Red";
 									count=2;
 									ammoLeft=30;
 								};
-							};
-							class ItemCargo
-							{
-								items=1;
-								class Item0
+								class Item2
 								{
-									name="ACE_tourniquet";
-									count=1;
+									name="HandGrenade";
+									count=2;
+									ammoLeft=1;
+								};
+								class Item3
+								{
+									name="SmokeShell";
+									count=4;
+									ammoLeft=1;
 								};
 							};
 						};
 						map="ItemMap";
 						compass="ItemCompass";
 						watch="ItemWatch";
-						headgear="rhsusf_ach_bare_tan_ess";
+						headgear="rhsusf_ach_helmet_ESS_ocp_alt";
 					};
 				};
-				id=11;
+				id=245;
 				type="B_Soldier_F";
 				class CustomAttributes
 				{
@@ -1153,7 +1133,7 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
@@ -1183,7 +1163,7 @@ class items
 		class Attributes
 		{
 		};
-		id=7;
+		id=241;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -1220,7 +1200,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-5.7949219,0.0014390945,6.0629883};
+					position[]={-5.7956543,0.0014390945,6.0600586};
 				};
 				side="West";
 				flags=7;
@@ -1229,6 +1209,7 @@ class items
 					rank="LIEUTENANT";
 					init="call{this disableAI ""MOVE"";" \n "this setSpeaker ""NoVoice"";" \n "enableRadio false;}";
 					description="Alpha Squad Leader@ALPHA";
+					isPlayer=1;
 					isPlayable=1;
 					class Inventory
 					{
@@ -1439,7 +1420,7 @@ class items
 						headgear="rhsusf_ach_helmet_headset_ess_ocp_alt";
 					};
 				};
-				id=13;
+				id=247;
 				type="B_Soldier_SL_F";
 				class CustomAttributes
 				{
@@ -1477,11 +1458,30 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
 					class Attribute2
+					{
+						property="speaker";
+						expression="_this setspeaker _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="Male10ENG";
+							};
+						};
+					};
+					class Attribute3
 					{
 						property="lambs_danger_dangerRadio";
 						expression="if (_value) then { _this setVariable ['lambs_danger_dangerRadio', _value, true]; }";
@@ -1500,7 +1500,26 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					class Attribute4
+					{
+						property="pitch";
+						expression="_this setpitch _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"SCALAR"
+									};
+								};
+								value=1.04;
+							};
+						};
+					};
+					nAttributes=5;
 				};
 			};
 			class Item1
@@ -1508,7 +1527,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-4.7939453,0.0014390945,6.0620117};
+					position[]={-4.7944336,0.0014390945,6.059082};
 				};
 				side="West";
 				flags=5;
@@ -1716,7 +1735,7 @@ class items
 						headgear="rhsusf_ach_helmet_ocp_alt";
 					};
 				};
-				id=14;
+				id=248;
 				type="B_medic_F";
 				class CustomAttributes
 				{
@@ -1754,7 +1773,7 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
@@ -1785,7 +1804,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-5.7939453,0.0014390945,4.0620117};
+					position[]={-5.7944336,0.0014390945,4.059082};
 				};
 				side="West";
 				flags=5;
@@ -1987,11 +2006,30 @@ class items
 						headgear="rhsusf_ach_helmet_headset_ess_ocp_alt";
 					};
 				};
-				id=15;
+				id=249;
 				type="B_Soldier_TL_F";
 				class CustomAttributes
 				{
 					class Attribute0
+					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="RED";
+							};
+						};
+					};
+					class Attribute1
 					{
 						property="lambs_danger_disableAI";
 						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
@@ -2010,7 +2048,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
@@ -2025,11 +2063,11 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
-					class Attribute2
+					class Attribute3
 					{
 						property="lambs_danger_dangerRadio";
 						expression="if (_value) then { _this setVariable ['lambs_danger_dangerRadio', _value, true]; }";
@@ -2048,7 +2086,7 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					nAttributes=4;
 				};
 			};
 			class Item3
@@ -2056,7 +2094,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-4.7939453,0.0014390945,4.0620117};
+					position[]={-4.7944336,0.0014390945,4.059082};
 				};
 				side="West";
 				flags=5;
@@ -2193,11 +2231,30 @@ class items
 						headgear="rhsusf_ach_helmet_ESS_ocp_alt";
 					};
 				};
-				id=16;
+				id=250;
 				type="B_soldier_AR_F";
 				class CustomAttributes
 				{
 					class Attribute0
+					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="RED";
+							};
+						};
+					};
+					class Attribute1
 					{
 						property="lambs_danger_disableAI";
 						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
@@ -2216,7 +2273,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
@@ -2231,11 +2288,11 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
-					class Attribute2
+					class Attribute3
 					{
 						property="lambs_danger_dangerRadio";
 						expression="if (_value) then { _this setVariable ['lambs_danger_dangerRadio', _value, true]; }";
@@ -2254,7 +2311,7 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					nAttributes=4;
 				};
 			};
 			class Item4
@@ -2262,7 +2319,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-3.7939453,0.0014390945,4.0620117};
+					position[]={-3.7944336,0.0014390945,4.059082};
 				};
 				side="West";
 				flags=5;
@@ -2458,11 +2515,30 @@ class items
 						headgear="rhsusf_ach_helmet_headset_ocp_alt";
 					};
 				};
-				id=17;
+				id=251;
 				type="B_soldier_AAR_F";
 				class CustomAttributes
 				{
 					class Attribute0
+					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="RED";
+							};
+						};
+					};
+					class Attribute1
 					{
 						property="lambs_danger_disableAI";
 						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
@@ -2481,7 +2557,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
@@ -2496,11 +2572,11 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
-					class Attribute2
+					class Attribute3
 					{
 						property="lambs_danger_dangerRadio";
 						expression="if (_value) then { _this setVariable ['lambs_danger_dangerRadio', _value, true]; }";
@@ -2519,7 +2595,7 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					nAttributes=4;
 				};
 			};
 			class Item5
@@ -2527,7 +2603,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-2.7939453,0.0014390945,4.0620117};
+					position[]={-2.7944336,0.0014390945,4.059082};
 				};
 				side="West";
 				flags=5;
@@ -2658,11 +2734,30 @@ class items
 						headgear="rhsusf_ach_helmet_ocp_alt";
 					};
 				};
-				id=18;
+				id=252;
 				type="B_soldier_LAT_F";
 				class CustomAttributes
 				{
 					class Attribute0
+					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="RED";
+							};
+						};
+					};
+					class Attribute1
 					{
 						property="lambs_danger_disableAI";
 						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
@@ -2681,7 +2776,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
@@ -2696,11 +2791,11 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
-					class Attribute2
+					class Attribute3
 					{
 						property="lambs_danger_dangerRadio";
 						expression="if (_value) then { _this setVariable ['lambs_danger_dangerRadio', _value, true]; }";
@@ -2719,7 +2814,7 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					nAttributes=4;
 				};
 			};
 			class Item6
@@ -2727,7 +2822,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-5.7939453,0.0014390945,2.0620117};
+					position[]={-5.7944336,0.0014390945,2.059082};
 				};
 				side="West";
 				flags=5;
@@ -2929,11 +3024,30 @@ class items
 						headgear="rhsusf_ach_helmet_headset_ess_ocp_alt";
 					};
 				};
-				id=19;
+				id=253;
 				type="B_Soldier_TL_F";
 				class CustomAttributes
 				{
 					class Attribute0
+					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="YELLOW";
+							};
+						};
+					};
+					class Attribute1
 					{
 						property="lambs_danger_disableAI";
 						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
@@ -2952,7 +3066,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
@@ -2967,11 +3081,11 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
-					class Attribute2
+					class Attribute3
 					{
 						property="lambs_danger_dangerRadio";
 						expression="if (_value) then { _this setVariable ['lambs_danger_dangerRadio', _value, true]; }";
@@ -2990,7 +3104,7 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					nAttributes=4;
 				};
 			};
 			class Item7
@@ -2998,7 +3112,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-4.7939453,0.0014390945,2.0620117};
+					position[]={-4.7944336,0.0014390945,2.059082};
 				};
 				side="West";
 				flags=5;
@@ -3135,11 +3249,30 @@ class items
 						headgear="rhsusf_ach_helmet_ocp_alt";
 					};
 				};
-				id=20;
+				id=254;
 				type="B_soldier_AR_F";
 				class CustomAttributes
 				{
 					class Attribute0
+					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="YELLOW";
+							};
+						};
+					};
+					class Attribute1
 					{
 						property="lambs_danger_disableAI";
 						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
@@ -3158,7 +3291,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
@@ -3173,11 +3306,11 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
-					class Attribute2
+					class Attribute3
 					{
 						property="lambs_danger_dangerRadio";
 						expression="if (_value) then { _this setVariable ['lambs_danger_dangerRadio', _value, true]; }";
@@ -3196,7 +3329,7 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					nAttributes=4;
 				};
 			};
 			class Item8
@@ -3204,7 +3337,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-3.7939453,0.0014390945,2.0620117};
+					position[]={-3.7944336,0.0014390945,2.059082};
 				};
 				side="West";
 				flags=5;
@@ -3400,11 +3533,30 @@ class items
 						headgear="rhsusf_ach_helmet_headset_ocp_alt";
 					};
 				};
-				id=21;
+				id=255;
 				type="B_soldier_AAR_F";
 				class CustomAttributes
 				{
 					class Attribute0
+					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="YELLOW";
+							};
+						};
+					};
+					class Attribute1
 					{
 						property="lambs_danger_disableAI";
 						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
@@ -3423,7 +3575,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
@@ -3438,11 +3590,11 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
-					class Attribute2
+					class Attribute3
 					{
 						property="lambs_danger_dangerRadio";
 						expression="if (_value) then { _this setVariable ['lambs_danger_dangerRadio', _value, true]; }";
@@ -3461,7 +3613,7 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					nAttributes=4;
 				};
 			};
 			class Item9
@@ -3469,7 +3621,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-2.7939453,0.0014390945,2.0620117};
+					position[]={-2.7944336,0.0014390945,2.059082};
 				};
 				side="West";
 				flags=5;
@@ -3600,11 +3752,30 @@ class items
 						headgear="rhsusf_ach_helmet_ESS_ocp_alt";
 					};
 				};
-				id=22;
+				id=256;
 				type="B_soldier_LAT_F";
 				class CustomAttributes
 				{
 					class Attribute0
+					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="YELLOW";
+							};
+						};
+					};
+					class Attribute1
 					{
 						property="lambs_danger_disableAI";
 						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
@@ -3623,7 +3794,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
@@ -3638,11 +3809,11 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
-					class Attribute2
+					class Attribute3
 					{
 						property="lambs_danger_dangerRadio";
 						expression="if (_value) then { _this setVariable ['lambs_danger_dangerRadio', _value, true]; }";
@@ -3661,14 +3832,14 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					nAttributes=4;
 				};
 			};
 		};
 		class Attributes
 		{
 		};
-		id=12;
+		id=246;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -3705,7 +3876,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-1.2988281,0.0014390945,6.027832};
+					position[]={-1.2993164,0.0014390945,6.0249023};
 				};
 				side="West";
 				flags=7;
@@ -3924,7 +4095,7 @@ class items
 						headgear="rhsusf_ach_helmet_headset_ess_ocp_alt";
 					};
 				};
-				id=24;
+				id=258;
 				type="B_Soldier_SL_F";
 				class CustomAttributes
 				{
@@ -3962,7 +4133,7 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
@@ -3993,7 +4164,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-0.29882813,0.0014390945,6.027832};
+					position[]={-0.29931641,0.0014390945,6.0249023};
 				};
 				side="West";
 				flags=5;
@@ -4201,7 +4372,7 @@ class items
 						headgear="rhsusf_ach_helmet_ocp_alt";
 					};
 				};
-				id=25;
+				id=259;
 				type="B_medic_F";
 				class CustomAttributes
 				{
@@ -4239,7 +4410,7 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
@@ -4270,7 +4441,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-1.2988281,0.0014390945,4.027832};
+					position[]={-1.2993164,0.0014390945,4.0249023};
 				};
 				side="West";
 				flags=5;
@@ -4472,11 +4643,30 @@ class items
 						headgear="rhsusf_ach_helmet_headset_ess_ocp_alt";
 					};
 				};
-				id=26;
+				id=260;
 				type="B_Soldier_TL_F";
 				class CustomAttributes
 				{
 					class Attribute0
+					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="BLUE";
+							};
+						};
+					};
+					class Attribute1
 					{
 						property="lambs_danger_disableAI";
 						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
@@ -4495,7 +4685,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
@@ -4510,11 +4700,11 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
-					class Attribute2
+					class Attribute3
 					{
 						property="lambs_danger_dangerRadio";
 						expression="if (_value) then { _this setVariable ['lambs_danger_dangerRadio', _value, true]; }";
@@ -4533,7 +4723,7 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					nAttributes=4;
 				};
 			};
 			class Item3
@@ -4541,7 +4731,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-0.29882813,0.0014390945,4.027832};
+					position[]={-0.29931641,0.0014390945,4.0249023};
 				};
 				side="West";
 				flags=5;
@@ -4678,11 +4868,30 @@ class items
 						headgear="rhsusf_ach_helmet_ocp_alt";
 					};
 				};
-				id=27;
+				id=261;
 				type="B_soldier_AR_F";
 				class CustomAttributes
 				{
 					class Attribute0
+					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="BLUE";
+							};
+						};
+					};
+					class Attribute1
 					{
 						property="lambs_danger_disableAI";
 						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
@@ -4701,7 +4910,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
@@ -4716,11 +4925,11 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
-					class Attribute2
+					class Attribute3
 					{
 						property="lambs_danger_dangerRadio";
 						expression="if (_value) then { _this setVariable ['lambs_danger_dangerRadio', _value, true]; }";
@@ -4739,7 +4948,7 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					nAttributes=4;
 				};
 			};
 			class Item4
@@ -4747,7 +4956,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={0.70117188,0.0014390945,4.027832};
+					position[]={0.70068359,0.0014390945,4.0249023};
 				};
 				side="West";
 				flags=5;
@@ -4943,11 +5152,30 @@ class items
 						headgear="rhsusf_ach_helmet_headset_ocp_alt";
 					};
 				};
-				id=28;
+				id=262;
 				type="B_soldier_AAR_F";
 				class CustomAttributes
 				{
 					class Attribute0
+					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="BLUE";
+							};
+						};
+					};
+					class Attribute1
 					{
 						property="lambs_danger_disableAI";
 						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
@@ -4966,7 +5194,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
@@ -4981,11 +5209,11 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
-					class Attribute2
+					class Attribute3
 					{
 						property="lambs_danger_dangerRadio";
 						expression="if (_value) then { _this setVariable ['lambs_danger_dangerRadio', _value, true]; }";
@@ -5004,7 +5232,7 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					nAttributes=4;
 				};
 			};
 			class Item5
@@ -5012,7 +5240,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={1.7011719,0.0014390945,4.027832};
+					position[]={1.7006836,0.0014390945,4.0249023};
 				};
 				side="West";
 				flags=5;
@@ -5143,11 +5371,30 @@ class items
 						headgear="rhsusf_ach_helmet_ESS_ocp_alt";
 					};
 				};
-				id=29;
+				id=263;
 				type="B_soldier_LAT_F";
 				class CustomAttributes
 				{
 					class Attribute0
+					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="BLUE";
+							};
+						};
+					};
+					class Attribute1
 					{
 						property="lambs_danger_disableAI";
 						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
@@ -5166,7 +5413,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
@@ -5181,11 +5428,11 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
-					class Attribute2
+					class Attribute3
 					{
 						property="lambs_danger_dangerRadio";
 						expression="if (_value) then { _this setVariable ['lambs_danger_dangerRadio', _value, true]; }";
@@ -5204,7 +5451,7 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					nAttributes=4;
 				};
 			};
 			class Item6
@@ -5212,7 +5459,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-1.2988281,0.0014390945,2.027832};
+					position[]={-1.2993164,0.0014390945,2.0249023};
 				};
 				side="West";
 				flags=5;
@@ -5414,11 +5661,30 @@ class items
 						headgear="rhsusf_ach_helmet_headset_ess_ocp_alt";
 					};
 				};
-				id=30;
+				id=264;
 				type="B_Soldier_TL_F";
 				class CustomAttributes
 				{
 					class Attribute0
+					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="GREEN";
+							};
+						};
+					};
+					class Attribute1
 					{
 						property="lambs_danger_disableAI";
 						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
@@ -5437,7 +5703,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
@@ -5452,11 +5718,11 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
-					class Attribute2
+					class Attribute3
 					{
 						property="lambs_danger_dangerRadio";
 						expression="if (_value) then { _this setVariable ['lambs_danger_dangerRadio', _value, true]; }";
@@ -5475,7 +5741,7 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					nAttributes=4;
 				};
 			};
 			class Item7
@@ -5483,7 +5749,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-0.29882813,0.0014390945,2.027832};
+					position[]={-0.29931641,0.0014390945,2.0249023};
 				};
 				side="West";
 				flags=5;
@@ -5620,11 +5886,30 @@ class items
 						headgear="rhsusf_ach_helmet_ESS_ocp_alt";
 					};
 				};
-				id=31;
+				id=265;
 				type="B_soldier_AR_F";
 				class CustomAttributes
 				{
 					class Attribute0
+					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="GREEN";
+							};
+						};
+					};
+					class Attribute1
 					{
 						property="lambs_danger_disableAI";
 						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
@@ -5643,7 +5928,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
@@ -5658,11 +5943,11 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
-					class Attribute2
+					class Attribute3
 					{
 						property="lambs_danger_dangerRadio";
 						expression="if (_value) then { _this setVariable ['lambs_danger_dangerRadio', _value, true]; }";
@@ -5681,7 +5966,7 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					nAttributes=4;
 				};
 			};
 			class Item8
@@ -5689,7 +5974,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={0.70117188,0.0014390945,2.027832};
+					position[]={0.70068359,0.0014390945,2.0249023};
 				};
 				side="West";
 				flags=5;
@@ -5885,11 +6170,30 @@ class items
 						headgear="rhsusf_ach_helmet_headset_ocp_alt";
 					};
 				};
-				id=32;
+				id=266;
 				type="B_soldier_AAR_F";
 				class CustomAttributes
 				{
 					class Attribute0
+					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="GREEN";
+							};
+						};
+					};
+					class Attribute1
 					{
 						property="lambs_danger_disableAI";
 						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
@@ -5908,7 +6212,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
@@ -5923,11 +6227,11 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
-					class Attribute2
+					class Attribute3
 					{
 						property="lambs_danger_dangerRadio";
 						expression="if (_value) then { _this setVariable ['lambs_danger_dangerRadio', _value, true]; }";
@@ -5946,7 +6250,7 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					nAttributes=4;
 				};
 			};
 			class Item9
@@ -5954,7 +6258,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={1.7011719,0.0014390945,2.027832};
+					position[]={1.7006836,0.0014390945,2.0249023};
 				};
 				side="West";
 				flags=5;
@@ -6085,11 +6389,30 @@ class items
 						headgear="rhsusf_ach_helmet_ocp_alt";
 					};
 				};
-				id=33;
+				id=267;
 				type="B_soldier_LAT_F";
 				class CustomAttributes
 				{
 					class Attribute0
+					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="GREEN";
+							};
+						};
+					};
+					class Attribute1
 					{
 						property="lambs_danger_disableAI";
 						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
@@ -6108,7 +6431,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
@@ -6123,11 +6446,11 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
-					class Attribute2
+					class Attribute3
 					{
 						property="lambs_danger_dangerRadio";
 						expression="if (_value) then { _this setVariable ['lambs_danger_dangerRadio', _value, true]; }";
@@ -6146,14 +6469,14 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					nAttributes=4;
 				};
 			};
 		};
 		class Attributes
 		{
 		};
-		id=23;
+		id=257;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -6190,7 +6513,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={4.0117188,0.0014390945,6.0239258};
+					position[]={4.0112305,0.0014390945,6.0209961};
 				};
 				side="West";
 				flags=7;
@@ -6409,7 +6732,7 @@ class items
 						headgear="rhsusf_ach_helmet_headset_ess_ocp_alt";
 					};
 				};
-				id=35;
+				id=269;
 				type="B_Soldier_SL_F";
 				class CustomAttributes
 				{
@@ -6447,7 +6770,7 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
@@ -6478,7 +6801,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={5.0117188,0.0014390945,6.0229492};
+					position[]={5.0112305,0.0014390945,6.0200195};
 				};
 				side="West";
 				flags=5;
@@ -6686,7 +7009,7 @@ class items
 						headgear="rhsusf_ach_helmet_ocp_alt";
 					};
 				};
-				id=36;
+				id=270;
 				type="B_medic_F";
 				class CustomAttributes
 				{
@@ -6724,7 +7047,7 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
@@ -6755,7 +7078,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={4.0117188,0.0014390945,4.0229492};
+					position[]={4.0112305,0.0014390945,4.0200195};
 				};
 				side="West";
 				flags=5;
@@ -6957,11 +7280,30 @@ class items
 						headgear="rhsusf_ach_helmet_headset_ess_ocp_alt";
 					};
 				};
-				id=37;
+				id=271;
 				type="B_Soldier_TL_F";
 				class CustomAttributes
 				{
 					class Attribute0
+					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="RED";
+							};
+						};
+					};
+					class Attribute1
 					{
 						property="lambs_danger_disableAI";
 						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
@@ -6980,7 +7322,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
@@ -6995,11 +7337,11 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
-					class Attribute2
+					class Attribute3
 					{
 						property="lambs_danger_dangerRadio";
 						expression="if (_value) then { _this setVariable ['lambs_danger_dangerRadio', _value, true]; }";
@@ -7018,7 +7360,7 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					nAttributes=4;
 				};
 			};
 			class Item3
@@ -7026,7 +7368,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={5.0117188,0.0014390945,4.0229492};
+					position[]={5.0112305,0.0014390945,4.0200195};
 				};
 				side="West";
 				flags=5;
@@ -7163,11 +7505,30 @@ class items
 						headgear="rhsusf_ach_helmet_ESS_ocp_alt";
 					};
 				};
-				id=38;
+				id=272;
 				type="B_soldier_AR_F";
 				class CustomAttributes
 				{
 					class Attribute0
+					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="RED";
+							};
+						};
+					};
+					class Attribute1
 					{
 						property="lambs_danger_disableAI";
 						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
@@ -7186,7 +7547,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
@@ -7201,11 +7562,11 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
-					class Attribute2
+					class Attribute3
 					{
 						property="lambs_danger_dangerRadio";
 						expression="if (_value) then { _this setVariable ['lambs_danger_dangerRadio', _value, true]; }";
@@ -7224,7 +7585,7 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					nAttributes=4;
 				};
 			};
 			class Item4
@@ -7232,7 +7593,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={6.0117188,0.0014390945,4.0229492};
+					position[]={6.0112305,0.0014390945,4.0200195};
 				};
 				side="West";
 				flags=5;
@@ -7428,11 +7789,30 @@ class items
 						headgear="rhsusf_ach_helmet_headset_ocp_alt";
 					};
 				};
-				id=39;
+				id=273;
 				type="B_soldier_AAR_F";
 				class CustomAttributes
 				{
 					class Attribute0
+					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="RED";
+							};
+						};
+					};
+					class Attribute1
 					{
 						property="lambs_danger_disableAI";
 						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
@@ -7451,7 +7831,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
@@ -7466,11 +7846,11 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
-					class Attribute2
+					class Attribute3
 					{
 						property="lambs_danger_dangerRadio";
 						expression="if (_value) then { _this setVariable ['lambs_danger_dangerRadio', _value, true]; }";
@@ -7489,7 +7869,7 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					nAttributes=4;
 				};
 			};
 			class Item5
@@ -7497,7 +7877,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={7.0117188,0.0014390945,4.0229492};
+					position[]={7.0112305,0.0014390945,4.0200195};
 				};
 				side="West";
 				flags=5;
@@ -7628,11 +8008,30 @@ class items
 						headgear="rhsusf_ach_helmet_ocp_alt";
 					};
 				};
-				id=40;
+				id=274;
 				type="B_soldier_LAT_F";
 				class CustomAttributes
 				{
 					class Attribute0
+					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="RED";
+							};
+						};
+					};
+					class Attribute1
 					{
 						property="lambs_danger_disableAI";
 						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
@@ -7651,7 +8050,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
@@ -7666,11 +8065,11 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
-					class Attribute2
+					class Attribute3
 					{
 						property="lambs_danger_dangerRadio";
 						expression="if (_value) then { _this setVariable ['lambs_danger_dangerRadio', _value, true]; }";
@@ -7689,7 +8088,7 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					nAttributes=4;
 				};
 			};
 			class Item6
@@ -7697,7 +8096,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={4.0117188,0.0014390945,2.0229492};
+					position[]={4.0112305,0.0014390945,2.0200195};
 				};
 				side="West";
 				flags=5;
@@ -7899,11 +8298,30 @@ class items
 						headgear="rhsusf_ach_helmet_headset_ess_ocp_alt";
 					};
 				};
-				id=41;
+				id=275;
 				type="B_Soldier_TL_F";
 				class CustomAttributes
 				{
 					class Attribute0
+					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="YELLOW";
+							};
+						};
+					};
+					class Attribute1
 					{
 						property="lambs_danger_disableAI";
 						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
@@ -7922,7 +8340,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
@@ -7937,11 +8355,11 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
-					class Attribute2
+					class Attribute3
 					{
 						property="lambs_danger_dangerRadio";
 						expression="if (_value) then { _this setVariable ['lambs_danger_dangerRadio', _value, true]; }";
@@ -7960,7 +8378,7 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					nAttributes=4;
 				};
 			};
 			class Item7
@@ -7968,7 +8386,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={5.0117188,0.0014390945,2.0229492};
+					position[]={5.0112305,0.0014390945,2.0200195};
 				};
 				side="West";
 				flags=5;
@@ -8105,11 +8523,30 @@ class items
 						headgear="rhsusf_ach_helmet_ocp_alt";
 					};
 				};
-				id=42;
+				id=276;
 				type="B_soldier_AR_F";
 				class CustomAttributes
 				{
 					class Attribute0
+					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="YELLOW";
+							};
+						};
+					};
+					class Attribute1
 					{
 						property="lambs_danger_disableAI";
 						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
@@ -8128,7 +8565,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
@@ -8143,11 +8580,11 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
-					class Attribute2
+					class Attribute3
 					{
 						property="lambs_danger_dangerRadio";
 						expression="if (_value) then { _this setVariable ['lambs_danger_dangerRadio', _value, true]; }";
@@ -8166,7 +8603,7 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					nAttributes=4;
 				};
 			};
 			class Item8
@@ -8174,7 +8611,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={6.0117188,0.0014390945,2.0229492};
+					position[]={6.0112305,0.0014390945,2.0200195};
 				};
 				side="West";
 				flags=5;
@@ -8370,11 +8807,30 @@ class items
 						headgear="rhsusf_ach_helmet_headset_ocp_alt";
 					};
 				};
-				id=43;
+				id=277;
 				type="B_soldier_AAR_F";
 				class CustomAttributes
 				{
 					class Attribute0
+					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="YELLOW";
+							};
+						};
+					};
+					class Attribute1
 					{
 						property="lambs_danger_disableAI";
 						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
@@ -8393,7 +8849,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
@@ -8408,11 +8864,11 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
-					class Attribute2
+					class Attribute3
 					{
 						property="lambs_danger_dangerRadio";
 						expression="if (_value) then { _this setVariable ['lambs_danger_dangerRadio', _value, true]; }";
@@ -8431,7 +8887,7 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					nAttributes=4;
 				};
 			};
 			class Item9
@@ -8439,7 +8895,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={7.0117188,0.0014390945,2.0229492};
+					position[]={7.0112305,0.0014390945,2.0200195};
 				};
 				side="West";
 				flags=5;
@@ -8570,11 +9026,30 @@ class items
 						headgear="rhsusf_ach_helmet_ESS_ocp_alt";
 					};
 				};
-				id=44;
+				id=278;
 				type="B_soldier_LAT_F";
 				class CustomAttributes
 				{
 					class Attribute0
+					{
+						property="a3aa_ee_team_colors";
+						expression="[_this, _value] call a3aa_ee_team_colors_fnc_setColor";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="YELLOW";
+							};
+						};
+					};
+					class Attribute1
 					{
 						property="lambs_danger_disableAI";
 						expression="if (_value) then { _this setVariable ['lambs_danger_disableAI', _value, true]; }";
@@ -8593,7 +9068,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="a3aa_ee_extended_gear_insignia";
 						expression="[_this, _value] call a3aa_ee_extended_gear_fnc_insignia";
@@ -8608,11 +9083,11 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
-					class Attribute2
+					class Attribute3
 					{
 						property="lambs_danger_dangerRadio";
 						expression="if (_value) then { _this setVariable ['lambs_danger_dangerRadio', _value, true]; }";
@@ -8631,14 +9106,14 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					nAttributes=4;
 				};
 			};
 		};
 		class Attributes
 		{
 		};
-		id=34;
+		id=268;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -8675,7 +9150,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-6.0332031,0.0014390945,-1.0512695};
+					position[]={-6.0336914,0.0014390945,-1.0541992};
 				};
 				side="West";
 				flags=7;
@@ -8894,7 +9369,7 @@ class items
 						headgear="rhsusf_ach_helmet_headset_ocp_alt";
 					};
 				};
-				id=46;
+				id=280;
 				type="B_Soldier_TL_F";
 				class CustomAttributes
 				{
@@ -8932,7 +9407,7 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
@@ -8963,7 +9438,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-5.0332031,0.0014390945,-1.0512695};
+					position[]={-5.0336914,0.0014390945,-1.0541992};
 				};
 				side="West";
 				flags=5;
@@ -9098,7 +9573,7 @@ class items
 						headgear="rhsusf_ach_helmet_ESS_ocp_alt";
 					};
 				};
-				id=47;
+				id=281;
 				type="B_soldier_AR_F";
 				class CustomAttributes
 				{
@@ -9136,7 +9611,7 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
@@ -9167,7 +9642,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-4.0332031,0.0014390945,-1.0512695};
+					position[]={-4.0336914,0.0014390945,-1.0541992};
 				};
 				side="West";
 				flags=5;
@@ -9315,7 +9790,7 @@ class items
 						headgear="rhsusf_ach_helmet_ocp_alt";
 					};
 				};
-				id=48;
+				id=282;
 				type="B_soldier_AAR_F";
 				class CustomAttributes
 				{
@@ -9353,7 +9828,7 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
@@ -9383,7 +9858,7 @@ class items
 		class Attributes
 		{
 		};
-		id=45;
+		id=279;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -9420,7 +9895,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-0.92285156,0.0014390945,-1.2075195};
+					position[]={-0.92333984,0.0014390945,-1.2104492};
 				};
 				side="West";
 				flags=7;
@@ -9639,7 +10114,7 @@ class items
 						headgear="rhsusf_ach_helmet_headset_ocp_alt";
 					};
 				};
-				id=50;
+				id=284;
 				type="B_Soldier_TL_F";
 				class CustomAttributes
 				{
@@ -9677,7 +10152,7 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
@@ -9708,7 +10183,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={0.077148438,0.0014390945,-1.2075195};
+					position[]={0.076660156,0.0014390945,-1.2104492};
 				};
 				side="West";
 				flags=5;
@@ -9866,7 +10341,7 @@ class items
 						headgear="rhsusf_ach_helmet_ESS_ocp_alt";
 					};
 				};
-				id=51;
+				id=285;
 				type="B_soldier_AT_F";
 				class CustomAttributes
 				{
@@ -9904,7 +10379,7 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
@@ -9935,7 +10410,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={1.0771484,0.0014390945,-1.2075195};
+					position[]={1.0766602,0.0014390945,-1.2104492};
 				};
 				side="West";
 				flags=5;
@@ -10083,7 +10558,7 @@ class items
 						headgear="rhsusf_ach_helmet_ocp_alt";
 					};
 				};
-				id=52;
+				id=286;
 				type="B_soldier_AAT_F";
 				class CustomAttributes
 				{
@@ -10121,7 +10596,7 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
@@ -10151,7 +10626,7 @@ class items
 		class Attributes
 		{
 		};
-		id=49;
+		id=283;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -10188,7 +10663,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-6.3798828,0.0014390945,-4.1977539};
+					position[]={-6.3803711,0.0014390945,-4.2006836};
 				};
 				side="West";
 				flags=6;
@@ -10375,7 +10850,7 @@ class items
 						headgear="rhs_Booniehat_ocp";
 					};
 				};
-				id=54;
+				id=288;
 				type="B_spotter_F";
 				class CustomAttributes
 				{
@@ -10413,7 +10888,7 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
@@ -10444,7 +10919,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-5.3798828,0.0014390945,-4.1967773};
+					position[]={-5.3806152,0.0014390945,-4.2001953};
 				};
 				side="West";
 				flags=4;
@@ -10599,8 +11074,8 @@ class items
 						headgear="rhs_Booniehat_ocp";
 					};
 				};
-				id=55;
-				type="B_spotter_F";
+				id=289;
+				type="B_soldier_M_F";
 				class CustomAttributes
 				{
 					class Attribute0
@@ -10637,11 +11112,30 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
 					class Attribute2
+					{
+						property="speaker";
+						expression="_this setspeaker _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"STRING"
+									};
+								};
+								value="Male10ENG";
+							};
+						};
+					};
+					class Attribute3
 					{
 						property="lambs_danger_dangerRadio";
 						expression="if (_value) then { _this setVariable ['lambs_danger_dangerRadio', _value, true]; }";
@@ -10660,14 +11154,33 @@ class items
 							};
 						};
 					};
-					nAttributes=3;
+					class Attribute4
+					{
+						property="pitch";
+						expression="_this setpitch _value;";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"SCALAR"
+									};
+								};
+								value=1;
+							};
+						};
+					};
+					nAttributes=5;
 				};
 			};
 		};
 		class Attributes
 		{
 		};
-		id=53;
+		id=287;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -10704,7 +11217,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-0.93066406,0.0014390945,-4.8461914};
+					position[]={-0.93115234,0.0014390945,-4.8491211};
 				};
 				side="West";
 				flags=7;
@@ -10867,7 +11380,7 @@ class items
 						headgear="rhsusf_ach_helmet_headset_ocp_alt";
 					};
 				};
-				id=57;
+				id=291;
 				type="B_support_AMort_F";
 				class CustomAttributes
 				{
@@ -10905,7 +11418,7 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
@@ -10936,7 +11449,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={0.068359375,0.0014390945,-4.8461914};
+					position[]={0.067871094,0.0014390945,-4.8491211};
 				};
 				side="West";
 				flags=5;
@@ -11069,7 +11582,7 @@ class items
 						headgear="rhsusf_ach_helmet_ESS_ocp_alt";
 					};
 				};
-				id=58;
+				id=292;
 				type="B_support_Mort_F";
 				class CustomAttributes
 				{
@@ -11107,7 +11620,7 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
@@ -11137,7 +11650,7 @@ class items
 		class Attributes
 		{
 		};
-		id=56;
+		id=290;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -11174,7 +11687,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={4.0341797,0.0014390945,-1.0981445};
+					position[]={4.0336914,0.0014390945,-1.1010742};
 				};
 				side="West";
 				flags=7;
@@ -11336,7 +11849,7 @@ class items
 						headgear="rhsusf_ach_helmet_headset_ess_ocp_alt";
 					};
 				};
-				id=60;
+				id=294;
 				type="B_engineer_F";
 				class CustomAttributes
 				{
@@ -11374,7 +11887,7 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
@@ -11405,7 +11918,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={5.0341797,0.0014390945,-1.0991211};
+					position[]={5.0336914,0.0014390945,-1.1020508};
 				};
 				side="West";
 				flags=5;
@@ -11560,7 +12073,7 @@ class items
 						headgear="rhsusf_ach_helmet_headset_ocp_alt";
 					};
 				};
-				id=61;
+				id=295;
 				type="B_engineer_F";
 				class CustomAttributes
 				{
@@ -11598,7 +12111,7 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
@@ -11629,7 +12142,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={6.0341797,0.0014390945,-1.0991211};
+					position[]={6.0336914,0.0014390945,-1.1020508};
 				};
 				side="West";
 				flags=5;
@@ -11784,7 +12297,7 @@ class items
 						headgear="rhsusf_ach_helmet_headset_ocp_alt";
 					};
 				};
-				id=62;
+				id=296;
 				type="B_engineer_F";
 				class CustomAttributes
 				{
@@ -11822,7 +12335,7 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
@@ -11853,7 +12366,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={7.0341797,0.0014390945,-1.0991211};
+					position[]={7.0336914,0.0014390945,-1.1020508};
 				};
 				side="West";
 				flags=5;
@@ -12008,7 +12521,7 @@ class items
 						headgear="rhsusf_ach_helmet_headset_ocp_alt";
 					};
 				};
-				id=63;
+				id=297;
 				type="B_engineer_F";
 				class CustomAttributes
 				{
@@ -12046,7 +12559,7 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
@@ -12076,7 +12589,7 @@ class items
 		class Attributes
 		{
 		};
-		id=59;
+		id=293;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -12113,7 +12626,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-6.5966797,0.0014390945,-8.2749023};
+					position[]={-6.597168,0.0014390945,-8.277832};
 				};
 				side="West";
 				flags=7;
@@ -12252,7 +12765,7 @@ class items
 						headgear="rhsusf_cvc_green_ess";
 					};
 				};
-				id=65;
+				id=299;
 				type="B_crew_F";
 				class CustomAttributes
 				{
@@ -12290,7 +12803,7 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
@@ -12321,7 +12834,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-5.5976563,0.0014390945,-8.2758789};
+					position[]={-5.5981445,0.0014390945,-8.2788086};
 				};
 				side="West";
 				flags=5;
@@ -12454,7 +12967,7 @@ class items
 						headgear="rhsusf_cvc_green_alt_helmet";
 					};
 				};
-				id=66;
+				id=300;
 				type="B_crew_F";
 				class CustomAttributes
 				{
@@ -12511,7 +13024,7 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
@@ -12542,7 +13055,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-4.5976563,0.0014390945,-8.2758789};
+					position[]={-4.5981445,0.0014390945,-8.2788086};
 				};
 				side="West";
 				flags=5;
@@ -12661,7 +13174,7 @@ class items
 						headgear="rhsusf_cvc_green_helmet";
 					};
 				};
-				id=67;
+				id=301;
 				type="B_crew_F";
 				class CustomAttributes
 				{
@@ -12718,7 +13231,7 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
@@ -12748,7 +13261,7 @@ class items
 		class Attributes
 		{
 		};
-		id=64;
+		id=298;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -12785,7 +13298,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-0.98828125,0.0014390945,-7.9760742};
+					position[]={-0.98876953,0.0014390945,-7.9790039};
 				};
 				side="West";
 				flags=7;
@@ -12924,7 +13437,7 @@ class items
 						headgear="rhsusf_hgu56p_visor_black";
 					};
 				};
-				id=69;
+				id=303;
 				type="B_Pilot_F";
 				class CustomAttributes
 				{
@@ -12981,7 +13494,7 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
@@ -13012,7 +13525,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={0.01171875,0.0014390945,-7.9770508};
+					position[]={0.011230469,0.0014390945,-7.9799805};
 				};
 				side="West";
 				flags=5;
@@ -13164,7 +13677,7 @@ class items
 						headgear="rhsusf_hgu56p_visor_black";
 					};
 				};
-				id=70;
+				id=304;
 				type="B_Pilot_F";
 				class CustomAttributes
 				{
@@ -13221,7 +13734,7 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
@@ -13251,7 +13764,7 @@ class items
 		class Attributes
 		{
 		};
-		id=68;
+		id=302;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -13288,7 +13801,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={3.012207,0.0014390945,-7.9760742};
+					position[]={3.0117188,0.0014390945,-7.9790039};
 				};
 				side="West";
 				flags=7;
@@ -13431,7 +13944,7 @@ class items
 						headgear="H_PilotHelmetFighter_B";
 					};
 				};
-				id=72;
+				id=306;
 				type="B_Pilot_F";
 				class CustomAttributes
 				{
@@ -13488,7 +14001,7 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="";
 							};
 						};
 					};
@@ -13556,7 +14069,7 @@ class items
 		class Attributes
 		{
 		};
-		id=71;
+		id=305;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -13593,7 +14106,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={4.0341797,0.0014390945,-4.8457031};
+					position[]={4.0336914,0.0014390945,-4.8486328};
 				};
 				side="West";
 				flags=7;
@@ -13666,7 +14179,7 @@ class items
 						headgear="rhsusf_patrolcap_ocp";
 					};
 				};
-				id=74;
+				id=308;
 				type="B_Protagonist_VR_F";
 				class CustomAttributes
 				{
@@ -13761,11 +14274,30 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="Curator";
 							};
 						};
 					};
-					nAttributes=5;
+					class Attribute5
+					{
+						property="a3aa_insta_zeus_unit_curator";
+						expression="[_this, _value] call a3aa_insta_zeus_fnc_createUnitCurator";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"BOOL"
+									};
+								};
+								value=1;
+							};
+						};
+					};
+					nAttributes=6;
 				};
 			};
 			class Item1
@@ -13773,7 +14305,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={5.0341797,0.0014390945,-4.8457031};
+					position[]={5.0336914,0.0014390945,-4.8486328};
 				};
 				side="West";
 				flags=5;
@@ -13846,7 +14378,7 @@ class items
 						headgear="rhsusf_patrolcap_ocp";
 					};
 				};
-				id=75;
+				id=309;
 				type="B_Protagonist_VR_F";
 				class CustomAttributes
 				{
@@ -13941,18 +14473,37 @@ class items
 										"STRING"
 									};
 								};
-								value="CNTOpatchAlt";
+								value="Curator";
 							};
 						};
 					};
-					nAttributes=5;
+					class Attribute5
+					{
+						property="a3aa_insta_zeus_unit_curator";
+						expression="[_this, _value] call a3aa_insta_zeus_fnc_createUnitCurator";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"BOOL"
+									};
+								};
+								value=1;
+							};
+						};
+					};
+					nAttributes=6;
 				};
 			};
 		};
 		class Attributes
 		{
 		};
-		id=73;
+		id=307;
 		class CustomAttributes
 		{
 			class Attribute0
@@ -13982,12 +14533,12 @@ class items
 		dataType="Logic";
 		class PositionInfo
 		{
-			position[]={0.42480469,0,-0.28173828};
+			position[]={0.42431641,0,-0.28466797};
 		};
 		areaSize[]={200,-1,200};
 		areaIsRectangle=1;
 		flags=1;
-		id=76;
+		id=310;
 		type="a3aa_ee_custom_location";
 		class CustomAttributes
 		{


### PR DESCRIPTION
PL:
- Headgear changed from RHS "Patrol Cap OEF-CP" to RHS "ACH OEF-CP (Headset/Alt)" to give leader a helmet (fixes #82).
- Uniform content: moved radios 152 & 148 to backpack (fixes #95).


Platoon Sergeant:
- Headgear changed from RHS "ACH (Tan/Headset/ESS)" to RHS "ACH OEF-CP (Headset/Alt)" to fit the rest of the platoon (fixes #112).


Platoon Medic:
- Headgear changed from RHS "ACH (Tan)" to RHS "ACH OEF-CP (Alt)" to fit the rest of the platoon (fixes #112).


Platoon Rifleman:
- Headgear changed from RHS "ACH (Tan/ESS)" to RHS "ACH OEF-CP (ESS/Alt)" to fit the rest of the platoon (fixes #112).


SL:
- Uniform content: moved radio 152 to backpack (fixes #95).


MMG Leader:
- Uniform content: moved radio 152 to backpack (fixes #95).


MAT Leader:
- Uniform content: moved radio 152 to backpack (fixes #95).


MAT Gunner:
- Launcher replaced with TFN "MAAWS Mk4 Mod 0 (olive)" Launcher (fixes #90).


ENG Leader:
- Uniform content: moved radio 152 to backpack (fixes #95).
- Backpack content: changed ammo count to 4 regular mags and 2 tracer mag (fixes #83).


ENG Rifleman:
- Backpack content: changed ammo count to 5 regular mags and 1 tracer mag (fixes #83).


DMT Marksman:
- Soldier class changed from "B_spotter_F" to "B_soldier_M_F" (fixes #94).


MTR Leader:
- Vest content: changed ammo count to 5 regular mags and 1 tracer mag (fixes #83).


MTR Gunner:
- Vest content: changed ammo count to 5 regular mags and 1 tracer mag (fixes #83).


Zeus:
- Fixed missing Zeus status (fixes #113).


Alpha Squad Leader:
- set to player via attributes (fixes #122).


PLT & SQD Medic, Rifleman, LAT, MMG Ammo Bearer, MAT Gunner, MAT Ammo Bearer, Engineer:
- Uniform content: added 1x Pistolmag to ensure Riflemags do not get split across uniform and vest (uniform container always gets filled first by the game).


All Units:
- Fixed missing standard ACRE2 radio channels (fixes #110).
- Uniform content: added 1x epinephrine (fixes #107) and sorted all items in a more logical manner (fixes #111).
- Vest content: sorted all items in a more logical manner (fixes #111).
- Backpack content: sorted all items in a more logical manner (fixes #111).
- Fireteam members: fixed ST HUD colours for fireteam members of Alpha, Bravo and Charlie (fixes #117).


Crates:
- Added a mortar supply crate (fixes #77).