### PR TITLE
TFN Camo Helmets

### DIFF
--- a/reference-adaptations/TFN%20Camo%20Helmets/composition.sqe
+++ b/reference-adaptations/TFN%20Camo%20Helmets/composition.sqe
@@ -1,0 +1,35 @@
+version=54;
+center[]={5071.9619,5,2671.9951};
+class items
+{
+	items=1;
+	class Item0
+	{
+		dataType="Logic";
+		id=518;
+		type="a3aa_ee_execute_code_3den";
+		class CustomAttributes
+		{
+			class Attribute0
+			{
+				property="a3aa_ee_execute_code_3den_code";
+				expression="[_this, _value] call a3aa_ee_execute_code_fnc_exec3DEN";
+				class Value
+				{
+					class data
+					{
+						class type
+						{
+							type[]=
+							{
+								"STRING"
+							};
+						};
+						value="{ " \n "    private _unit = _x; " \n "    private _loadout = getUnitLoadout _unit; " \n "    private _helmet = _loadout#6; " \n "    if (""_h_c_"" in _helmet  " \n "        || ""_h_s_"" in _helmet  " \n "        || ""_h_l_"" in _helmet " \n "    ) then { " \n "        private _asArray = _helmet splitString ""_""; " \n "        private _biome = _asArray select ((count _asArray)-1); " \n "        private _newHelm = ""cnto_flecktarn_h_b_"" + _biome; " \n "        _loadout set [6, _newHelm]; " \n "        _unit setUnitLoadout _loadout; " \n "    }; " \n "} forEach playableUnits; " \n "save3DENInventory playableUnits;";
+					};
+				};
+			};
+			nAttributes=1;
+		};
+	};
+};

--- a/reference-adaptations/TFN%20Camo%20Helmets/header.sqe
+++ b/reference-adaptations/TFN%20Camo%20Helmets/header.sqe
@@ -1,0 +1,8 @@
+version=54;
+name="TFN Camo Helmets";
+author="Seb";
+category="CNTOStandardFactionAdaptation";
+requiredAddons[]=
+{
+	"a3aa_ee_execute_code"
+};


### PR DESCRIPTION
- Provides module for TFN "Scrim" camo net helmets, which have been in our repo for ages but never used.
- Only replaces the combat helmet variants - boonies/crew/etc untouched
- Works with camo modules being placed before and after scrim module

Known issues:
There is no Urban scrim helmet, which may cause either of the following issues when urban camo is used:
- When switching to urban camo AFTER placing the camo module they will not be replaced.
- When placing the scrim module AFTER placing an urban camo module, all combat helmets will be deleted.

I don't think that this is an issue as urban camonets is a stupid idea. 

This would fix itself automatically if an urban scrim helmet was added to the repo under the same class naming convention, if we cared that much.